### PR TITLE
Update server example to Hummingbird 2.0

### DIFF
--- a/Examples/Server/Package.swift
+++ b/Examples/Server/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "swift-otel", path: "../.."),
-        .package(url: "https://github.com/hummingbird-project/hummingbird", exact: "2.0.0-alpha.1"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.4.1"),
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.0.0"),

--- a/Examples/Server/Sources/ServerExample/ServerExample.swift
+++ b/Examples/Server/Sources/ServerExample/ServerExample.swift
@@ -65,12 +65,12 @@ enum ServerMiddlewareExample {
         InstrumentationSystem.bootstrap(tracer)
 
         // Create an HTTP server with instrumentation middleware and a simple /hello endpoint, on 127.0.0.1:8080.
-        let router = HBRouter()
-        router.middlewares.add(HBTracingMiddleware())
-        router.middlewares.add(HBMetricsMiddleware())
-        router.middlewares.add(HBLogRequestsMiddleware(.info))
+        let router = Router()
+        router.middlewares.add(TracingMiddleware())
+        router.middlewares.add(MetricsMiddleware())
+        router.middlewares.add(LogRequestsMiddleware(.info))
         router.get("hello") { _, _ in "hello" }
-        var app = HBApplication(router: router)
+        var app = Application(router: router)
 
         // Add the tracer lifecycle service to the HTTP server service group and start the application.
         app.addServices(metrics, tracer)


### PR DESCRIPTION
The server example was still using a pinned Hummingbird 2.0 Alpha. This PR updates it to the latest 2.0 release.