### PR TITLE
Add integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,50 @@
+name: "Integration Tests"
+on: [push, pull_request]
+jobs:
+  integration_test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        swift: ["5.9", "5.10", "latest"]
+
+    steps:
+      - name: Install Swift
+        uses: vapor/swiftly-action@v0.1
+        with:
+          toolchain: ${{ matrix.swift }}
+        env:
+          SWIFTLY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install OTel Collector
+        run: |
+          gh release download -p 'otelcol_*linux_amd64.tar.gz' -R open-telemetry/opentelemetry-collector-releases
+          tar -xvf "$(ls otelcol_*_linux_amd64.tar.gz | tail -1)"
+          mv otelcol /usr/local/bin
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Checkout
+        uses: actions/checkout@v4.2.0
+
+      - name: Start OTel Collector
+        working-directory: ./IntegrationTests
+        run: |
+          touch otel-collector-output.jsonl
+          otelcol --config=otel-collector-config.yml &
+
+      - name: Wait for OTel gRPC server
+        uses: iFaxity/wait-on-action@v1.2.1
+        with:
+          resource: tcp:127.0.0.1:4317
+
+      - name: Resolve Swift dependencies
+        working-directory: ./IntegrationTests
+        run: swift package resolve
+
+      - name: Run Integration Tests
+        working-directory: ./IntegrationTests
+        run: |
+          OTEL_COLLECTOR_OUTPUT=$(pwd)/otel-collector-output.jsonl swift test

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ xcuserdata/
 .protoc-grpc-swift-plugins.download/
 swift-otel-workspace.xcworkspace/
 .benchmarkBaselines
+IntegrationTests/otel-collector-output/

--- a/IntegrationTests/Package.swift
+++ b/IntegrationTests/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "swift-otel-integration-tests",
+    dependencies: [
+        .package(path: "../"),
+        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0"),
+    ],
+    targets: [
+        .testTarget(
+            name: "IntegrationTests",
+            dependencies: [
+                .product(name: "OTel", package: "swift-otel"),
+                .product(name: "OTLPGRPC", package: "swift-otel"),
+                .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
+            ],
+            swiftSettings: [.enableExperimentalFeature("StrictConcurrency=complete")]
+        ),
+    ],
+    swiftLanguageVersions: [.version("6"), .v5]
+)

--- a/IntegrationTests/Tests/IntegrationTests/OTLPGRPCIntegrationTests.swift
+++ b/IntegrationTests/Tests/IntegrationTests/OTLPGRPCIntegrationTests.swift
@@ -1,0 +1,133 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+@testable import Instrumentation
+@testable import Logging
+import NIO
+import OTel
+import OTLPGRPC
+import ServiceLifecycle
+import W3CTraceContext
+import XCTest
+
+final class OTLPGRPCIntegrationTests: XCTestCase, @unchecked Sendable {
+    func test_example() async throws {
+        LoggingSystem.bootstrapInternal { label in
+            var handler = StreamLogHandler.standardOutput(label: label)
+            handler.logLevel = .trace
+            return handler
+        }
+        let logger = Logger(label: "test")
+        let group = MultiThreadedEventLoopGroup.singleton
+        let exporter = try OTLPGRPCSpanExporter(
+            configuration: OTLPGRPCSpanExporterConfiguration(environment: [:]),
+            group: group,
+            requestLogger: logger,
+            backgroundActivityLogger: logger
+        )
+        let processor = OTelBatchSpanProcessor(
+            exporter: exporter,
+            configuration: .init(
+                environment: [:],
+                scheduleDelay: .zero
+            )
+        )
+        let tracer = OTelTracer(
+            idGenerator: OTelRandomIDGenerator(),
+            sampler: OTelConstantSampler(isOn: true),
+            propagator: OTelW3CPropagator(),
+            processor: processor,
+            environment: [:],
+            resource: OTelResource(attributes: ["service.name": "IntegrationTests"])
+        )
+
+        InstrumentationSystem.bootstrapInternal(tracer)
+
+        let serviceGroup = ServiceGroup(
+            configuration: .init(
+                services: [
+                    .init(service: tracer),
+                    .init(service: TestService(), successTerminationBehavior: .gracefullyShutdownGroup),
+                ],
+                logger: logger
+            )
+        )
+        try await serviceGroup.run()
+    }
+}
+
+struct TestService: Service {
+    func run() async throws {
+        let otelCollectorOutputPath = try XCTUnwrap(ProcessInfo.processInfo.environment["OTEL_COLLECTOR_OUTPUT"])
+        let outputFileURL = URL(fileURLWithPath: otelCollectorOutputPath)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outputFileURL.path), outputFileURL.path)
+
+        let span = InstrumentationSystem.tracer.startSpan("test")
+        span.attributes["foo"] = "bar"
+        span.setStatus(.init(code: .ok))
+        span.end()
+
+        // wait for export
+        try await Task.sleep(for: .seconds(2))
+
+        let jsonDecoder = JSONDecoder()
+        let outputFileContents = try String(contentsOf: outputFileURL, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines)
+        let lines = outputFileContents.components(separatedBy: .newlines)
+        let exportLine = try XCTUnwrap(lines.last)
+        let decodedExportLine = try jsonDecoder.decode(ExportLine.self, from: Data(exportLine.utf8))
+        let resourceSpans = try XCTUnwrap(decodedExportLine.resourceSpans.first)
+        let scopeSpans = try XCTUnwrap(resourceSpans.scopeSpans.first)
+        let exportedSpan = try XCTUnwrap(scopeSpans.spans.first)
+
+        XCTAssertEqual(exportedSpan.spanID, span.context.spanContext?.spanID.description)
+        XCTAssertEqual(exportedSpan.traceID, span.context.spanContext?.traceID.description)
+        XCTAssertEqual(exportedSpan.name, "test")
+        XCTAssertEqual(exportedSpan.attributes, [.init(key: "foo", value: .init(stringValue: "bar"))])
+    }
+}
+
+struct ExportLine: Decodable {
+    let resourceSpans: [ResourceSpan]
+
+    struct ResourceSpan: Decodable {
+        let scopeSpans: [ScopeSpans]
+
+        struct ScopeSpans: Decodable {
+            let spans: [Span]
+
+            struct Span: Decodable {
+                let traceID: String
+                let spanID: String
+                let name: String
+                let attributes: [Attribute]
+
+                private enum CodingKeys: String, CodingKey {
+                    case traceID = "traceId"
+                    case spanID = "spanId"
+                    case name
+                    case attributes
+                }
+
+                struct Attribute: Decodable, Equatable {
+                    let key: String
+                    let value: Value
+
+                    struct Value: Decodable, Equatable {
+                        let stringValue: String
+                    }
+                }
+            }
+        }
+    }
+}

--- a/IntegrationTests/otel-collector-config.yml
+++ b/IntegrationTests/otel-collector-config.yml
@@ -1,0 +1,17 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "127.0.0.1:4317"
+
+exporters:
+  file:
+    path: /home/runner/work/swift-otel/swift-otel/IntegrationTests/otel-collector-output.jsonl
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [file]
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/srikanthccv/otelcol-jsonschema/main/schema.json

--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,9 @@ define contents_xcworkspacedata
 	<Group location="container:Benchmarks" name="Benchmarks">
 		<FileRef location="group:." name="benchmarks"></FileRef>
 	</Group>
+	<Group location="container:IntegrationTests" name="IntegrationTests">
+		<FileRef location="group:." name="integration-tests"></FileRef>
+	</Group>
 </Workspace>
 endef
 export contents_xcworkspacedata

--- a/scripts/validate_format.sh
+++ b/scripts/validate_format.sh
@@ -36,7 +36,7 @@ printf "=> Checking format\n"
 FIRST_OUT="$(git status --porcelain)"
 # swiftformat does not scale so we loop ourselves
 shopt -u dotglob
-find Sources/* Tests/* Examples/* Benchmarks/* -type d -not -path "*/Generated*" | while IFS= read -r d; do
+find Sources/* Tests/* Examples/* Benchmarks/* IntegrationTests/* -type d -not -path "*/Generated*" | while IFS= read -r d; do
   printf "   * checking $d... "
   out=$(mint run swiftformat -quiet $d 2>&1)
   if [[ $out == *$'\n' ]]; then

--- a/scripts/validate_license_headers.sh
+++ b/scripts/validate_license_headers.sh
@@ -112,6 +112,7 @@ EOF
     find . \
       \( \! -path './.build/*' \) -a \
       \( \! -path './Benchmarks/.build/*' \) -a \
+      \( \! -path './IntegrationTests/.build/*' \) -a \
       \( \! -path '*/Generated/*' \) -a \
       \( "${matching_files[@]}" \) -a \
       \( \! \( "${exceptions[@]}" \) \) | while read line; do


### PR DESCRIPTION
This PR sets up integration tests to run on GitHub Actions. The workflow runs an OTel Collector and configures it to export traces to a `jsonl` file. The integration tests themselves then export to the collector and decode the written `jsonl` file to inspect the output.