### PR TITLE
Add support for compiling against Musl

### DIFF
--- a/Sources/OTel/Configuration/OTelEnvironment.swift
+++ b/Sources/OTel/Configuration/OTelEnvironment.swift
@@ -24,13 +24,22 @@ import Foundation
 /// A wrapper for reading environment values.
 public struct OTelEnvironment: Sendable {
     /// The key-value pairs in the environment.
+    ///
+    /// - Note: All keys are lowercased to enable case-insensitive lookup.
     public let values: [String: String]
 
     /// Create an environment wrapping the given key-value pairs.
     ///
     /// - Parameter values: The key-value pairs to wrap.
     public init(values: [String: String]) {
-        self.values = values
+        self.values = Dictionary(uniqueKeysWithValues: values.map { ($0.key.lowercased(), $0.value) })
+    }
+
+    /// Accesses the value associated with the given key for reading by ignoring its case.
+    ///
+    /// - Parameter key: The key to look up case-insensitively.
+    public subscript(key: String) -> String? {
+        values[key.lowercased()]
     }
 
     /// Retrieve a configuration value by transforming an environment value into the given type.
@@ -89,7 +98,7 @@ public struct OTelEnvironment: Sendable {
             return programmaticOverride
         }
 
-        if let value = values[key] {
+        if let value = self[key] {
             return try transformedValue(value, forKey: key, using: transformValue)
         }
 
@@ -123,9 +132,9 @@ public struct OTelEnvironment: Sendable {
             return programmaticOverride
         }
 
-        if let value = values[signalSpecificKey] {
+        if let value = self[signalSpecificKey] {
             return try transformedValue(value, forKey: signalSpecificKey, using: transformValue)
-        } else if let value = values[sharedKey] {
+        } else if let value = self[sharedKey] {
             return try transformedValue(value, forKey: sharedKey, using: transformValue)
         }
 
@@ -167,7 +176,7 @@ public struct OTelEnvironment: Sendable {
     /// - Returns: An ``OTelEnvironment`` exposing the process-wide environment values.
     public static func detected() -> OTelEnvironment {
         let values = ProcessInfo.processInfo.environment
-        return OTelEnvironment(values: values)
+        return OTelEnvironment(values: Dictionary(uniqueKeysWithValues: values.map { ($0.key.lowercased(), $0.value) }))
     }
 
     /// Extract headers from a given environment value.
@@ -207,6 +216,6 @@ public struct OTelEnvironment: Sendable {
 
 extension OTelEnvironment: ExpressibleByDictionaryLiteral {
     public init(dictionaryLiteral elements: (String, String)...) {
-        values = [String: String](uniqueKeysWithValues: elements)
+        values = [String: String](uniqueKeysWithValues: elements.map { ($0.0.lowercased(), $0.1) })
     }
 }

--- a/Sources/OTel/Configuration/OTelEnvironment.swift
+++ b/Sources/OTel/Configuration/OTelEnvironment.swift
@@ -11,8 +11,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux)
+#if canImport(Glibc)
     import Glibc
+#elseif canImport(Musl)
+    import Musl
 #else
     import Darwin.C
 #endif
@@ -164,21 +166,7 @@ public struct OTelEnvironment: Sendable {
     ///
     /// - Returns: An ``OTelEnvironment`` exposing the process-wide environment values.
     public static func detected() -> OTelEnvironment {
-        var values = [String: String]()
-
-        let environmentPointer = environ
-        var index = 0
-
-        while let entry = environmentPointer.advanced(by: index).pointee {
-            let entry = String(cString: entry)
-            if let i = entry.firstIndex(of: "=") {
-                let key = entry.prefix(upTo: i).uppercased()
-                let value = String(entry[i...].dropFirst("=".count))
-                values[key] = value
-            }
-            index += 1
-        }
-
+        let values = ProcessInfo.processInfo.environment
         return OTelEnvironment(values: values)
     }
 

--- a/Sources/OTel/Resource/OTelEnvironmentResourceDetector.swift
+++ b/Sources/OTel/Resource/OTelEnvironmentResourceDetector.swift
@@ -28,7 +28,7 @@ public struct OTelEnvironmentResourceDetector: OTelResourceDetector, CustomStrin
 
     public func resource(logger: Logger) throws -> OTelResource {
         let environmentKey = "OTEL_RESOURCE_ATTRIBUTES"
-        guard let environmentValue = environment.values[environmentKey] else { return OTelResource() }
+        guard let environmentValue = environment[environmentKey] else { return OTelResource() }
 
         let attributes: SpanAttributes = try {
             var attributes = SpanAttributes()

--- a/Sources/OTel/Resource/OTelResourceDetection.swift
+++ b/Sources/OTel/Resource/OTelResourceDetection.swift
@@ -108,7 +108,7 @@ public struct OTelResourceDetection<Clock: _Concurrency.Clock>: Sendable where C
     }
 
     private func serviceName(environment: OTelEnvironment, resource: OTelResource, logger: Logger) -> String {
-        if let serviceName = environment.values["OTEL_SERVICE_NAME"] {
+        if let serviceName = environment["OTEL_SERVICE_NAME"] {
             logger.debug(#"Using service name from "OTEL_SERVICE_NAME" environment variable."#, metadata: [
                 "service_name": "\(serviceName)",
             ])

--- a/Sources/OTelTesting/Metrics+TestHelpers.swift
+++ b/Sources/OTelTesting/Metrics+TestHelpers.swift
@@ -11,101 +11,103 @@
 //
 //===----------------------------------------------------------------------===//
 
-@testable import OTel
-import XCTest
+#if canImport(XCTest)
+    @testable import OTel
+    import XCTest
 
-extension Counter {
-    package var atomicValue: Int64 { atomic.load(ordering: .relaxed) }
-}
-
-extension FloatingPointCounter {
-    package var atomicValue: Double { Double(bitPattern: atomic.load(ordering: .relaxed)) }
-}
-
-extension Gauge {
-    package var atomicValue: Double { Double(bitPattern: atomic.load(ordering: .relaxed)) }
-}
-
-extension Histogram {
-    private struct EquatableBucket: Equatable {
-        var bound: Value
-        var count: Int
+    extension Counter {
+        package var atomicValue: Int64 { atomic.load(ordering: .relaxed) }
     }
 
-    package func assertStateEquals(
-        count: Int,
-        sum: Value,
-        buckets: [(bound: Value, count: Int)],
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) {
-        let state = box.withLockedValue { $0 }
-        XCTAssertEqual(state.count, count, "Unexpected count", file: file, line: line)
-        XCTAssertEqual(state.sum, sum, "Unexpected sum", file: file, line: line)
-        XCTAssertEqual(
-            state.buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
-            buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
-            "Unexpected buckets",
-            file: file, line: line
-        )
-    }
-}
-
-extension OTelMetricPoint.OTelMetricData {
-    package var asSum: OTelSum? {
-        guard case .sum(let sum) = self.data else { return nil }
-        return sum
+    extension FloatingPointCounter {
+        package var atomicValue: Double { Double(bitPattern: atomic.load(ordering: .relaxed)) }
     }
 
-    package var asGauge: OTelGauge? {
-        guard case .gauge(let gauge) = self.data else { return nil }
-        return gauge
+    extension Gauge {
+        package var atomicValue: Double { Double(bitPattern: atomic.load(ordering: .relaxed)) }
     }
 
-    package var asHistogram: OTelHistogram? {
-        guard case .histogram(let histogram) = self.data else { return nil }
-        return histogram
-    }
-
-    package func assertIsCumulativeSumWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #filePath, line: UInt = #line) {
-        guard
-            case .sum(let sum) = data,
-            sum.monotonic,
-            sum.aggregationTemporality == .cumulative,
-            sum.points.count == 1,
-            let point = sum.points.first
-        else {
-            XCTFail("Not cumulative sum with one point: \(self)", file: file, line: line)
-            return
-        }
-        XCTAssertEqual(point.value, value, file: file, line: line)
-    }
-
-    package func assertIsGaugeWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #filePath, line: UInt = #line) {
-        guard
-            case .gauge(let gauge) = data,
-            gauge.points.count == 1,
-            let point = gauge.points.first
-        else {
-            XCTFail("Not gauge with one point: \(self)", file: file, line: line)
-            return
-        }
-        XCTAssertEqual(point.value, value, file: file, line: line)
-    }
-
-    package func assertIsCumulativeHistogramWith(count: Int, sum: Double, buckets: [OTelHistogramDataPoint.Bucket], file: StaticString = #filePath, line: UInt = #line) {
-        guard
-            case .histogram(let histogram) = data,
-            histogram.aggregationTemporality == .cumulative,
-            histogram.points.count == 1,
-            let point = histogram.points.first
-        else {
-            XCTFail("Not cumulative histogram with one point: \(self)", file: file, line: line)
-            return
+    extension Histogram {
+        private struct EquatableBucket: Equatable {
+            var bound: Value
+            var count: Int
         }
 
-        XCTAssertEqual(point.count, UInt64(count), file: file, line: line)
-        XCTAssertEqual(point.sum, sum, file: file, line: line)
-        XCTAssertEqual(point.buckets, buckets, file: file, line: line)
+        package func assertStateEquals(
+            count: Int,
+            sum: Value,
+            buckets: [(bound: Value, count: Int)],
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) {
+            let state = box.withLockedValue { $0 }
+            XCTAssertEqual(state.count, count, "Unexpected count", file: file, line: line)
+            XCTAssertEqual(state.sum, sum, "Unexpected sum", file: file, line: line)
+            XCTAssertEqual(
+                state.buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
+                buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
+                "Unexpected buckets",
+                file: file, line: line
+            )
+        }
     }
-}
+
+    extension OTelMetricPoint.OTelMetricData {
+        package var asSum: OTelSum? {
+            guard case .sum(let sum) = self.data else { return nil }
+            return sum
+        }
+
+        package var asGauge: OTelGauge? {
+            guard case .gauge(let gauge) = self.data else { return nil }
+            return gauge
+        }
+
+        package var asHistogram: OTelHistogram? {
+            guard case .histogram(let histogram) = self.data else { return nil }
+            return histogram
+        }
+
+        package func assertIsCumulativeSumWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #filePath, line: UInt = #line) {
+            guard
+                case .sum(let sum) = data,
+                sum.monotonic,
+                sum.aggregationTemporality == .cumulative,
+                sum.points.count == 1,
+                let point = sum.points.first
+            else {
+                XCTFail("Not cumulative sum with one point: \(self)", file: file, line: line)
+                return
+            }
+            XCTAssertEqual(point.value, value, file: file, line: line)
+        }
+
+        package func assertIsGaugeWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #filePath, line: UInt = #line) {
+            guard
+                case .gauge(let gauge) = data,
+                gauge.points.count == 1,
+                let point = gauge.points.first
+            else {
+                XCTFail("Not gauge with one point: \(self)", file: file, line: line)
+                return
+            }
+            XCTAssertEqual(point.value, value, file: file, line: line)
+        }
+
+        package func assertIsCumulativeHistogramWith(count: Int, sum: Double, buckets: [OTelHistogramDataPoint.Bucket], file: StaticString = #filePath, line: UInt = #line) {
+            guard
+                case .histogram(let histogram) = data,
+                histogram.aggregationTemporality == .cumulative,
+                histogram.points.count == 1,
+                let point = histogram.points.first
+            else {
+                XCTFail("Not cumulative histogram with one point: \(self)", file: file, line: line)
+                return
+            }
+
+            XCTAssertEqual(point.count, UInt64(count), file: file, line: line)
+            XCTAssertEqual(point.sum, sum, file: file, line: line)
+            XCTAssertEqual(point.buckets, buckets, file: file, line: line)
+        }
+    }
+#endif

--- a/Sources/OTelTesting/RecordingMetricExporter.swift
+++ b/Sources/OTelTesting/RecordingMetricExporter.swift
@@ -11,47 +11,49 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIOConcurrencyHelpers
-import OTel
-import XCTest
+#if canImport(XCTest)
+    import NIOConcurrencyHelpers
+    import OTel
+    import XCTest
 
-package struct RecordingMetricExporter: OTelMetricExporter {
-    package typealias ExportCall = Collection<OTel.OTelResourceMetrics> & Sendable
+    package struct RecordingMetricExporter: OTelMetricExporter {
+        package typealias ExportCall = Collection<OTel.OTelResourceMetrics> & Sendable
 
-    package struct RecordedCalls {
-        var exportCalls = [any ExportCall]()
-        var forceFlushCallCount = 0
-        var shutdownCallCount = 0
+        package struct RecordedCalls {
+            var exportCalls = [any ExportCall]()
+            var forceFlushCallCount = 0
+            var shutdownCallCount = 0
+        }
+
+        package let recordedCalls = NIOLockedValueBox(RecordedCalls())
+
+        package init() {}
+
+        package func export(_ batch: some Collection<OTel.OTelResourceMetrics> & Sendable) {
+            recordedCalls.withLockedValue { $0.exportCalls.append(batch) }
+        }
+
+        package func forceFlush() {
+            recordedCalls.withLockedValue { $0.forceFlushCallCount += 1 }
+        }
+
+        package func shutdown() {
+            recordedCalls.withLockedValue { $0.shutdownCallCount += 1 }
+        }
     }
 
-    package let recordedCalls = NIOLockedValueBox(RecordedCalls())
-
-    package init() {}
-
-    package func export(_ batch: some Collection<OTel.OTelResourceMetrics> & Sendable) {
-        recordedCalls.withLockedValue { $0.exportCalls.append(batch) }
+    extension RecordingMetricExporter {
+        package func assert(
+            exportCallCount: Int,
+            forceFlushCallCount: Int,
+            shutdownCallCount: Int,
+            file: StaticString = #filePath,
+            line: UInt = #line
+        ) {
+            let recordedCalls = recordedCalls.withLockedValue { $0 }
+            XCTAssertEqual(recordedCalls.exportCalls.count, exportCallCount, "Unexpected export call count", file: file, line: line)
+            XCTAssertEqual(recordedCalls.forceFlushCallCount, forceFlushCallCount, "Unexpected forceFlush call count", file: file, line: line)
+            XCTAssertEqual(recordedCalls.shutdownCallCount, shutdownCallCount, "Unexpected shutdown call count", file: file, line: line)
+        }
     }
-
-    package func forceFlush() {
-        recordedCalls.withLockedValue { $0.forceFlushCallCount += 1 }
-    }
-
-    package func shutdown() {
-        recordedCalls.withLockedValue { $0.shutdownCallCount += 1 }
-    }
-}
-
-extension RecordingMetricExporter {
-    package func assert(
-        exportCallCount: Int,
-        forceFlushCallCount: Int,
-        shutdownCallCount: Int,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) {
-        let recordedCalls = recordedCalls.withLockedValue { $0 }
-        XCTAssertEqual(recordedCalls.exportCalls.count, exportCallCount, "Unexpected export call count", file: file, line: line)
-        XCTAssertEqual(recordedCalls.forceFlushCallCount, forceFlushCallCount, "Unexpected forceFlush call count", file: file, line: line)
-        XCTAssertEqual(recordedCalls.shutdownCallCount, shutdownCallCount, "Unexpected shutdown call count", file: file, line: line)
-    }
-}
+#endif

--- a/Sources/OTelTesting/XCTAssertThrowsEquatableError.swift
+++ b/Sources/OTelTesting/XCTAssertThrowsEquatableError.swift
@@ -11,17 +11,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+#if canImport(XCTest)
+    import XCTest
 
-public func XCTAssertThrowsError<E: Error & Equatable>(_ expression: @autoclosure () throws -> some Any, _ error: E) {
-    do {
-        let value = try expression()
-        XCTFail("Expected error but received value: \(value)")
-    } catch let actualError {
-        guard let e = actualError as? E else {
-            XCTFail("Expected \(type(of: E.self)), but received \(type(of: actualError))")
-            return
+    public func XCTAssertThrowsError<E: Error & Equatable>(_ expression: @autoclosure () throws -> some Any, _ error: E) {
+        do {
+            let value = try expression()
+            XCTFail("Expected error but received value: \(value)")
+        } catch let actualError {
+            guard let e = actualError as? E else {
+                XCTFail("Expected \(type(of: E.self)), but received \(type(of: actualError))")
+                return
+            }
+            XCTAssertEqual(e, error)
         }
-        XCTAssertEqual(e, error)
     }
-}
+#endif

--- a/Sources/OTelTesting/XCTAssertThrowsFatalError.swift
+++ b/Sources/OTelTesting/XCTAssertThrowsFatalError.swift
@@ -11,27 +11,29 @@
 //
 //===----------------------------------------------------------------------===//
 
-import OTel
-import XCTest
+#if canImport(XCTest)
+    import OTel
+    import XCTest
 
-package func XCTAssertThrowsFatalError(
-    _ expectedMessage: @escaping @Sendable @autoclosure () -> String? = nil,
-    timeout seconds: TimeInterval = 0.1,
-    _ expression: @escaping @Sendable () -> Void,
-    file: StaticString = #filePath,
-    line: UInt = #line
-) {
-    let hookedFatalErrorCalled = XCTestExpectation(description: "hooked fatalError called")
-    withHookedFatalError {
-        DispatchQueue.global().async { expression() }
-        guard case .completed = XCTWaiter.wait(for: [hookedFatalErrorCalled], timeout: seconds) else {
-            XCTFail("Operation did not throw fatalError", file: file, line: line)
-            return
-        }
-    } onFatalError: { message, _, _ in
-        hookedFatalErrorCalled.fulfill()
-        if let expectedMessage = expectedMessage() {
-            XCTAssertEqual(message, expectedMessage, "Operation threw fatalError but with unexpected message", file: file, line: line)
+    package func XCTAssertThrowsFatalError(
+        _ expectedMessage: @escaping @Sendable @autoclosure () -> String? = nil,
+        timeout seconds: TimeInterval = 0.1,
+        _ expression: @escaping @Sendable () -> Void,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let hookedFatalErrorCalled = XCTestExpectation(description: "hooked fatalError called")
+        withHookedFatalError {
+            DispatchQueue.global().async { expression() }
+            guard case .completed = XCTWaiter.wait(for: [hookedFatalErrorCalled], timeout: seconds) else {
+                XCTFail("Operation did not throw fatalError", file: file, line: line)
+                return
+            }
+        } onFatalError: { message, _, _ in
+            hookedFatalErrorCalled.fulfill()
+            if let expectedMessage = expectedMessage() {
+                XCTAssertEqual(message, expectedMessage, "Operation threw fatalError but with unexpected message", file: file, line: line)
+            }
         }
     }
-}
+#endif

--- a/Tests/OTelTests/Configuration/OTelEnvironmentTests.swift
+++ b/Tests/OTelTests/Configuration/OTelEnvironmentTests.swift
@@ -24,7 +24,7 @@ final class OTelEnvironmentTests: XCTestCase {
 
         XCTAssertEqual(environment.values.count, keyValuePairs.count)
         for (key, value) in keyValuePairs {
-            XCTAssertEqual(environment.values[key.uppercased()], value)
+            XCTAssertEqual(environment[key.lowercased()], value)
         }
     }
 


### PR DESCRIPTION
This adds support for compiling against Musl and the static linux sdk. It adds a check if Glic or Musl is available. It replaces environ with ProcessInfo.processInfo.environment due to some issues with the static linux sdk. 

As XCTest is not available in the static linux sdk, I've added canImports to a few files in OTelTesting. As it is only an internal module it should not be an issue.

Closes #143 