### PR TITLE
docs: Add proposal doc for revised 1.0 API

### DIFF
--- a/docs/public-api-for-1.0.md
+++ b/docs/public-api-for-1.0.md
@@ -245,6 +245,13 @@ extension OTel {
 
 ### Make backends
 
+For more advanced use cases, we offer APIs for constructing the backends to compose with other types in the Swift
+observability ecosystem. These APIs all have a similar shape and return a tuple of two things:
+
+- The factory: a value that could be passed directly to the observability subsystem bootstrap, e.g.
+  `LoggingSystem.bootstrap(_:)`; and
+- The service: a type that performs the background work required for the operation of the backend.
+
 ```swift
 extension OTel {
     public static func makeLoggingBackend(

--- a/docs/public-api-for-1.0.md
+++ b/docs/public-api-for-1.0.md
@@ -517,6 +517,17 @@ This proposal does not do this for the following reasons:
 
 - Specification guidance: The chosen structure mirrors the configuration hierarchy defined in the OTel spec.
 
+### Reducing the set of default enabled package traits
+
+This proposal uses traits to guard the provision of both the HTTP and gRPC exporters. This allows adopters to reduce
+their build times if they want to explicitly remove support for one of the exporters.
+
+Disabling the `OTLPGRPC` trait by default was considered but was rejected in favour of:
+
+- Ease of use, out of the box.
+
+- Support for runtime configuration by operators without manual steps on by the developer.
+
 ## Future directions
 
 ### Resource detection

--- a/docs/public-api-for-1.0.md
+++ b/docs/public-api-for-1.0.md
@@ -244,24 +244,21 @@ extension OTel {
 
 ```swift
 extension OTel {
-    public typealias LogsFactory = (@Sendable (String) -> any Logging.LogHandler)
-    public typealias MetricsFactory = CoreMetrics.MetricsFactory
-    public typealias TracesFactory = Tracing.Instrument
-
     public static func makeLoggingBackend(
         configuration: OTel.Configuration = .default,
         detectEnvironmentOverrides: Bool = true
-    ) throws -> (factory: LogsFactory, service: some Service)
+    ) throws -> (factory: @Sendable (String) -> any Logging.LogHandler, service: some
+    Service)
 
     public static func makeMetricsBackend(
         configuration: OTel.Configuration = .default,
         detectEnvironmentOverrides: Bool = true
-    ) throws -> (factory: any MetricsFactory, service: some Service)
+    ) throws -> (factory: any CoreMetrics.MetricsFactory, service: some Service)
 
     public static func makeTracingBackend(
         configuration: OTel.Configuration = .default,
         detectEnvironmentOverrides: Bool = true
-    ) throws -> (factory: any TracesFactory, service: some Service)
+    ) throws -> (factory: any Tracing.Instrument, service: some Service)
 }
 ```
 

--- a/docs/public-api-for-1.0.md
+++ b/docs/public-api-for-1.0.md
@@ -19,6 +19,9 @@ the proposed API, we must also consider the other features that are planned for 
 
 - Reduced ceremony for bootstrapping the Swift observability backends.
 
+Note that this package is not focused on providing a full "OTel SDK", and so the API is focussed only on bootstrapping
+the Swift observability backends with OTLP exporters.
+
 The remaining part of this proposal focuses on the proposed API changes.
 
 ## Existing API

--- a/docs/public-api-for-1.0.md
+++ b/docs/public-api-for-1.0.md
@@ -11,7 +11,7 @@ the proposed API, we must also consider the other features that are planned for 
 
 - Support for OTLP Logging backend.
 
-- Update existing GRPC exporter to use Swift GRPC v2.
+- Update existing gRPC exporter to use gRPC Swift v2.
 
 - Add support for an OTLP/HTTP exporter.
 

--- a/docs/public-api-for-1.0.md
+++ b/docs/public-api-for-1.0.md
@@ -1,5 +1,9 @@
 # Proposal: Revised public API to support 1.0 roadmap
 
+- Author: [Si Beaumont](https://github.com/simonjbeaumont)
+- Discussion: [Swift Forums](https://forums.swift.org/t/swift-otel-proposed-revised-api-for-1-0-release/80214/)
+- Status: Accepted
+
 ## Introduction
 
 Swift OTel provides an OTLP backend for the Swift observability packages (Swift Log, Swift Metrics, and Swift


### PR DESCRIPTION
### Motivation

Following discussions with maintainers and stakeholders, we'd like to rework (and reduce) the public API surface of this package to support the 1.0 release. We'd like for this transition to be coordinated and well documented.

### Modifications

Add a proposal document for the revised API, incorporating the early feedback we've had so far.

### Results

Document will exist in the repo as an artifact of the design and decisions around the 1.0 API surface.