### PR TITLE
Use W3C Trace Context from swift-otel org

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.4.1"),
-        .package(url: "https://github.com/slashmo/swift-w3c-trace-context.git", exact: "1.0.0-beta.3"),
+        .package(url: "https://github.com/swift-otel/swift-w3c-trace-context.git", exact: "1.0.0-beta.3"),
 
         // MARK: - OTLP
 


### PR DESCRIPTION
Swift W3C TraceContext was migrated from `slashmo/swift-w3c-trace-context` to `swift-otel/swift-w3c-trace-context`.
