### PR TITLE
Typo fixed by replacing logger with logLevel.

### DIFF
--- a/Sources/OTel/OTel.docc/Resource Detection/resource-detection.md
+++ b/Sources/OTel/OTel.docc/Resource Detection/resource-detection.md
@@ -44,7 +44,7 @@ let resourceDetection = OTelResourceDetection(detectors: [
     OTelEnvironmentResourceDetector(environment: environment),
 ])
 
-let resource = await resourceDetection.resource(environment: environment, logger: logger)
+let resource = await resourceDetection.resource(environment: environment, logLevel: .trace)
 
 // ... pass the resource to other Swift OTel components
 ```


### PR DESCRIPTION
## Changes
Replaced in [Resource Detection](https://swiftpackageindex.com/swift-otel/swift-otel/0.11.0/documentation/otel/resource-detection) article
```
let resource = await resourceDetection.resource(environment: environment, logger: logger)
```
by
```
let resource = await resourceDetection.resource(environment: environment, logLevel: .trace)
```

Fixes #201 