### PR TITLE
[Metrics] Fix histogram buckets

### DIFF
--- a/Sources/OTel/Metrics/OTelInstrument/Histogram+OTelInstrument.swift
+++ b/Sources/OTel/Metrics/OTelInstrument/Histogram+OTelInstrument.swift
@@ -41,9 +41,15 @@ extension Histogram: OTelMetricInstrument {
                     min: nil,
                     max: nil,
                     buckets: state.buckets.map {
-                        .init(upperBound: $0.bound.bucketRepresentation, count: UInt64($0.count))
+                        .init(
+                            upperBound: $0.bound.bucketRepresentation,
+                            count: UInt64($0.count)
+                        )
                     } + [
-                        .init(upperBound: .infinity, count: UInt64(state.count)),
+                        .init(
+                            upperBound: .infinity,
+                            count: UInt64(state.countAboveUpperBound)
+                        ),
                     ]
                 )]
             ))

--- a/Sources/OTelTesting/Metrics+TestHelpers.swift
+++ b/Sources/OTelTesting/Metrics+TestHelpers.swift
@@ -37,6 +37,7 @@
             count: Int,
             sum: Value,
             buckets: [(bound: Value, count: Int)],
+            countAboveUpperBound: Int,
             file: StaticString = #filePath,
             line: UInt = #line
         ) {
@@ -49,6 +50,7 @@
                 "Unexpected buckets",
                 file: file, line: line
             )
+            XCTAssertEqual(state.countAboveUpperBound, countAboveUpperBound, "Unexpected countAboveUpperBound", file: file, line: line)
         }
     }
 

--- a/Sources/OTelTesting/Metrics+TestHelpers.swift
+++ b/Sources/OTelTesting/Metrics+TestHelpers.swift
@@ -36,6 +36,7 @@ extension Histogram {
         count: Int,
         sum: Value,
         buckets: [(bound: Value, count: Int)],
+        countAboveUpperBound: Int,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
@@ -48,6 +49,7 @@ extension Histogram {
             "Unexpected buckets",
             file: file, line: line
         )
+        XCTAssertEqual(state.countAboveUpperBound, countAboveUpperBound, "Unexpected countAboveUpperBound", file: file, line: line)
     }
 }
 

--- a/Tests/OTelTests/Metrics/MetricStore/HistogramTests.swift
+++ b/Tests/OTelTests/Metrics/MetricStore/HistogramTests.swift
@@ -29,39 +29,39 @@ final class HistogramTests: XCTestCase {
             (bound: .milliseconds(250), count: 0),
             (bound: .milliseconds(500), count: 0),
             (bound: .seconds(1), count: 0),
-        ])
+        ], countAboveUpperBound: 0)
 
         histogram.record(.milliseconds(400))
         histogram.assertStateEquals(count: 1, sum: .milliseconds(400), buckets: [
             (bound: .milliseconds(100), count: 0),
             (bound: .milliseconds(250), count: 0),
             (bound: .milliseconds(500), count: 1),
-            (bound: .seconds(1), count: 1),
-        ])
+            (bound: .seconds(1), count: 0),
+        ], countAboveUpperBound: 0)
 
         histogram.record(.milliseconds(600))
         histogram.assertStateEquals(count: 2, sum: .milliseconds(1000), buckets: [
             (bound: .milliseconds(100), count: 0),
             (bound: .milliseconds(250), count: 0),
             (bound: .milliseconds(500), count: 1),
-            (bound: .seconds(1), count: 2),
-        ])
+            (bound: .seconds(1), count: 1),
+        ], countAboveUpperBound: 0)
 
         histogram.record(.milliseconds(1200))
         histogram.assertStateEquals(count: 3, sum: .milliseconds(2200), buckets: [
             (bound: .milliseconds(100), count: 0),
             (bound: .milliseconds(250), count: 0),
             (bound: .milliseconds(500), count: 1),
-            (bound: .seconds(1), count: 2),
-        ])
+            (bound: .seconds(1), count: 1),
+        ], countAboveUpperBound: 1)
 
         histogram.record(.milliseconds(80))
         histogram.assertStateEquals(count: 4, sum: .milliseconds(2280), buckets: [
             (bound: .milliseconds(100), count: 1),
-            (bound: .milliseconds(250), count: 1),
-            (bound: .milliseconds(500), count: 2),
-            (bound: .seconds(1), count: 3),
-        ])
+            (bound: .milliseconds(250), count: 0),
+            (bound: .milliseconds(500), count: 1),
+            (bound: .seconds(1), count: 1),
+        ], countAboveUpperBound: 1)
     }
 
     func test_record_concurrent() async {
@@ -83,8 +83,8 @@ final class HistogramTests: XCTestCase {
         }
         histogram.assertStateEquals(count: 200_000, sum: .seconds(100_000), buckets: [
             (bound: .milliseconds(500), count: 100_000),
-            (bound: .milliseconds(700), count: 200_000),
-        ])
+            (bound: .milliseconds(700), count: 100_000),
+        ], countAboveUpperBound: 0)
     }
 
     func test_bucketRepresentation_duration() {

--- a/Tests/OTelTests/Metrics/OTelInstrument/HistogramMeasurementTests.swift
+++ b/Tests/OTelTests/Metrics/OTelInstrument/HistogramMeasurementTests.swift
@@ -36,8 +36,8 @@ final class HistogramMeasurementTests: XCTestCase {
             .init(upperBound: 0.1, count: 0),
             .init(upperBound: 0.25, count: 0),
             .init(upperBound: 0.5, count: 1),
-            .init(upperBound: 1.0, count: 1),
-            .init(upperBound: .infinity, count: 1),
+            .init(upperBound: 1.0, count: 0),
+            .init(upperBound: .infinity, count: 0),
         ])
 
         histogram.record(.milliseconds(600))
@@ -45,8 +45,8 @@ final class HistogramMeasurementTests: XCTestCase {
             .init(upperBound: 0.1, count: 0),
             .init(upperBound: 0.25, count: 0),
             .init(upperBound: 0.5, count: 1),
-            .init(upperBound: 1.0, count: 2),
-            .init(upperBound: .infinity, count: 2),
+            .init(upperBound: 1.0, count: 1),
+            .init(upperBound: .infinity, count: 0),
         ])
 
         histogram.record(.milliseconds(1200))
@@ -54,17 +54,17 @@ final class HistogramMeasurementTests: XCTestCase {
             .init(upperBound: 0.1, count: 0),
             .init(upperBound: 0.25, count: 0),
             .init(upperBound: 0.5, count: 1),
-            .init(upperBound: 1.0, count: 2),
-            .init(upperBound: .infinity, count: 3),
+            .init(upperBound: 1.0, count: 1),
+            .init(upperBound: .infinity, count: 1),
         ])
 
         histogram.record(.milliseconds(80))
         histogram.measure().data.assertIsCumulativeHistogramWith(count: 4, sum: 2.28, buckets: [
             .init(upperBound: 0.1, count: 1),
-            .init(upperBound: 0.25, count: 1),
-            .init(upperBound: 0.5, count: 2),
-            .init(upperBound: 1.0, count: 3),
-            .init(upperBound: .infinity, count: 4),
+            .init(upperBound: 0.25, count: 0),
+            .init(upperBound: 0.5, count: 1),
+            .init(upperBound: 1.0, count: 1),
+            .init(upperBound: .infinity, count: 1),
         ])
     }
 
@@ -84,7 +84,7 @@ final class HistogramMeasurementTests: XCTestCase {
         }
         histogram.measure().data.assertIsCumulativeHistogramWith(count: 200_000, sum: 100_000, buckets: [
             .init(upperBound: 0.5, count: 100_000),
-            .init(upperBound: .infinity, count: 200_000),
+            .init(upperBound: .infinity, count: 100_000),
         ])
     }
 

--- a/Tests/OTelTests/Metrics/SwiftMetricsFactory/OTLPMetricsFactoryTests.swift
+++ b/Tests/OTelTests/Metrics/SwiftMetricsFactory/OTLPMetricsFactoryTests.swift
@@ -98,7 +98,7 @@ final class OTLPMetricsFactoryTests: XCTestCase {
             histogram.assertStateEquals(count: 0, sum: .zero, buckets: [
                 (bound: .milliseconds(100), count: 0),
                 (bound: .milliseconds(200), count: 0),
-            ])
+            ], countAboveUpperBound: 0)
         }
 
         do {
@@ -107,7 +107,7 @@ final class OTLPMetricsFactoryTests: XCTestCase {
             histogram.assertStateEquals(count: 0, sum: .zero, buckets: [
                 (bound: .milliseconds(300), count: 0),
                 (bound: .milliseconds(400), count: 0),
-            ])
+            ], countAboveUpperBound: 0)
         }
     }
 
@@ -124,7 +124,7 @@ final class OTLPMetricsFactoryTests: XCTestCase {
             histogram.assertStateEquals(count: 0, sum: 0, buckets: [
                 (bound: 0.1, count: 0),
                 (bound: 0.2, count: 0),
-            ])
+            ], countAboveUpperBound: 0)
         }
 
         do {
@@ -133,7 +133,7 @@ final class OTLPMetricsFactoryTests: XCTestCase {
             histogram.assertStateEquals(count: 0, sum: 0, buckets: [
                 (bound: 0.3, count: 0),
                 (bound: 0.4, count: 0),
-            ])
+            ], countAboveUpperBound: 0)
         }
     }
 
@@ -206,55 +206,55 @@ final class OTLPMetricsFactoryTests: XCTestCase {
             (bound: 0.25, count: 0),
             (bound: 0.50, count: 0),
             (bound: 1.00, count: 0),
-        ])
+        ], countAboveUpperBound: 0)
 
         recorder.record(0.4)
         (recorder as? ValueHistogram)?.assertStateEquals(count: 1, sum: 0.4, buckets: [
             (bound: 0.10, count: 0),
             (bound: 0.25, count: 0),
             (bound: 0.50, count: 1),
-            (bound: 1.00, count: 1),
-        ])
+            (bound: 1.00, count: 0),
+        ], countAboveUpperBound: 0)
 
         recorder.record(0.6)
         (recorder as? ValueHistogram)?.assertStateEquals(count: 2, sum: 1.0, buckets: [
             (bound: 0.10, count: 0),
             (bound: 0.25, count: 0),
             (bound: 0.50, count: 1),
-            (bound: 1.00, count: 2),
-        ])
+            (bound: 1.00, count: 1),
+        ], countAboveUpperBound: 0)
 
         recorder.record(1.2)
         (recorder as? ValueHistogram)?.assertStateEquals(count: 3, sum: 2.2, buckets: [
             (bound: 0.10, count: 0),
             (bound: 0.25, count: 0),
             (bound: 0.50, count: 1),
-            (bound: 1.00, count: 2),
-        ])
+            (bound: 1.00, count: 1),
+        ], countAboveUpperBound: 1)
 
         recorder.record(0.01)
         (recorder as? ValueHistogram)?.assertStateEquals(count: 4, sum: 2.21, buckets: [
             (bound: 0.10, count: 1),
-            (bound: 0.25, count: 1),
-            (bound: 0.50, count: 2),
-            (bound: 1.00, count: 3),
-        ])
+            (bound: 0.25, count: 0),
+            (bound: 0.50, count: 1),
+            (bound: 1.00, count: 1),
+        ], countAboveUpperBound: 1)
 
         recorder.record(Int64(1))
         (recorder as? ValueHistogram)?.assertStateEquals(count: 5, sum: 3.21, buckets: [
             (bound: 0.10, count: 1),
-            (bound: 0.25, count: 1),
-            (bound: 0.50, count: 2),
-            (bound: 1.00, count: 4),
-        ])
+            (bound: 0.25, count: 0),
+            (bound: 0.50, count: 1),
+            (bound: 1.00, count: 2),
+        ], countAboveUpperBound: 1)
 
         recorder.record(Int64(2))
         (recorder as? ValueHistogram)?.assertStateEquals(count: 6, sum: 5.21, buckets: [
             (bound: 0.10, count: 1),
-            (bound: 0.25, count: 1),
-            (bound: 0.50, count: 2),
-            (bound: 1.00, count: 4),
-        ])
+            (bound: 0.25, count: 0),
+            (bound: 0.50, count: 1),
+            (bound: 1.00, count: 2),
+        ], countAboveUpperBound: 2)
     }
 
     func test_Timer_methods() throws {
@@ -274,39 +274,39 @@ final class OTLPMetricsFactoryTests: XCTestCase {
             (bound: .nanoseconds(250), count: 0),
             (bound: .nanoseconds(500), count: 0),
             (bound: .microseconds(1), count: 0),
-        ])
+        ], countAboveUpperBound: 0)
 
         timer.recordNanoseconds(400)
         (timer as? DurationHistogram)?.assertStateEquals(count: 1, sum: .nanoseconds(400), buckets: [
             (bound: .nanoseconds(100), count: 0),
             (bound: .nanoseconds(250), count: 0),
             (bound: .nanoseconds(500), count: 1),
-            (bound: .microseconds(1), count: 1),
-        ])
+            (bound: .microseconds(1), count: 0),
+        ], countAboveUpperBound: 0)
 
         timer.recordNanoseconds(600)
         (timer as? DurationHistogram)?.assertStateEquals(count: 2, sum: .nanoseconds(1000), buckets: [
             (bound: .nanoseconds(100), count: 0),
             (bound: .nanoseconds(250), count: 0),
             (bound: .nanoseconds(500), count: 1),
-            (bound: .microseconds(1), count: 2),
-        ])
+            (bound: .microseconds(1), count: 1),
+        ], countAboveUpperBound: 0)
 
         timer.recordNanoseconds(1200)
         (timer as? DurationHistogram)?.assertStateEquals(count: 3, sum: .nanoseconds(2200), buckets: [
             (bound: .nanoseconds(100), count: 0),
             (bound: .nanoseconds(250), count: 0),
             (bound: .nanoseconds(500), count: 1),
-            (bound: .microseconds(1), count: 2),
-        ])
+            (bound: .microseconds(1), count: 1),
+        ], countAboveUpperBound: 1)
 
         timer.recordNanoseconds(80)
         (timer as? DurationHistogram)?.assertStateEquals(count: 4, sum: .nanoseconds(2280), buckets: [
             (bound: .nanoseconds(100), count: 1),
-            (bound: .nanoseconds(250), count: 1),
-            (bound: .nanoseconds(500), count: 2),
-            (bound: .microseconds(1), count: 3),
-        ])
+            (bound: .nanoseconds(250), count: 0),
+            (bound: .nanoseconds(500), count: 1),
+            (bound: .microseconds(1), count: 1),
+        ], countAboveUpperBound: 1)
     }
 
     func test_reregister_withoutDimensions() {


### PR DESCRIPTION
## Summary

[OpenTelemetry histogram](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#histogram) buckets are only supposed to include the counts of values in that bucket, unlike the values in that bucket + all lower buckets (like [Prometheus histograms](https://prometheus.io/docs/concepts/metric_types/#histogram)).

The original histogram implementation was brought over from swift-prometheus, but the bucketing logic wasn't updated to account for this difference between Prometheus and OpenTelemetry.

This PR fixes the bucketing logic to conform to the OpenTelemetry specification, and to avoid double-counting when histograms are, for example, imported into Prometheus.

## Test Plan

Updated unit tests to reflect this change, plus verified manually that when emitting histograms from a Swift service into otel-collector, which forwards them to Prometheus, we now get correct histograms (previously they were double counted and the results were incorrect.)
