### PR TITLE
Add iOS platform

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let sharedSwiftSettings: [SwiftSetting] = [.enableExperimentalFeature("StrictCon
 
 let package = Package(
     name: "swift-otel",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v13), .iOS(.v16)],
     products: [
         .library(name: "OTel", targets: ["OTel"]),
         .library(name: "OTLPGRPC", targets: ["OTLPGRPC"]),


### PR DESCRIPTION
Thank you for creating this awesome library!

We would like to use it to add tracing to our iOS app.

In general the Package builds fine, but Xcode defaults to iOS12 for the deploymentTarget
It uses APIs that are only available on iOS16+ (`Duration` and `Clock` specifically)

Please let me know if i can add anything more (maybe updating CI to actually run the tests against iOS?)

PS: I also completely understand if "officially supporting" iOS is too restrictive/maintainance burden and you chose not to go forward with this.

