### PR TITLE
[CI] Fix otelcol installation in integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,8 @@ jobs:
 
       - name: Install OTel Collector
         run: |
-          gh release download -p 'otelcol_*linux_amd64.tar.gz' -R open-telemetry/opentelemetry-collector-releases
+          latest_tag=$(gh release list -R open-telemetry/opentelemetry-collector-releases --json tagName --jq '.[].tagName' | grep -m 1 '^v')
+          gh release download -p 'otelcol_*linux_amd64.tar.gz' -R open-telemetry/opentelemetry-collector-releases $latest_tag
           tar -xvf "$(ls otelcol_*_linux_amd64.tar.gz | tail -1)"
           mv otelcol /usr/local/bin
         env:


### PR DESCRIPTION
https://github.com/open-telemetry/opentelemetry-collector-releases/releases recently started exposing both `otelcol` and `cmd/builder` releases, breaking the previous installation script in our integration tests. This PR updates the script to check for the latest actual `otelcol` release and downloads the executable from it.
