### PR TITLE
[CI] Remove Swift 6.0 from workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.0", "latest"]
+        swift: ["latest"]
 
     steps:
       - name: Install Swift

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.0", "latest"]
+        swift: ["latest"]
 
     steps:
       - name: Install Swift


### PR DESCRIPTION
Removes Swift 6.0 from GitHub Actions workflow runs in preparation for bumping the package to 6.1.
