### PR TITLE
Enable active span lookup via ServiceContext

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         .library(name: "OTLPGRPC", targets: ["OTLPGRPC"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),

--- a/Sources/OTel/Tracing/OTelTracer.swift
+++ b/Sources/OTel/Tracing/OTelTracer.swift
@@ -36,6 +36,7 @@ public final class OTelTracer<
 
     private let eventStream: AsyncStream<Event>
     private let eventStreamContinuation: AsyncStream<Event>.Continuation
+    private let recordingSpans = NIOLockedValueBox([OTelSpanContext: OTelSpan]())
 
     @_spi(Testing)
     public init(
@@ -179,7 +180,7 @@ extension OTelTracer: Tracer {
                 return .noOp(NoOpTracer.NoOpSpan(context: childContext))
             }
 
-            return .recording(
+            let recordingSpan = OTelSpan.recording(
                 operationName: operationName,
                 kind: kind,
                 context: childContext,
@@ -188,8 +189,11 @@ extension OTelTracer: Tracer {
                 startTimeNanosecondsSinceEpoch: instant().nanosecondsSinceEpoch,
                 onEnd: { [weak self] span, endTimeNanosecondsSinceEpoch in
                     self?.process(span, endedAt: endTimeNanosecondsSinceEpoch)
+                    self?.recordingSpans.withLockedValue { $0[spanContext] = nil }
                 }
             )
+            recordingSpans.withLockedValue { $0[spanContext] = recordingSpan }
+            return recordingSpan
         }()
 
         eventStreamContinuation.yield(.spanStarted(span, parentContext: parentContext))
@@ -216,6 +220,12 @@ extension OTelTracer: Tracer {
             links: span.links
         )
         eventStreamContinuation.yield(.spanEnded(finishedSpan))
+    }
+
+    public func activeSpan(identifiedBy context: ServiceContext) -> OTelSpan? {
+        guard let spanContext = context.spanContext else { return nil }
+        guard let recordingSpan = recordingSpans.withLockedValue({ $0[spanContext] }) else { return nil }
+        return recordingSpan
     }
 }
 

--- a/Tests/OTelTests/Tracing/OTelTracerTests.swift
+++ b/Tests/OTelTests/Tracing/OTelTracerTests.swift
@@ -288,6 +288,49 @@ final class OTelTracerTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(batch).map(\.operationName), ["test"])
     }
 
+    func test_spanIdentifiedByServiceContext_withoutSpanContext_returnsSpan() {
+        let tracer = OTelTracer(
+            idGenerator: OTelRandomIDGenerator(),
+            sampler: OTelConstantSampler(isOn: true),
+            propagator: OTelW3CPropagator(),
+            processor: OTelNoOpSpanProcessor(),
+            environment: [:],
+            resource: OTelResource()
+        )
+
+        XCTAssertNil(tracer.activeSpan(identifiedBy: .topLevel))
+    }
+
+    func test_spanIdentifiedByServiceContext_withSpanContext_identifyingRecordingSpan_returnsSpan() async {
+        let tracer = OTelTracer(
+            idGenerator: OTelRandomIDGenerator(),
+            sampler: OTelConstantSampler(isOn: true),
+            propagator: OTelW3CPropagator(),
+            processor: OTelNoOpSpanProcessor(),
+            environment: [:],
+            resource: OTelResource()
+        )
+
+        let span = tracer.startSpan("test")
+        XCTAssertIdentical(span, tracer.activeSpan(identifiedBy: span.context))
+    }
+
+    func test_spanIdentifiedByServiceContext_withSpanContext_identifyingEndedSpan_returnsNil() async {
+        let tracer = OTelTracer(
+            idGenerator: OTelRandomIDGenerator(),
+            sampler: OTelConstantSampler(isOn: true),
+            propagator: OTelW3CPropagator(),
+            processor: OTelNoOpSpanProcessor(),
+            environment: [:],
+            resource: OTelResource()
+        )
+
+        let span = tracer.startSpan("test")
+        span.end()
+
+        XCTAssertNil(tracer.activeSpan(identifiedBy: span.context))
+    }
+
     // MARK: - Instrument
 
     func test_inject_withSpanContext_callsPropagator() {


### PR DESCRIPTION
Implements active span lookup based on https://github.com/apple/swift-distributed-tracing/pull/160.