### PR TITLE
Mark all previously public API as package visibile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ $(OTLP_CORE_SWIFTS): $(OTLP_CORE_PROTOS) $(PROTO_MODULEMAP) $(PROTOC_GEN_SWIFT)
 		--proto_path=$(PROTO_ROOT) \
 		--plugin=$(PROTOC_GEN_SWIFT) \
 		--swift_out=$(OTLP_CORE_SWIFT_ROOT) \
-		--swift_opt=Visibility=Public \
+		--swift_opt=Visibility=Package \
 		--experimental_allow_proto3_optional \
 
 $(OTLP_CLIENT_GRPC_SWIFTS): $(OTLP_GRPC_PROTOS) $(PROTO_MODULEMAP) $(PROTOC_GEN_GRPC_SWIFT)

--- a/Sources/OTLPCore/Generated/opentelemetry/proto/common/v1/common.pb.swift
+++ b/Sources/OTLPCore/Generated/opentelemetry/proto/common/v1/common.pb.swift
@@ -37,16 +37,16 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// AnyValue is used to represent any type of attribute value. AnyValue may contain a
 /// primitive value such as a string or integer or it may contain an arbitrary nested
 /// object containing arrays, key-value lists and primitives.
-public struct Opentelemetry_Proto_Common_V1_AnyValue {
+package struct Opentelemetry_Proto_Common_V1_AnyValue {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The value is one of the listed fields. It is valid for all values to be unspecified
   /// in which case this AnyValue is considered to be "empty".
-  public var value: Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value? = nil
+  package var value: Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value? = nil
 
-  public var stringValue: String {
+  package var stringValue: String {
     get {
       if case .stringValue(let v)? = value {return v}
       return String()
@@ -54,7 +54,7 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
     set {value = .stringValue(newValue)}
   }
 
-  public var boolValue: Bool {
+  package var boolValue: Bool {
     get {
       if case .boolValue(let v)? = value {return v}
       return false
@@ -62,7 +62,7 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
     set {value = .boolValue(newValue)}
   }
 
-  public var intValue: Int64 {
+  package var intValue: Int64 {
     get {
       if case .intValue(let v)? = value {return v}
       return 0
@@ -70,7 +70,7 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
     set {value = .intValue(newValue)}
   }
 
-  public var doubleValue: Double {
+  package var doubleValue: Double {
     get {
       if case .doubleValue(let v)? = value {return v}
       return 0
@@ -78,7 +78,7 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
     set {value = .doubleValue(newValue)}
   }
 
-  public var arrayValue: Opentelemetry_Proto_Common_V1_ArrayValue {
+  package var arrayValue: Opentelemetry_Proto_Common_V1_ArrayValue {
     get {
       if case .arrayValue(let v)? = value {return v}
       return Opentelemetry_Proto_Common_V1_ArrayValue()
@@ -86,7 +86,7 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
     set {value = .arrayValue(newValue)}
   }
 
-  public var kvlistValue: Opentelemetry_Proto_Common_V1_KeyValueList {
+  package var kvlistValue: Opentelemetry_Proto_Common_V1_KeyValueList {
     get {
       if case .kvlistValue(let v)? = value {return v}
       return Opentelemetry_Proto_Common_V1_KeyValueList()
@@ -94,7 +94,7 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
     set {value = .kvlistValue(newValue)}
   }
 
-  public var bytesValue: Data {
+  package var bytesValue: Data {
     get {
       if case .bytesValue(let v)? = value {return v}
       return Data()
@@ -102,11 +102,11 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
     set {value = .bytesValue(newValue)}
   }
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The value is one of the listed fields. It is valid for all values to be unspecified
   /// in which case this AnyValue is considered to be "empty".
-  public enum OneOf_Value: Equatable {
+  package enum OneOf_Value: Equatable {
     case stringValue(String)
     case boolValue(Bool)
     case intValue(Int64)
@@ -116,7 +116,7 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
     case bytesValue(Data)
 
   #if !swift(>=4.1)
-    public static func ==(lhs: Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value, rhs: Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value) -> Bool {
+    package static func ==(lhs: Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value, rhs: Opentelemetry_Proto_Common_V1_AnyValue.OneOf_Value) -> Bool {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
@@ -155,22 +155,22 @@ public struct Opentelemetry_Proto_Common_V1_AnyValue {
   #endif
   }
 
-  public init() {}
+  package init() {}
 }
 
 /// ArrayValue is a list of AnyValue messages. We need ArrayValue as a message
 /// since oneof in AnyValue does not allow repeated fields.
-public struct Opentelemetry_Proto_Common_V1_ArrayValue {
+package struct Opentelemetry_Proto_Common_V1_ArrayValue {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// Array of values. The array may be empty (contain 0 elements).
-  public var values: [Opentelemetry_Proto_Common_V1_AnyValue] = []
+  package var values: [Opentelemetry_Proto_Common_V1_AnyValue] = []
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 }
 
 /// KeyValueList is a list of KeyValue messages. We need KeyValueList as a message
@@ -178,7 +178,7 @@ public struct Opentelemetry_Proto_Common_V1_ArrayValue {
 /// a list of KeyValue messages (e.g. in Span) we use `repeated KeyValue` directly to
 /// avoid unnecessary extra wrapping (which slows down the protocol). The 2 approaches
 /// are semantically equivalent.
-public struct Opentelemetry_Proto_Common_V1_KeyValueList {
+package struct Opentelemetry_Proto_Common_V1_KeyValueList {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -187,60 +187,60 @@ public struct Opentelemetry_Proto_Common_V1_KeyValueList {
   /// contain 0 elements).
   /// The keys MUST be unique (it is not allowed to have more than one
   /// value with the same key).
-  public var values: [Opentelemetry_Proto_Common_V1_KeyValue] = []
+  package var values: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 }
 
 /// KeyValue is a key-value pair that is used to store Span attributes, Link
 /// attributes, etc.
-public struct Opentelemetry_Proto_Common_V1_KeyValue {
+package struct Opentelemetry_Proto_Common_V1_KeyValue {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var key: String = String()
+  package var key: String = String()
 
-  public var value: Opentelemetry_Proto_Common_V1_AnyValue {
+  package var value: Opentelemetry_Proto_Common_V1_AnyValue {
     get {return _value ?? Opentelemetry_Proto_Common_V1_AnyValue()}
     set {_value = newValue}
   }
   /// Returns true if `value` has been explicitly set.
-  public var hasValue: Bool {return self._value != nil}
+  package var hasValue: Bool {return self._value != nil}
   /// Clears the value of `value`. Subsequent reads from it will return its default value.
-  public mutating func clearValue() {self._value = nil}
+  package mutating func clearValue() {self._value = nil}
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 
   fileprivate var _value: Opentelemetry_Proto_Common_V1_AnyValue? = nil
 }
 
 /// InstrumentationScope is a message representing the instrumentation scope information
 /// such as the fully qualified name and version. 
-public struct Opentelemetry_Proto_Common_V1_InstrumentationScope {
+package struct Opentelemetry_Proto_Common_V1_InstrumentationScope {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// An empty instrumentation scope name means the name is unknown.
-  public var name: String = String()
+  package var name: String = String()
 
-  public var version: String = String()
+  package var version: String = String()
 
   /// Additional attributes that describe the scope. [Optional].
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
-  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
+  package var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
-  public var droppedAttributesCount: UInt32 = 0
+  package var droppedAttributesCount: UInt32 = 0
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 }
 
 #if swift(>=5.5) && canImport(_Concurrency)
@@ -257,8 +257,8 @@ extension Opentelemetry_Proto_Common_V1_InstrumentationScope: @unchecked Sendabl
 fileprivate let _protobuf_package = "opentelemetry.proto.common.v1"
 
 extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".AnyValue"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".AnyValue"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "string_value"),
     2: .standard(proto: "bool_value"),
     3: .standard(proto: "int_value"),
@@ -268,7 +268,7 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
     7: .standard(proto: "bytes_value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -345,7 +345,7 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -384,7 +384,7 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Common_V1_AnyValue, rhs: Opentelemetry_Proto_Common_V1_AnyValue) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Common_V1_AnyValue, rhs: Opentelemetry_Proto_Common_V1_AnyValue) -> Bool {
     if lhs.value != rhs.value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -392,12 +392,12 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
 }
 
 extension Opentelemetry_Proto_Common_V1_ArrayValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".ArrayValue"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".ArrayValue"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "values"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -409,14 +409,14 @@ extension Opentelemetry_Proto_Common_V1_ArrayValue: SwiftProtobuf.Message, Swift
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.values.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.values, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Common_V1_ArrayValue, rhs: Opentelemetry_Proto_Common_V1_ArrayValue) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Common_V1_ArrayValue, rhs: Opentelemetry_Proto_Common_V1_ArrayValue) -> Bool {
     if lhs.values != rhs.values {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -424,12 +424,12 @@ extension Opentelemetry_Proto_Common_V1_ArrayValue: SwiftProtobuf.Message, Swift
 }
 
 extension Opentelemetry_Proto_Common_V1_KeyValueList: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".KeyValueList"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".KeyValueList"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "values"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -441,14 +441,14 @@ extension Opentelemetry_Proto_Common_V1_KeyValueList: SwiftProtobuf.Message, Swi
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.values.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.values, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Common_V1_KeyValueList, rhs: Opentelemetry_Proto_Common_V1_KeyValueList) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Common_V1_KeyValueList, rhs: Opentelemetry_Proto_Common_V1_KeyValueList) -> Bool {
     if lhs.values != rhs.values {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -456,13 +456,13 @@ extension Opentelemetry_Proto_Common_V1_KeyValueList: SwiftProtobuf.Message, Swi
 }
 
 extension Opentelemetry_Proto_Common_V1_KeyValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".KeyValue"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".KeyValue"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "key"),
     2: .same(proto: "value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -475,7 +475,7 @@ extension Opentelemetry_Proto_Common_V1_KeyValue: SwiftProtobuf.Message, SwiftPr
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -489,7 +489,7 @@ extension Opentelemetry_Proto_Common_V1_KeyValue: SwiftProtobuf.Message, SwiftPr
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Common_V1_KeyValue, rhs: Opentelemetry_Proto_Common_V1_KeyValue) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Common_V1_KeyValue, rhs: Opentelemetry_Proto_Common_V1_KeyValue) -> Bool {
     if lhs.key != rhs.key {return false}
     if lhs._value != rhs._value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
@@ -498,15 +498,15 @@ extension Opentelemetry_Proto_Common_V1_KeyValue: SwiftProtobuf.Message, SwiftPr
 }
 
 extension Opentelemetry_Proto_Common_V1_InstrumentationScope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".InstrumentationScope"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".InstrumentationScope"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "version"),
     3: .same(proto: "attributes"),
     4: .standard(proto: "dropped_attributes_count"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -521,7 +521,7 @@ extension Opentelemetry_Proto_Common_V1_InstrumentationScope: SwiftProtobuf.Mess
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.name.isEmpty {
       try visitor.visitSingularStringField(value: self.name, fieldNumber: 1)
     }
@@ -537,7 +537,7 @@ extension Opentelemetry_Proto_Common_V1_InstrumentationScope: SwiftProtobuf.Mess
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Common_V1_InstrumentationScope, rhs: Opentelemetry_Proto_Common_V1_InstrumentationScope) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Common_V1_InstrumentationScope, rhs: Opentelemetry_Proto_Common_V1_InstrumentationScope) -> Bool {
     if lhs.name != rhs.name {return false}
     if lhs.version != rhs.version {return false}
     if lhs.attributes != rhs.attributes {return false}

--- a/Sources/OTLPCore/Generated/opentelemetry/proto/logs/v1/logs.pb.swift
+++ b/Sources/OTLPCore/Generated/opentelemetry/proto/logs/v1/logs.pb.swift
@@ -35,8 +35,8 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// Possible values for LogRecord.SeverityNumber.
-public enum Opentelemetry_Proto_Logs_V1_SeverityNumber: SwiftProtobuf.Enum {
-  public typealias RawValue = Int
+package enum Opentelemetry_Proto_Logs_V1_SeverityNumber: SwiftProtobuf.Enum {
+  package typealias RawValue = Int
 
   /// UNSPECIFIED is the default SeverityNumber, it MUST NOT be used.
   case unspecified // = 0
@@ -66,11 +66,11 @@ public enum Opentelemetry_Proto_Logs_V1_SeverityNumber: SwiftProtobuf.Enum {
   case fatal4 // = 24
   case UNRECOGNIZED(Int)
 
-  public init() {
+  package init() {
     self = .unspecified
   }
 
-  public init?(rawValue: Int) {
+  package init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .unspecified
     case 1: self = .trace
@@ -101,7 +101,7 @@ public enum Opentelemetry_Proto_Logs_V1_SeverityNumber: SwiftProtobuf.Enum {
     }
   }
 
-  public var rawValue: Int {
+  package var rawValue: Int {
     switch self {
     case .unspecified: return 0
     case .trace: return 1
@@ -138,7 +138,7 @@ public enum Opentelemetry_Proto_Logs_V1_SeverityNumber: SwiftProtobuf.Enum {
 
 extension Opentelemetry_Proto_Logs_V1_SeverityNumber: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Opentelemetry_Proto_Logs_V1_SeverityNumber] = [
+  package static let allCases: [Opentelemetry_Proto_Logs_V1_SeverityNumber] = [
     .unspecified,
     .trace,
     .trace2,
@@ -174,8 +174,8 @@ extension Opentelemetry_Proto_Logs_V1_SeverityNumber: CaseIterable {
 /// To extract the bit-field, for example, use an expression like:
 ///
 ///   (logRecord.flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK)
-public enum Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf.Enum {
-  public typealias RawValue = Int
+package enum Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf.Enum {
+  package typealias RawValue = Int
 
   /// The zero value for the enum. Should not be used for comparisons.
   /// Instead use bitwise "and" with the appropriate mask as shown above.
@@ -185,11 +185,11 @@ public enum Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf.Enum {
   case traceFlagsMask // = 255
   case UNRECOGNIZED(Int)
 
-  public init() {
+  package init() {
     self = .doNotUse
   }
 
-  public init?(rawValue: Int) {
+  package init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .doNotUse
     case 255: self = .traceFlagsMask
@@ -197,7 +197,7 @@ public enum Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf.Enum {
     }
   }
 
-  public var rawValue: Int {
+  package var rawValue: Int {
     switch self {
     case .doNotUse: return 0
     case .traceFlagsMask: return 255
@@ -211,7 +211,7 @@ public enum Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf.Enum {
 
 extension Opentelemetry_Proto_Logs_V1_LogRecordFlags: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Opentelemetry_Proto_Logs_V1_LogRecordFlags] = [
+  package static let allCases: [Opentelemetry_Proto_Logs_V1_LogRecordFlags] = [
     .doNotUse,
     .traceFlagsMask,
   ]
@@ -229,7 +229,7 @@ extension Opentelemetry_Proto_Logs_V1_LogRecordFlags: CaseIterable {
 ///
 /// When new fields are added into this message, the OTLP request MUST be updated
 /// as well.
-public struct Opentelemetry_Proto_Logs_V1_LogsData {
+package struct Opentelemetry_Proto_Logs_V1_LogsData {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -239,46 +239,46 @@ public struct Opentelemetry_Proto_Logs_V1_LogsData {
   /// one element. Intermediary nodes that receive data from multiple origins
   /// typically batch the data before forwarding further and in that case this
   /// array will contain multiple elements.
-  public var resourceLogs: [Opentelemetry_Proto_Logs_V1_ResourceLogs] = []
+  package var resourceLogs: [Opentelemetry_Proto_Logs_V1_ResourceLogs] = []
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 }
 
 /// A collection of ScopeLogs from a Resource.
-public struct Opentelemetry_Proto_Logs_V1_ResourceLogs {
+package struct Opentelemetry_Proto_Logs_V1_ResourceLogs {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The resource for the logs in this message.
   /// If this field is not set then resource info is unknown.
-  public var resource: Opentelemetry_Proto_Resource_V1_Resource {
+  package var resource: Opentelemetry_Proto_Resource_V1_Resource {
     get {return _resource ?? Opentelemetry_Proto_Resource_V1_Resource()}
     set {_resource = newValue}
   }
   /// Returns true if `resource` has been explicitly set.
-  public var hasResource: Bool {return self._resource != nil}
+  package var hasResource: Bool {return self._resource != nil}
   /// Clears the value of `resource`. Subsequent reads from it will return its default value.
-  public mutating func clearResource() {self._resource = nil}
+  package mutating func clearResource() {self._resource = nil}
 
   /// A list of ScopeLogs that originate from a resource.
-  public var scopeLogs: [Opentelemetry_Proto_Logs_V1_ScopeLogs] = []
+  package var scopeLogs: [Opentelemetry_Proto_Logs_V1_ScopeLogs] = []
 
   /// This schema_url applies to the data in the "resource" field. It does not apply
   /// to the data in the "scope_logs" field which have their own schema_url field.
-  public var schemaURL: String = String()
+  package var schemaURL: String = String()
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 
   fileprivate var _resource: Opentelemetry_Proto_Resource_V1_Resource? = nil
 }
 
 /// A collection of Logs produced by a Scope.
-public struct Opentelemetry_Proto_Logs_V1_ScopeLogs {
+package struct Opentelemetry_Proto_Logs_V1_ScopeLogs {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -286,31 +286,31 @@ public struct Opentelemetry_Proto_Logs_V1_ScopeLogs {
   /// The instrumentation scope information for the logs in this message.
   /// Semantically when InstrumentationScope isn't set, it is equivalent with
   /// an empty instrumentation scope name (unknown).
-  public var scope: Opentelemetry_Proto_Common_V1_InstrumentationScope {
+  package var scope: Opentelemetry_Proto_Common_V1_InstrumentationScope {
     get {return _scope ?? Opentelemetry_Proto_Common_V1_InstrumentationScope()}
     set {_scope = newValue}
   }
   /// Returns true if `scope` has been explicitly set.
-  public var hasScope: Bool {return self._scope != nil}
+  package var hasScope: Bool {return self._scope != nil}
   /// Clears the value of `scope`. Subsequent reads from it will return its default value.
-  public mutating func clearScope() {self._scope = nil}
+  package mutating func clearScope() {self._scope = nil}
 
   /// A list of log records.
-  public var logRecords: [Opentelemetry_Proto_Logs_V1_LogRecord] = []
+  package var logRecords: [Opentelemetry_Proto_Logs_V1_LogRecord] = []
 
   /// This schema_url applies to all logs in the "logs" field.
-  public var schemaURL: String = String()
+  package var schemaURL: String = String()
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 
   fileprivate var _scope: Opentelemetry_Proto_Common_V1_InstrumentationScope? = nil
 }
 
 /// A log record according to OpenTelemetry Log Data Model:
 /// https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
-public struct Opentelemetry_Proto_Logs_V1_LogRecord {
+package struct Opentelemetry_Proto_Logs_V1_LogRecord {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -318,7 +318,7 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord {
   /// time_unix_nano is the time when the event occurred.
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   /// Value of 0 indicates unknown or missing timestamp.
-  public var timeUnixNano: UInt64 = 0
+  package var timeUnixNano: UInt64 = 0
 
   /// Time when the event was observed by the collection system.
   /// For events that originate in OpenTelemetry (e.g. using OpenTelemetry Logging SDK)
@@ -335,41 +335,41 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord {
   ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   /// Value of 0 indicates unknown or missing timestamp.
-  public var observedTimeUnixNano: UInt64 = 0
+  package var observedTimeUnixNano: UInt64 = 0
 
   /// Numerical value of the severity, normalized to values described in Log Data Model.
   /// [Optional].
-  public var severityNumber: Opentelemetry_Proto_Logs_V1_SeverityNumber = .unspecified
+  package var severityNumber: Opentelemetry_Proto_Logs_V1_SeverityNumber = .unspecified
 
   /// The severity text (also known as log level). The original string representation as
   /// it is known at the source. [Optional].
-  public var severityText: String = String()
+  package var severityText: String = String()
 
   /// A value containing the body of the log record. Can be for example a human-readable
   /// string message (including multi-line) describing the event in a free form or it can
   /// be a structured data composed of arrays and maps of other values. [Optional].
-  public var body: Opentelemetry_Proto_Common_V1_AnyValue {
+  package var body: Opentelemetry_Proto_Common_V1_AnyValue {
     get {return _body ?? Opentelemetry_Proto_Common_V1_AnyValue()}
     set {_body = newValue}
   }
   /// Returns true if `body` has been explicitly set.
-  public var hasBody: Bool {return self._body != nil}
+  package var hasBody: Bool {return self._body != nil}
   /// Clears the value of `body`. Subsequent reads from it will return its default value.
-  public mutating func clearBody() {self._body = nil}
+  package mutating func clearBody() {self._body = nil}
 
   /// Additional attributes that describe the specific event occurrence. [Optional].
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
-  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
+  package var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
-  public var droppedAttributesCount: UInt32 = 0
+  package var droppedAttributesCount: UInt32 = 0
 
   /// Flags, a bit field. 8 least significant bits are the trace flags as
   /// defined in W3C Trace Context specification. 24 most significant bits are reserved
   /// and must be set to 0. Readers must not assume that 24 most significant bits
   /// will be zero and must correctly mask the bits when reading 8-bit trace flag (use
   /// flags & LOG_RECORD_FLAGS_TRACE_FLAGS_MASK). [Optional].
-  public var flags: UInt32 = 0
+  package var flags: UInt32 = 0
 
   /// A unique identifier for a trace. All logs from the same trace share
   /// the same `trace_id`. The ID is a 16-byte array. An ID with all zeroes OR
@@ -382,7 +382,7 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord {
   /// trace if any of the following is true:
   ///   - the field is not present,
   ///   - the field contains an invalid value.
-  public var traceID: Data = Data()
+  package var traceID: Data = Data()
 
   /// A unique identifier for a span within a trace, assigned when the span
   /// is created. The ID is an 8-byte array. An ID with all zeroes OR of length
@@ -396,11 +396,11 @@ public struct Opentelemetry_Proto_Logs_V1_LogRecord {
   /// span if any of the following is true:
   ///   - the field is not present,
   ///   - the field contains an invalid value.
-  public var spanID: Data = Data()
+  package var spanID: Data = Data()
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 
   fileprivate var _body: Opentelemetry_Proto_Common_V1_AnyValue? = nil
 }
@@ -419,7 +419,7 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: @unchecked Sendable {}
 fileprivate let _protobuf_package = "opentelemetry.proto.logs.v1"
 
 extension Opentelemetry_Proto_Logs_V1_SeverityNumber: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "SEVERITY_NUMBER_UNSPECIFIED"),
     1: .same(proto: "SEVERITY_NUMBER_TRACE"),
     2: .same(proto: "SEVERITY_NUMBER_TRACE2"),
@@ -449,19 +449,19 @@ extension Opentelemetry_Proto_Logs_V1_SeverityNumber: SwiftProtobuf._ProtoNamePr
 }
 
 extension Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "LOG_RECORD_FLAGS_DO_NOT_USE"),
     255: .same(proto: "LOG_RECORD_FLAGS_TRACE_FLAGS_MASK"),
   ]
 }
 
 extension Opentelemetry_Proto_Logs_V1_LogsData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".LogsData"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".LogsData"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "resource_logs"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -473,14 +473,14 @@ extension Opentelemetry_Proto_Logs_V1_LogsData: SwiftProtobuf.Message, SwiftProt
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.resourceLogs.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.resourceLogs, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Logs_V1_LogsData, rhs: Opentelemetry_Proto_Logs_V1_LogsData) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Logs_V1_LogsData, rhs: Opentelemetry_Proto_Logs_V1_LogsData) -> Bool {
     if lhs.resourceLogs != rhs.resourceLogs {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -488,14 +488,14 @@ extension Opentelemetry_Proto_Logs_V1_LogsData: SwiftProtobuf.Message, SwiftProt
 }
 
 extension Opentelemetry_Proto_Logs_V1_ResourceLogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".ResourceLogs"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".ResourceLogs"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "resource"),
     2: .standard(proto: "scope_logs"),
     3: .standard(proto: "schema_url"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -509,7 +509,7 @@ extension Opentelemetry_Proto_Logs_V1_ResourceLogs: SwiftProtobuf.Message, Swift
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -526,7 +526,7 @@ extension Opentelemetry_Proto_Logs_V1_ResourceLogs: SwiftProtobuf.Message, Swift
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Logs_V1_ResourceLogs, rhs: Opentelemetry_Proto_Logs_V1_ResourceLogs) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Logs_V1_ResourceLogs, rhs: Opentelemetry_Proto_Logs_V1_ResourceLogs) -> Bool {
     if lhs._resource != rhs._resource {return false}
     if lhs.scopeLogs != rhs.scopeLogs {return false}
     if lhs.schemaURL != rhs.schemaURL {return false}
@@ -536,14 +536,14 @@ extension Opentelemetry_Proto_Logs_V1_ResourceLogs: SwiftProtobuf.Message, Swift
 }
 
 extension Opentelemetry_Proto_Logs_V1_ScopeLogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".ScopeLogs"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".ScopeLogs"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "scope"),
     2: .standard(proto: "log_records"),
     3: .standard(proto: "schema_url"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -557,7 +557,7 @@ extension Opentelemetry_Proto_Logs_V1_ScopeLogs: SwiftProtobuf.Message, SwiftPro
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -574,7 +574,7 @@ extension Opentelemetry_Proto_Logs_V1_ScopeLogs: SwiftProtobuf.Message, SwiftPro
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Logs_V1_ScopeLogs, rhs: Opentelemetry_Proto_Logs_V1_ScopeLogs) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Logs_V1_ScopeLogs, rhs: Opentelemetry_Proto_Logs_V1_ScopeLogs) -> Bool {
     if lhs._scope != rhs._scope {return false}
     if lhs.logRecords != rhs.logRecords {return false}
     if lhs.schemaURL != rhs.schemaURL {return false}
@@ -584,8 +584,8 @@ extension Opentelemetry_Proto_Logs_V1_ScopeLogs: SwiftProtobuf.Message, SwiftPro
 }
 
 extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".LogRecord"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".LogRecord"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "time_unix_nano"),
     11: .standard(proto: "observed_time_unix_nano"),
     2: .standard(proto: "severity_number"),
@@ -598,7 +598,7 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
     10: .standard(proto: "span_id"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -619,7 +619,7 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -657,7 +657,7 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftPro
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Logs_V1_LogRecord, rhs: Opentelemetry_Proto_Logs_V1_LogRecord) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Logs_V1_LogRecord, rhs: Opentelemetry_Proto_Logs_V1_LogRecord) -> Bool {
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
     if lhs.observedTimeUnixNano != rhs.observedTimeUnixNano {return false}
     if lhs.severityNumber != rhs.severityNumber {return false}

--- a/Sources/OTLPCore/Generated/opentelemetry/proto/metrics/v1/metrics.pb.swift
+++ b/Sources/OTLPCore/Generated/opentelemetry/proto/metrics/v1/metrics.pb.swift
@@ -37,8 +37,8 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// AggregationTemporality defines how a metric aggregator reports aggregated
 /// values. It describes how those values relate to the time interval over
 /// which they are aggregated.
-public enum Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf.Enum {
-  public typealias RawValue = Int
+package enum Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf.Enum {
+  package typealias RawValue = Int
 
   /// UNSPECIFIED is the default AggregationTemporality, it MUST not be used.
   case unspecified // = 0
@@ -107,11 +107,11 @@ public enum Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf
   case cumulative // = 2
   case UNRECOGNIZED(Int)
 
-  public init() {
+  package init() {
     self = .unspecified
   }
 
-  public init?(rawValue: Int) {
+  package init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .unspecified
     case 1: self = .delta
@@ -120,7 +120,7 @@ public enum Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf
     }
   }
 
-  public var rawValue: Int {
+  package var rawValue: Int {
     switch self {
     case .unspecified: return 0
     case .delta: return 1
@@ -135,7 +135,7 @@ public enum Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf
 
 extension Opentelemetry_Proto_Metrics_V1_AggregationTemporality: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Opentelemetry_Proto_Metrics_V1_AggregationTemporality] = [
+  package static let allCases: [Opentelemetry_Proto_Metrics_V1_AggregationTemporality] = [
     .unspecified,
     .delta,
     .cumulative,
@@ -150,8 +150,8 @@ extension Opentelemetry_Proto_Metrics_V1_AggregationTemporality: CaseIterable {
 /// a data point, for example, use an expression like:
 ///
 ///   (point.flags & DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK) == DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK
-public enum Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf.Enum {
-  public typealias RawValue = Int
+package enum Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf.Enum {
+  package typealias RawValue = Int
 
   /// The zero value for the enum. Should not be used for comparisons.
   /// Instead use bitwise "and" with the appropriate mask as shown above.
@@ -163,11 +163,11 @@ public enum Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf.Enum {
   case noRecordedValueMask // = 1
   case UNRECOGNIZED(Int)
 
-  public init() {
+  package init() {
     self = .doNotUse
   }
 
-  public init?(rawValue: Int) {
+  package init?(rawValue: Int) {
     switch rawValue {
     case 0: self = .doNotUse
     case 1: self = .noRecordedValueMask
@@ -175,7 +175,7 @@ public enum Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf.Enum {
     }
   }
 
-  public var rawValue: Int {
+  package var rawValue: Int {
     switch self {
     case .doNotUse: return 0
     case .noRecordedValueMask: return 1
@@ -189,7 +189,7 @@ public enum Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf.Enum {
 
 extension Opentelemetry_Proto_Metrics_V1_DataPointFlags: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Opentelemetry_Proto_Metrics_V1_DataPointFlags] = [
+  package static let allCases: [Opentelemetry_Proto_Metrics_V1_DataPointFlags] = [
     .doNotUse,
     .noRecordedValueMask,
   ]
@@ -207,7 +207,7 @@ extension Opentelemetry_Proto_Metrics_V1_DataPointFlags: CaseIterable {
 ///
 /// When new fields are added into this message, the OTLP request MUST be updated
 /// as well.
-public struct Opentelemetry_Proto_Metrics_V1_MetricsData {
+package struct Opentelemetry_Proto_Metrics_V1_MetricsData {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -217,46 +217,46 @@ public struct Opentelemetry_Proto_Metrics_V1_MetricsData {
   /// one element. Intermediary nodes that receive data from multiple origins
   /// typically batch the data before forwarding further and in that case this
   /// array will contain multiple elements.
-  public var resourceMetrics: [Opentelemetry_Proto_Metrics_V1_ResourceMetrics] = []
+  package var resourceMetrics: [Opentelemetry_Proto_Metrics_V1_ResourceMetrics] = []
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 }
 
 /// A collection of ScopeMetrics from a Resource.
-public struct Opentelemetry_Proto_Metrics_V1_ResourceMetrics {
+package struct Opentelemetry_Proto_Metrics_V1_ResourceMetrics {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The resource for the metrics in this message.
   /// If this field is not set then no resource info is known.
-  public var resource: Opentelemetry_Proto_Resource_V1_Resource {
+  package var resource: Opentelemetry_Proto_Resource_V1_Resource {
     get {return _resource ?? Opentelemetry_Proto_Resource_V1_Resource()}
     set {_resource = newValue}
   }
   /// Returns true if `resource` has been explicitly set.
-  public var hasResource: Bool {return self._resource != nil}
+  package var hasResource: Bool {return self._resource != nil}
   /// Clears the value of `resource`. Subsequent reads from it will return its default value.
-  public mutating func clearResource() {self._resource = nil}
+  package mutating func clearResource() {self._resource = nil}
 
   /// A list of metrics that originate from a resource.
-  public var scopeMetrics: [Opentelemetry_Proto_Metrics_V1_ScopeMetrics] = []
+  package var scopeMetrics: [Opentelemetry_Proto_Metrics_V1_ScopeMetrics] = []
 
   /// This schema_url applies to the data in the "resource" field. It does not apply
   /// to the data in the "scope_metrics" field which have their own schema_url field.
-  public var schemaURL: String = String()
+  package var schemaURL: String = String()
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 
   fileprivate var _resource: Opentelemetry_Proto_Resource_V1_Resource? = nil
 }
 
 /// A collection of Metrics produced by an Scope.
-public struct Opentelemetry_Proto_Metrics_V1_ScopeMetrics {
+package struct Opentelemetry_Proto_Metrics_V1_ScopeMetrics {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -264,24 +264,24 @@ public struct Opentelemetry_Proto_Metrics_V1_ScopeMetrics {
   /// The instrumentation scope information for the metrics in this message.
   /// Semantically when InstrumentationScope isn't set, it is equivalent with
   /// an empty instrumentation scope name (unknown).
-  public var scope: Opentelemetry_Proto_Common_V1_InstrumentationScope {
+  package var scope: Opentelemetry_Proto_Common_V1_InstrumentationScope {
     get {return _scope ?? Opentelemetry_Proto_Common_V1_InstrumentationScope()}
     set {_scope = newValue}
   }
   /// Returns true if `scope` has been explicitly set.
-  public var hasScope: Bool {return self._scope != nil}
+  package var hasScope: Bool {return self._scope != nil}
   /// Clears the value of `scope`. Subsequent reads from it will return its default value.
-  public mutating func clearScope() {self._scope = nil}
+  package mutating func clearScope() {self._scope = nil}
 
   /// A list of metrics that originate from an instrumentation library.
-  public var metrics: [Opentelemetry_Proto_Metrics_V1_Metric] = []
+  package var metrics: [Opentelemetry_Proto_Metrics_V1_Metric] = []
 
   /// This schema_url applies to all metrics in the "metrics" field.
-  public var schemaURL: String = String()
+  package var schemaURL: String = String()
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 
   fileprivate var _scope: Opentelemetry_Proto_Common_V1_InstrumentationScope? = nil
 }
@@ -371,27 +371,27 @@ public struct Opentelemetry_Proto_Metrics_V1_ScopeMetrics {
 /// to support correct rate calculation.  Although it may be omitted
 /// when the start time is truly unknown, setting StartTimeUnixNano is
 /// strongly encouraged.
-public struct Opentelemetry_Proto_Metrics_V1_Metric {
+package struct Opentelemetry_Proto_Metrics_V1_Metric {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// name of the metric, including its DNS name prefix. It must be unique.
-  public var name: String = String()
+  package var name: String = String()
 
   /// description of the metric, which can be used in documentation.
-  public var description_p: String = String()
+  package var description_p: String = String()
 
   /// unit in which the metric value is reported. Follows the format
   /// described by http://unitsofmeasure.org/ucum.html.
-  public var unit: String = String()
+  package var unit: String = String()
 
   /// Data determines the aggregation type (if any) of the metric, what is the
   /// reported value type for the data points, as well as the relatationship to
   /// the time interval over which they are reported.
-  public var data: Opentelemetry_Proto_Metrics_V1_Metric.OneOf_Data? = nil
+  package var data: Opentelemetry_Proto_Metrics_V1_Metric.OneOf_Data? = nil
 
-  public var gauge: Opentelemetry_Proto_Metrics_V1_Gauge {
+  package var gauge: Opentelemetry_Proto_Metrics_V1_Gauge {
     get {
       if case .gauge(let v)? = data {return v}
       return Opentelemetry_Proto_Metrics_V1_Gauge()
@@ -399,7 +399,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric {
     set {data = .gauge(newValue)}
   }
 
-  public var sum: Opentelemetry_Proto_Metrics_V1_Sum {
+  package var sum: Opentelemetry_Proto_Metrics_V1_Sum {
     get {
       if case .sum(let v)? = data {return v}
       return Opentelemetry_Proto_Metrics_V1_Sum()
@@ -407,7 +407,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric {
     set {data = .sum(newValue)}
   }
 
-  public var histogram: Opentelemetry_Proto_Metrics_V1_Histogram {
+  package var histogram: Opentelemetry_Proto_Metrics_V1_Histogram {
     get {
       if case .histogram(let v)? = data {return v}
       return Opentelemetry_Proto_Metrics_V1_Histogram()
@@ -415,7 +415,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric {
     set {data = .histogram(newValue)}
   }
 
-  public var exponentialHistogram: Opentelemetry_Proto_Metrics_V1_ExponentialHistogram {
+  package var exponentialHistogram: Opentelemetry_Proto_Metrics_V1_ExponentialHistogram {
     get {
       if case .exponentialHistogram(let v)? = data {return v}
       return Opentelemetry_Proto_Metrics_V1_ExponentialHistogram()
@@ -423,7 +423,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric {
     set {data = .exponentialHistogram(newValue)}
   }
 
-  public var summary: Opentelemetry_Proto_Metrics_V1_Summary {
+  package var summary: Opentelemetry_Proto_Metrics_V1_Summary {
     get {
       if case .summary(let v)? = data {return v}
       return Opentelemetry_Proto_Metrics_V1_Summary()
@@ -431,12 +431,12 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric {
     set {data = .summary(newValue)}
   }
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Data determines the aggregation type (if any) of the metric, what is the
   /// reported value type for the data points, as well as the relatationship to
   /// the time interval over which they are reported.
-  public enum OneOf_Data: Equatable {
+  package enum OneOf_Data: Equatable {
     case gauge(Opentelemetry_Proto_Metrics_V1_Gauge)
     case sum(Opentelemetry_Proto_Metrics_V1_Sum)
     case histogram(Opentelemetry_Proto_Metrics_V1_Histogram)
@@ -444,7 +444,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric {
     case summary(Opentelemetry_Proto_Metrics_V1_Summary)
 
   #if !swift(>=4.1)
-    public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Metric.OneOf_Data, rhs: Opentelemetry_Proto_Metrics_V1_Metric.OneOf_Data) -> Bool {
+    package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Metric.OneOf_Data, rhs: Opentelemetry_Proto_Metrics_V1_Metric.OneOf_Data) -> Bool {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
@@ -475,7 +475,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric {
   #endif
   }
 
-  public init() {}
+  package init() {}
 }
 
 /// Gauge represents the type of a scalar metric that always exports the
@@ -487,73 +487,73 @@ public struct Opentelemetry_Proto_Metrics_V1_Metric {
 /// aggregation, regardless of aggregation temporalities. Therefore,
 /// AggregationTemporality is not included. Consequently, this also means
 /// "StartTimeUnixNano" is ignored for all data points.
-public struct Opentelemetry_Proto_Metrics_V1_Gauge {
+package struct Opentelemetry_Proto_Metrics_V1_Gauge {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_NumberDataPoint] = []
+  package var dataPoints: [Opentelemetry_Proto_Metrics_V1_NumberDataPoint] = []
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 }
 
 /// Sum represents the type of a scalar metric that is calculated as a sum of all
 /// reported measurements over a time interval.
-public struct Opentelemetry_Proto_Metrics_V1_Sum {
+package struct Opentelemetry_Proto_Metrics_V1_Sum {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_NumberDataPoint] = []
+  package var dataPoints: [Opentelemetry_Proto_Metrics_V1_NumberDataPoint] = []
 
   /// aggregation_temporality describes if the aggregator reports delta changes
   /// since last report time, or cumulative changes since a fixed start time.
-  public var aggregationTemporality: Opentelemetry_Proto_Metrics_V1_AggregationTemporality = .unspecified
+  package var aggregationTemporality: Opentelemetry_Proto_Metrics_V1_AggregationTemporality = .unspecified
 
   /// If "true" means that the sum is monotonic.
-  public var isMonotonic: Bool = false
+  package var isMonotonic: Bool = false
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 }
 
 /// Histogram represents the type of a metric that is calculated by aggregating
 /// as a Histogram of all reported measurements over a time interval.
-public struct Opentelemetry_Proto_Metrics_V1_Histogram {
+package struct Opentelemetry_Proto_Metrics_V1_Histogram {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_HistogramDataPoint] = []
+  package var dataPoints: [Opentelemetry_Proto_Metrics_V1_HistogramDataPoint] = []
 
   /// aggregation_temporality describes if the aggregator reports delta changes
   /// since last report time, or cumulative changes since a fixed start time.
-  public var aggregationTemporality: Opentelemetry_Proto_Metrics_V1_AggregationTemporality = .unspecified
+  package var aggregationTemporality: Opentelemetry_Proto_Metrics_V1_AggregationTemporality = .unspecified
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 }
 
 /// ExponentialHistogram represents the type of a metric that is calculated by aggregating
 /// as a ExponentialHistogram of all reported double measurements over a time interval.
-public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogram {
+package struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogram {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint] = []
+  package var dataPoints: [Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint] = []
 
   /// aggregation_temporality describes if the aggregator reports delta changes
   /// since last report time, or cumulative changes since a fixed start time.
-  public var aggregationTemporality: Opentelemetry_Proto_Metrics_V1_AggregationTemporality = .unspecified
+  package var aggregationTemporality: Opentelemetry_Proto_Metrics_V1_AggregationTemporality = .unspecified
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 }
 
 /// Summary metric data are used to convey quantile summaries,
@@ -562,21 +562,21 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogram {
 /// data type. These data points cannot always be merged in a meaningful way.
 /// While they can be useful in some applications, histogram data points are
 /// recommended for new applications.
-public struct Opentelemetry_Proto_Metrics_V1_Summary {
+package struct Opentelemetry_Proto_Metrics_V1_Summary {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  public var dataPoints: [Opentelemetry_Proto_Metrics_V1_SummaryDataPoint] = []
+  package var dataPoints: [Opentelemetry_Proto_Metrics_V1_SummaryDataPoint] = []
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 }
 
 /// NumberDataPoint is a single data point in a timeseries that describes the
 /// time-varying scalar value of a metric.
-public struct Opentelemetry_Proto_Metrics_V1_NumberDataPoint {
+package struct Opentelemetry_Proto_Metrics_V1_NumberDataPoint {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -585,26 +585,26 @@ public struct Opentelemetry_Proto_Metrics_V1_NumberDataPoint {
   /// where this point belongs. The list may be empty (may contain 0 elements).
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
-  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
+  package var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   /// StartTimeUnixNano is optional but strongly encouraged, see the
   /// the detailed comments above Metric.
   ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
-  public var startTimeUnixNano: UInt64 = 0
+  package var startTimeUnixNano: UInt64 = 0
 
   /// TimeUnixNano is required, see the detailed comments above Metric.
   ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
-  public var timeUnixNano: UInt64 = 0
+  package var timeUnixNano: UInt64 = 0
 
   /// The value itself.  A point is considered invalid when one of the recognized
   /// value fields is not present inside this oneof.
-  public var value: Opentelemetry_Proto_Metrics_V1_NumberDataPoint.OneOf_Value? = nil
+  package var value: Opentelemetry_Proto_Metrics_V1_NumberDataPoint.OneOf_Value? = nil
 
-  public var asDouble: Double {
+  package var asDouble: Double {
     get {
       if case .asDouble(let v)? = value {return v}
       return 0
@@ -612,7 +612,7 @@ public struct Opentelemetry_Proto_Metrics_V1_NumberDataPoint {
     set {value = .asDouble(newValue)}
   }
 
-  public var asInt: Int64 {
+  package var asInt: Int64 {
     get {
       if case .asInt(let v)? = value {return v}
       return 0
@@ -622,22 +622,22 @@ public struct Opentelemetry_Proto_Metrics_V1_NumberDataPoint {
 
   /// (Optional) List of exemplars collected from
   /// measurements that were used to form the data point
-  public var exemplars: [Opentelemetry_Proto_Metrics_V1_Exemplar] = []
+  package var exemplars: [Opentelemetry_Proto_Metrics_V1_Exemplar] = []
 
   /// Flags that apply to this specific data point.  See DataPointFlags
   /// for the available flags and their meaning.
-  public var flags: UInt32 = 0
+  package var flags: UInt32 = 0
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The value itself.  A point is considered invalid when one of the recognized
   /// value fields is not present inside this oneof.
-  public enum OneOf_Value: Equatable {
+  package enum OneOf_Value: Equatable {
     case asDouble(Double)
     case asInt(Int64)
 
   #if !swift(>=4.1)
-    public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_NumberDataPoint.OneOf_Value, rhs: Opentelemetry_Proto_Metrics_V1_NumberDataPoint.OneOf_Value) -> Bool {
+    package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_NumberDataPoint.OneOf_Value, rhs: Opentelemetry_Proto_Metrics_V1_NumberDataPoint.OneOf_Value) -> Bool {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
@@ -656,7 +656,7 @@ public struct Opentelemetry_Proto_Metrics_V1_NumberDataPoint {
   #endif
   }
 
-  public init() {}
+  package init() {}
 }
 
 /// HistogramDataPoint is a single data point in a timeseries that describes the
@@ -669,7 +669,7 @@ public struct Opentelemetry_Proto_Metrics_V1_NumberDataPoint {
 /// If the histogram does not contain the distribution of values, then both
 /// "explicit_bounds" and "bucket_counts" must be omitted and only "count" and
 /// "sum" are known.
-public struct Opentelemetry_Proto_Metrics_V1_HistogramDataPoint {
+package struct Opentelemetry_Proto_Metrics_V1_HistogramDataPoint {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -678,25 +678,25 @@ public struct Opentelemetry_Proto_Metrics_V1_HistogramDataPoint {
   /// where this point belongs. The list may be empty (may contain 0 elements).
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
-  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
+  package var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   /// StartTimeUnixNano is optional but strongly encouraged, see the
   /// the detailed comments above Metric.
   ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
-  public var startTimeUnixNano: UInt64 = 0
+  package var startTimeUnixNano: UInt64 = 0
 
   /// TimeUnixNano is required, see the detailed comments above Metric.
   ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
-  public var timeUnixNano: UInt64 = 0
+  package var timeUnixNano: UInt64 = 0
 
   /// count is the number of values in the population. Must be non-negative. This
   /// value must be equal to the sum of the "count" fields in buckets if a
   /// histogram is provided.
-  public var count: UInt64 = 0
+  package var count: UInt64 = 0
 
   /// sum of the values in the population. If count is zero then this field
   /// must be zero.
@@ -706,14 +706,14 @@ public struct Opentelemetry_Proto_Metrics_V1_HistogramDataPoint {
   /// Negative events *can* be recorded, but sum should not be filled out when
   /// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
   /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
-  public var sum: Double {
+  package var sum: Double {
     get {return _sum ?? 0}
     set {_sum = newValue}
   }
   /// Returns true if `sum` has been explicitly set.
-  public var hasSum: Bool {return self._sum != nil}
+  package var hasSum: Bool {return self._sum != nil}
   /// Clears the value of `sum`. Subsequent reads from it will return its default value.
-  public mutating func clearSum() {self._sum = nil}
+  package mutating func clearSum() {self._sum = nil}
 
   /// bucket_counts is an optional field contains the count values of histogram
   /// for each bucket.
@@ -722,7 +722,7 @@ public struct Opentelemetry_Proto_Metrics_V1_HistogramDataPoint {
   ///
   /// The number of elements in bucket_counts array must be by one greater than
   /// the number of elements in explicit_bounds array.
-  public var bucketCounts: [UInt64] = []
+  package var bucketCounts: [UInt64] = []
 
   /// explicit_bounds specifies buckets with explicitly defined bounds for values.
   ///
@@ -737,39 +737,39 @@ public struct Opentelemetry_Proto_Metrics_V1_HistogramDataPoint {
   /// Histogram buckets are inclusive of their upper boundary, except the last
   /// bucket where the boundary is at infinity. This format is intentionally
   /// compatible with the OpenMetrics histogram definition.
-  public var explicitBounds: [Double] = []
+  package var explicitBounds: [Double] = []
 
   /// (Optional) List of exemplars collected from
   /// measurements that were used to form the data point
-  public var exemplars: [Opentelemetry_Proto_Metrics_V1_Exemplar] = []
+  package var exemplars: [Opentelemetry_Proto_Metrics_V1_Exemplar] = []
 
   /// Flags that apply to this specific data point.  See DataPointFlags
   /// for the available flags and their meaning.
-  public var flags: UInt32 = 0
+  package var flags: UInt32 = 0
 
   /// min is the minimum value over (start_time, end_time].
-  public var min: Double {
+  package var min: Double {
     get {return _min ?? 0}
     set {_min = newValue}
   }
   /// Returns true if `min` has been explicitly set.
-  public var hasMin: Bool {return self._min != nil}
+  package var hasMin: Bool {return self._min != nil}
   /// Clears the value of `min`. Subsequent reads from it will return its default value.
-  public mutating func clearMin() {self._min = nil}
+  package mutating func clearMin() {self._min = nil}
 
   /// max is the maximum value over (start_time, end_time].
-  public var max: Double {
+  package var max: Double {
     get {return _max ?? 0}
     set {_max = newValue}
   }
   /// Returns true if `max` has been explicitly set.
-  public var hasMax: Bool {return self._max != nil}
+  package var hasMax: Bool {return self._max != nil}
   /// Clears the value of `max`. Subsequent reads from it will return its default value.
-  public mutating func clearMax() {self._max = nil}
+  package mutating func clearMax() {self._max = nil}
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 
   fileprivate var _sum: Double? = nil
   fileprivate var _min: Double? = nil
@@ -780,7 +780,7 @@ public struct Opentelemetry_Proto_Metrics_V1_HistogramDataPoint {
 /// time-varying values of a ExponentialHistogram of double values. A ExponentialHistogram contains
 /// summary statistics for a population of values, it may optionally contain the
 /// distribution of those values across a set of buckets.
-public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
+package struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -789,25 +789,25 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
   /// where this point belongs. The list may be empty (may contain 0 elements).
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
-  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
+  package var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   /// StartTimeUnixNano is optional but strongly encouraged, see the
   /// the detailed comments above Metric.
   ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
-  public var startTimeUnixNano: UInt64 = 0
+  package var startTimeUnixNano: UInt64 = 0
 
   /// TimeUnixNano is required, see the detailed comments above Metric.
   ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
-  public var timeUnixNano: UInt64 = 0
+  package var timeUnixNano: UInt64 = 0
 
   /// count is the number of values in the population. Must be
   /// non-negative. This value must be equal to the sum of the "bucket_counts"
   /// values in the positive and negative Buckets plus the "zero_count" field.
-  public var count: UInt64 = 0
+  package var count: UInt64 = 0
 
   /// sum of the values in the population. If count is zero then this field
   /// must be zero.
@@ -817,14 +817,14 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
   /// Negative events *can* be recorded, but sum should not be filled out when
   /// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
   /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#histogram
-  public var sum: Double {
+  package var sum: Double {
     get {return _sum ?? 0}
     set {_sum = newValue}
   }
   /// Returns true if `sum` has been explicitly set.
-  public var hasSum: Bool {return self._sum != nil}
+  package var hasSum: Bool {return self._sum != nil}
   /// Clears the value of `sum`. Subsequent reads from it will return its default value.
-  public mutating func clearSum() {self._sum = nil}
+  package mutating func clearSum() {self._sum = nil}
 
   /// scale describes the resolution of the histogram.  Boundaries are
   /// located at powers of the base, where:
@@ -841,7 +841,7 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
   ///
   /// scale is not restricted by the protocol, as the permissible
   /// values depend on the range of the data.
-  public var scale: Int32 = 0
+  package var scale: Int32 = 0
 
   /// zero_count is the count of values that are either exactly zero or
   /// within the region considered zero by the instrumentation at the
@@ -851,55 +851,55 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
   ///
   /// Implementations MAY consider the zero bucket to have probability
   /// mass equal to (zero_count / count).
-  public var zeroCount: UInt64 = 0
+  package var zeroCount: UInt64 = 0
 
   /// positive carries the positive range of exponential bucket counts.
-  public var positive: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets {
+  package var positive: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets {
     get {return _positive ?? Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets()}
     set {_positive = newValue}
   }
   /// Returns true if `positive` has been explicitly set.
-  public var hasPositive: Bool {return self._positive != nil}
+  package var hasPositive: Bool {return self._positive != nil}
   /// Clears the value of `positive`. Subsequent reads from it will return its default value.
-  public mutating func clearPositive() {self._positive = nil}
+  package mutating func clearPositive() {self._positive = nil}
 
   /// negative carries the negative range of exponential bucket counts.
-  public var negative: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets {
+  package var negative: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets {
     get {return _negative ?? Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets()}
     set {_negative = newValue}
   }
   /// Returns true if `negative` has been explicitly set.
-  public var hasNegative: Bool {return self._negative != nil}
+  package var hasNegative: Bool {return self._negative != nil}
   /// Clears the value of `negative`. Subsequent reads from it will return its default value.
-  public mutating func clearNegative() {self._negative = nil}
+  package mutating func clearNegative() {self._negative = nil}
 
   /// Flags that apply to this specific data point.  See DataPointFlags
   /// for the available flags and their meaning.
-  public var flags: UInt32 = 0
+  package var flags: UInt32 = 0
 
   /// (Optional) List of exemplars collected from
   /// measurements that were used to form the data point
-  public var exemplars: [Opentelemetry_Proto_Metrics_V1_Exemplar] = []
+  package var exemplars: [Opentelemetry_Proto_Metrics_V1_Exemplar] = []
 
   /// min is the minimum value over (start_time, end_time].
-  public var min: Double {
+  package var min: Double {
     get {return _min ?? 0}
     set {_min = newValue}
   }
   /// Returns true if `min` has been explicitly set.
-  public var hasMin: Bool {return self._min != nil}
+  package var hasMin: Bool {return self._min != nil}
   /// Clears the value of `min`. Subsequent reads from it will return its default value.
-  public mutating func clearMin() {self._min = nil}
+  package mutating func clearMin() {self._min = nil}
 
   /// max is the maximum value over (start_time, end_time].
-  public var max: Double {
+  package var max: Double {
     get {return _max ?? 0}
     set {_max = newValue}
   }
   /// Returns true if `max` has been explicitly set.
-  public var hasMax: Bool {return self._max != nil}
+  package var hasMax: Bool {return self._max != nil}
   /// Clears the value of `max`. Subsequent reads from it will return its default value.
-  public mutating func clearMax() {self._max = nil}
+  package mutating func clearMax() {self._max = nil}
 
   /// ZeroThreshold may be optionally set to convey the width of the zero
   /// region. Where the zero region is defined as the closed interval
@@ -907,13 +907,13 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
   /// When ZeroThreshold is 0, zero count bucket stores values that cannot be
   /// expressed using the standard exponential formula as well as values that
   /// have been rounded to zero.
-  public var zeroThreshold: Double = 0
+  package var zeroThreshold: Double = 0
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Buckets are a set of bucket counts, encoded in a contiguous array
   /// of counts.
-  public struct Buckets {
+  package struct Buckets {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -921,7 +921,7 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
     /// Offset is the bucket index of the first entry in the bucket_counts array.
     /// 
     /// Note: This uses a varint encoding as a simple form of compression.
-    public var offset: Int32 = 0
+    package var offset: Int32 = 0
 
     /// bucket_counts is an array of count values, where bucket_counts[i] carries
     /// the count of the bucket at index (offset+i). bucket_counts[i] is the count
@@ -932,14 +932,14 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
     /// fixed64.  This field is expected to have many buckets,
     /// especially zeros, so uint64 has been selected to ensure
     /// varint encoding.
-    public var bucketCounts: [UInt64] = []
+    package var bucketCounts: [UInt64] = []
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+    package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public init() {}
+    package init() {}
   }
 
-  public init() {}
+  package init() {}
 
   fileprivate var _sum: Double? = nil
   fileprivate var _positive: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets? = nil
@@ -950,7 +950,7 @@ public struct Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
 
 /// SummaryDataPoint is a single data point in a timeseries that describes the
 /// time-varying values of a Summary metric.
-public struct Opentelemetry_Proto_Metrics_V1_SummaryDataPoint {
+package struct Opentelemetry_Proto_Metrics_V1_SummaryDataPoint {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -959,23 +959,23 @@ public struct Opentelemetry_Proto_Metrics_V1_SummaryDataPoint {
   /// where this point belongs. The list may be empty (may contain 0 elements).
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
-  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
+  package var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   /// StartTimeUnixNano is optional but strongly encouraged, see the
   /// the detailed comments above Metric.
   ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
-  public var startTimeUnixNano: UInt64 = 0
+  package var startTimeUnixNano: UInt64 = 0
 
   /// TimeUnixNano is required, see the detailed comments above Metric.
   ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
-  public var timeUnixNano: UInt64 = 0
+  package var timeUnixNano: UInt64 = 0
 
   /// count is the number of values in the population. Must be non-negative.
-  public var count: UInt64 = 0
+  package var count: UInt64 = 0
 
   /// sum of the values in the population. If count is zero then this field
   /// must be zero.
@@ -985,17 +985,17 @@ public struct Opentelemetry_Proto_Metrics_V1_SummaryDataPoint {
   /// Negative events *can* be recorded, but sum should not be filled out when
   /// doing so.  This is specifically to enforce compatibility w/ OpenMetrics,
   /// see: https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#summary
-  public var sum: Double = 0
+  package var sum: Double = 0
 
   /// (Optional) list of values at different quantiles of the distribution calculated
   /// from the current snapshot. The quantiles must be strictly increasing.
-  public var quantileValues: [Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile] = []
+  package var quantileValues: [Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile] = []
 
   /// Flags that apply to this specific data point.  See DataPointFlags
   /// for the available flags and their meaning.
-  public var flags: UInt32 = 0
+  package var flags: UInt32 = 0
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// Represents the value at a given quantile of a distribution.
   ///
@@ -1005,33 +1005,33 @@ public struct Opentelemetry_Proto_Metrics_V1_SummaryDataPoint {
   ///
   /// See the following issue for more context:
   /// https://github.com/open-telemetry/opentelemetry-proto/issues/125
-  public struct ValueAtQuantile {
+  package struct ValueAtQuantile {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
 
     /// The quantile of a distribution. Must be in the interval
     /// [0.0, 1.0].
-    public var quantile: Double = 0
+    package var quantile: Double = 0
 
     /// The value at the given quantile of a distribution.
     ///
     /// Quantile values must NOT be negative.
-    public var value: Double = 0
+    package var value: Double = 0
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+    package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public init() {}
+    package init() {}
   }
 
-  public init() {}
+  package init() {}
 }
 
 /// A representation of an exemplar, which is a sample input measurement.
 /// Exemplars also hold information about the environment when the measurement
 /// was recorded, for example the span and trace ID of the active span when the
 /// exemplar was recorded.
-public struct Opentelemetry_Proto_Metrics_V1_Exemplar {
+package struct Opentelemetry_Proto_Metrics_V1_Exemplar {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1039,20 +1039,20 @@ public struct Opentelemetry_Proto_Metrics_V1_Exemplar {
   /// The set of key/value pairs that were filtered out by the aggregator, but
   /// recorded alongside the original measurement. Only key/value pairs that were
   /// filtered out by the aggregator should be included
-  public var filteredAttributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
+  package var filteredAttributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   /// time_unix_nano is the exact time when this exemplar was recorded
   ///
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January
   /// 1970.
-  public var timeUnixNano: UInt64 = 0
+  package var timeUnixNano: UInt64 = 0
 
   /// The value of the measurement that was recorded. An exemplar is
   /// considered invalid when one of the recognized value fields is not present
   /// inside this oneof.
-  public var value: Opentelemetry_Proto_Metrics_V1_Exemplar.OneOf_Value? = nil
+  package var value: Opentelemetry_Proto_Metrics_V1_Exemplar.OneOf_Value? = nil
 
-  public var asDouble: Double {
+  package var asDouble: Double {
     get {
       if case .asDouble(let v)? = value {return v}
       return 0
@@ -1060,7 +1060,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Exemplar {
     set {value = .asDouble(newValue)}
   }
 
-  public var asInt: Int64 {
+  package var asInt: Int64 {
     get {
       if case .asInt(let v)? = value {return v}
       return 0
@@ -1071,24 +1071,24 @@ public struct Opentelemetry_Proto_Metrics_V1_Exemplar {
   /// (Optional) Span ID of the exemplar trace.
   /// span_id may be missing if the measurement is not recorded inside a trace
   /// or if the trace is not sampled.
-  public var spanID: Data = Data()
+  package var spanID: Data = Data()
 
   /// (Optional) Trace ID of the exemplar trace.
   /// trace_id may be missing if the measurement is not recorded inside a trace
   /// or if the trace is not sampled.
-  public var traceID: Data = Data()
+  package var traceID: Data = Data()
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// The value of the measurement that was recorded. An exemplar is
   /// considered invalid when one of the recognized value fields is not present
   /// inside this oneof.
-  public enum OneOf_Value: Equatable {
+  package enum OneOf_Value: Equatable {
     case asDouble(Double)
     case asInt(Int64)
 
   #if !swift(>=4.1)
-    public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Exemplar.OneOf_Value, rhs: Opentelemetry_Proto_Metrics_V1_Exemplar.OneOf_Value) -> Bool {
+    package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Exemplar.OneOf_Value, rhs: Opentelemetry_Proto_Metrics_V1_Exemplar.OneOf_Value) -> Bool {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
       // enabled. https://github.com/apple/swift-protobuf/issues/1034
@@ -1107,7 +1107,7 @@ public struct Opentelemetry_Proto_Metrics_V1_Exemplar {
   #endif
   }
 
-  public init() {}
+  package init() {}
 }
 
 #if swift(>=5.5) && canImport(_Concurrency)
@@ -1139,7 +1139,7 @@ extension Opentelemetry_Proto_Metrics_V1_Exemplar.OneOf_Value: @unchecked Sendab
 fileprivate let _protobuf_package = "opentelemetry.proto.metrics.v1"
 
 extension Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "AGGREGATION_TEMPORALITY_UNSPECIFIED"),
     1: .same(proto: "AGGREGATION_TEMPORALITY_DELTA"),
     2: .same(proto: "AGGREGATION_TEMPORALITY_CUMULATIVE"),
@@ -1147,19 +1147,19 @@ extension Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf._
 }
 
 extension Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "DATA_POINT_FLAGS_DO_NOT_USE"),
     1: .same(proto: "DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK"),
   ]
 }
 
 extension Opentelemetry_Proto_Metrics_V1_MetricsData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".MetricsData"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".MetricsData"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "resource_metrics"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1171,14 +1171,14 @@ extension Opentelemetry_Proto_Metrics_V1_MetricsData: SwiftProtobuf.Message, Swi
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.resourceMetrics.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.resourceMetrics, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_MetricsData, rhs: Opentelemetry_Proto_Metrics_V1_MetricsData) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_MetricsData, rhs: Opentelemetry_Proto_Metrics_V1_MetricsData) -> Bool {
     if lhs.resourceMetrics != rhs.resourceMetrics {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -1186,14 +1186,14 @@ extension Opentelemetry_Proto_Metrics_V1_MetricsData: SwiftProtobuf.Message, Swi
 }
 
 extension Opentelemetry_Proto_Metrics_V1_ResourceMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".ResourceMetrics"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".ResourceMetrics"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "resource"),
     2: .standard(proto: "scope_metrics"),
     3: .standard(proto: "schema_url"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1207,7 +1207,7 @@ extension Opentelemetry_Proto_Metrics_V1_ResourceMetrics: SwiftProtobuf.Message,
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -1224,7 +1224,7 @@ extension Opentelemetry_Proto_Metrics_V1_ResourceMetrics: SwiftProtobuf.Message,
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ResourceMetrics, rhs: Opentelemetry_Proto_Metrics_V1_ResourceMetrics) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ResourceMetrics, rhs: Opentelemetry_Proto_Metrics_V1_ResourceMetrics) -> Bool {
     if lhs._resource != rhs._resource {return false}
     if lhs.scopeMetrics != rhs.scopeMetrics {return false}
     if lhs.schemaURL != rhs.schemaURL {return false}
@@ -1234,14 +1234,14 @@ extension Opentelemetry_Proto_Metrics_V1_ResourceMetrics: SwiftProtobuf.Message,
 }
 
 extension Opentelemetry_Proto_Metrics_V1_ScopeMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".ScopeMetrics"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".ScopeMetrics"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "scope"),
     2: .same(proto: "metrics"),
     3: .standard(proto: "schema_url"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1255,7 +1255,7 @@ extension Opentelemetry_Proto_Metrics_V1_ScopeMetrics: SwiftProtobuf.Message, Sw
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -1272,7 +1272,7 @@ extension Opentelemetry_Proto_Metrics_V1_ScopeMetrics: SwiftProtobuf.Message, Sw
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ScopeMetrics, rhs: Opentelemetry_Proto_Metrics_V1_ScopeMetrics) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ScopeMetrics, rhs: Opentelemetry_Proto_Metrics_V1_ScopeMetrics) -> Bool {
     if lhs._scope != rhs._scope {return false}
     if lhs.metrics != rhs.metrics {return false}
     if lhs.schemaURL != rhs.schemaURL {return false}
@@ -1282,8 +1282,8 @@ extension Opentelemetry_Proto_Metrics_V1_ScopeMetrics: SwiftProtobuf.Message, Sw
 }
 
 extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".Metric"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".Metric"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "name"),
     2: .same(proto: "description"),
     3: .same(proto: "unit"),
@@ -1294,7 +1294,7 @@ extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftPro
     11: .same(proto: "summary"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1373,7 +1373,7 @@ extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftPro
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -1413,7 +1413,7 @@ extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftPro
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Metric, rhs: Opentelemetry_Proto_Metrics_V1_Metric) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Metric, rhs: Opentelemetry_Proto_Metrics_V1_Metric) -> Bool {
     if lhs.name != rhs.name {return false}
     if lhs.description_p != rhs.description_p {return false}
     if lhs.unit != rhs.unit {return false}
@@ -1424,12 +1424,12 @@ extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftPro
 }
 
 extension Opentelemetry_Proto_Metrics_V1_Gauge: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".Gauge"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".Gauge"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "data_points"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1441,14 +1441,14 @@ extension Opentelemetry_Proto_Metrics_V1_Gauge: SwiftProtobuf.Message, SwiftProt
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.dataPoints.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.dataPoints, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Gauge, rhs: Opentelemetry_Proto_Metrics_V1_Gauge) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Gauge, rhs: Opentelemetry_Proto_Metrics_V1_Gauge) -> Bool {
     if lhs.dataPoints != rhs.dataPoints {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -1456,14 +1456,14 @@ extension Opentelemetry_Proto_Metrics_V1_Gauge: SwiftProtobuf.Message, SwiftProt
 }
 
 extension Opentelemetry_Proto_Metrics_V1_Sum: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".Sum"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".Sum"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "data_points"),
     2: .standard(proto: "aggregation_temporality"),
     3: .standard(proto: "is_monotonic"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1477,7 +1477,7 @@ extension Opentelemetry_Proto_Metrics_V1_Sum: SwiftProtobuf.Message, SwiftProtob
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.dataPoints.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.dataPoints, fieldNumber: 1)
     }
@@ -1490,7 +1490,7 @@ extension Opentelemetry_Proto_Metrics_V1_Sum: SwiftProtobuf.Message, SwiftProtob
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Sum, rhs: Opentelemetry_Proto_Metrics_V1_Sum) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Sum, rhs: Opentelemetry_Proto_Metrics_V1_Sum) -> Bool {
     if lhs.dataPoints != rhs.dataPoints {return false}
     if lhs.aggregationTemporality != rhs.aggregationTemporality {return false}
     if lhs.isMonotonic != rhs.isMonotonic {return false}
@@ -1500,13 +1500,13 @@ extension Opentelemetry_Proto_Metrics_V1_Sum: SwiftProtobuf.Message, SwiftProtob
 }
 
 extension Opentelemetry_Proto_Metrics_V1_Histogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".Histogram"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".Histogram"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "data_points"),
     2: .standard(proto: "aggregation_temporality"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1519,7 +1519,7 @@ extension Opentelemetry_Proto_Metrics_V1_Histogram: SwiftProtobuf.Message, Swift
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.dataPoints.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.dataPoints, fieldNumber: 1)
     }
@@ -1529,7 +1529,7 @@ extension Opentelemetry_Proto_Metrics_V1_Histogram: SwiftProtobuf.Message, Swift
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Histogram, rhs: Opentelemetry_Proto_Metrics_V1_Histogram) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Histogram, rhs: Opentelemetry_Proto_Metrics_V1_Histogram) -> Bool {
     if lhs.dataPoints != rhs.dataPoints {return false}
     if lhs.aggregationTemporality != rhs.aggregationTemporality {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
@@ -1538,13 +1538,13 @@ extension Opentelemetry_Proto_Metrics_V1_Histogram: SwiftProtobuf.Message, Swift
 }
 
 extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".ExponentialHistogram"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".ExponentialHistogram"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "data_points"),
     2: .standard(proto: "aggregation_temporality"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1557,7 +1557,7 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: SwiftProtobuf.Mes
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.dataPoints.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.dataPoints, fieldNumber: 1)
     }
@@ -1567,7 +1567,7 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: SwiftProtobuf.Mes
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogram, rhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogram) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogram, rhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogram) -> Bool {
     if lhs.dataPoints != rhs.dataPoints {return false}
     if lhs.aggregationTemporality != rhs.aggregationTemporality {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
@@ -1576,12 +1576,12 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: SwiftProtobuf.Mes
 }
 
 extension Opentelemetry_Proto_Metrics_V1_Summary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".Summary"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".Summary"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "data_points"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1593,14 +1593,14 @@ extension Opentelemetry_Proto_Metrics_V1_Summary: SwiftProtobuf.Message, SwiftPr
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.dataPoints.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.dataPoints, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Summary, rhs: Opentelemetry_Proto_Metrics_V1_Summary) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Summary, rhs: Opentelemetry_Proto_Metrics_V1_Summary) -> Bool {
     if lhs.dataPoints != rhs.dataPoints {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -1608,8 +1608,8 @@ extension Opentelemetry_Proto_Metrics_V1_Summary: SwiftProtobuf.Message, SwiftPr
 }
 
 extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".NumberDataPoint"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".NumberDataPoint"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     7: .same(proto: "attributes"),
     2: .standard(proto: "start_time_unix_nano"),
     3: .standard(proto: "time_unix_nano"),
@@ -1619,7 +1619,7 @@ extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint: SwiftProtobuf.Message,
     8: .same(proto: "flags"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1651,7 +1651,7 @@ extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint: SwiftProtobuf.Message,
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -1680,7 +1680,7 @@ extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint: SwiftProtobuf.Message,
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_NumberDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_NumberDataPoint) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_NumberDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_NumberDataPoint) -> Bool {
     if lhs.attributes != rhs.attributes {return false}
     if lhs.startTimeUnixNano != rhs.startTimeUnixNano {return false}
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
@@ -1693,8 +1693,8 @@ extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint: SwiftProtobuf.Message,
 }
 
 extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".HistogramDataPoint"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".HistogramDataPoint"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     9: .same(proto: "attributes"),
     2: .standard(proto: "start_time_unix_nano"),
     3: .standard(proto: "time_unix_nano"),
@@ -1708,7 +1708,7 @@ extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Messa
     12: .same(proto: "max"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1730,7 +1730,7 @@ extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Messa
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -1771,7 +1771,7 @@ extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Messa
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_HistogramDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_HistogramDataPoint) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_HistogramDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_HistogramDataPoint) -> Bool {
     if lhs.attributes != rhs.attributes {return false}
     if lhs.startTimeUnixNano != rhs.startTimeUnixNano {return false}
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
@@ -1789,8 +1789,8 @@ extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Messa
 }
 
 extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".ExponentialHistogramDataPoint"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".ExponentialHistogramDataPoint"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "attributes"),
     2: .standard(proto: "start_time_unix_nano"),
     3: .standard(proto: "time_unix_nano"),
@@ -1807,7 +1807,7 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftPro
     14: .standard(proto: "zero_threshold"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1832,7 +1832,7 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftPro
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -1882,7 +1882,7 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftPro
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint) -> Bool {
     if lhs.attributes != rhs.attributes {return false}
     if lhs.startTimeUnixNano != rhs.startTimeUnixNano {return false}
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
@@ -1903,13 +1903,13 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftPro
 }
 
 extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.protoMessageName + ".Buckets"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.protoMessageName + ".Buckets"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "offset"),
     2: .standard(proto: "bucket_counts"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1922,7 +1922,7 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets: 
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if self.offset != 0 {
       try visitor.visitSingularSInt32Field(value: self.offset, fieldNumber: 1)
     }
@@ -1932,7 +1932,7 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets: 
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets, rhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets, rhs: Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets) -> Bool {
     if lhs.offset != rhs.offset {return false}
     if lhs.bucketCounts != rhs.bucketCounts {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
@@ -1941,8 +1941,8 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets: 
 }
 
 extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".SummaryDataPoint"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".SummaryDataPoint"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     7: .same(proto: "attributes"),
     2: .standard(proto: "start_time_unix_nano"),
     3: .standard(proto: "time_unix_nano"),
@@ -1952,7 +1952,7 @@ extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: SwiftProtobuf.Message
     8: .same(proto: "flags"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -1970,7 +1970,7 @@ extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: SwiftProtobuf.Message
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if self.startTimeUnixNano != 0 {
       try visitor.visitSingularFixed64Field(value: self.startTimeUnixNano, fieldNumber: 2)
     }
@@ -1995,7 +1995,7 @@ extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: SwiftProtobuf.Message
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_SummaryDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_SummaryDataPoint) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_SummaryDataPoint, rhs: Opentelemetry_Proto_Metrics_V1_SummaryDataPoint) -> Bool {
     if lhs.attributes != rhs.attributes {return false}
     if lhs.startTimeUnixNano != rhs.startTimeUnixNano {return false}
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
@@ -2009,13 +2009,13 @@ extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: SwiftProtobuf.Message
 }
 
 extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.protoMessageName + ".ValueAtQuantile"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.protoMessageName + ".ValueAtQuantile"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "quantile"),
     2: .same(proto: "value"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2028,7 +2028,7 @@ extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile: Swift
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if self.quantile != 0 {
       try visitor.visitSingularDoubleField(value: self.quantile, fieldNumber: 1)
     }
@@ -2038,7 +2038,7 @@ extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile: Swift
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile, rhs: Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile, rhs: Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile) -> Bool {
     if lhs.quantile != rhs.quantile {return false}
     if lhs.value != rhs.value {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
@@ -2047,8 +2047,8 @@ extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile: Swift
 }
 
 extension Opentelemetry_Proto_Metrics_V1_Exemplar: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".Exemplar"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".Exemplar"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     7: .standard(proto: "filtered_attributes"),
     2: .standard(proto: "time_unix_nano"),
     3: .standard(proto: "as_double"),
@@ -2057,7 +2057,7 @@ extension Opentelemetry_Proto_Metrics_V1_Exemplar: SwiftProtobuf.Message, SwiftP
     5: .standard(proto: "trace_id"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -2088,7 +2088,7 @@ extension Opentelemetry_Proto_Metrics_V1_Exemplar: SwiftProtobuf.Message, SwiftP
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -2114,7 +2114,7 @@ extension Opentelemetry_Proto_Metrics_V1_Exemplar: SwiftProtobuf.Message, SwiftP
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Exemplar, rhs: Opentelemetry_Proto_Metrics_V1_Exemplar) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Metrics_V1_Exemplar, rhs: Opentelemetry_Proto_Metrics_V1_Exemplar) -> Bool {
     if lhs.filteredAttributes != rhs.filteredAttributes {return false}
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
     if lhs.value != rhs.value {return false}

--- a/Sources/OTLPCore/Generated/opentelemetry/proto/resource/v1/resource.pb.swift
+++ b/Sources/OTLPCore/Generated/opentelemetry/proto/resource/v1/resource.pb.swift
@@ -35,7 +35,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 }
 
 /// Resource information.
-public struct Opentelemetry_Proto_Resource_V1_Resource {
+package struct Opentelemetry_Proto_Resource_V1_Resource {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -43,15 +43,15 @@ public struct Opentelemetry_Proto_Resource_V1_Resource {
   /// Set of attributes that describe the resource.
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
-  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
+  package var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   /// dropped_attributes_count is the number of dropped attributes. If the value is 0, then
   /// no attributes were dropped.
-  public var droppedAttributesCount: UInt32 = 0
+  package var droppedAttributesCount: UInt32 = 0
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 }
 
 #if swift(>=5.5) && canImport(_Concurrency)
@@ -63,13 +63,13 @@ extension Opentelemetry_Proto_Resource_V1_Resource: @unchecked Sendable {}
 fileprivate let _protobuf_package = "opentelemetry.proto.resource.v1"
 
 extension Opentelemetry_Proto_Resource_V1_Resource: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".Resource"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".Resource"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "attributes"),
     2: .standard(proto: "dropped_attributes_count"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -82,7 +82,7 @@ extension Opentelemetry_Proto_Resource_V1_Resource: SwiftProtobuf.Message, Swift
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.attributes.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.attributes, fieldNumber: 1)
     }
@@ -92,7 +92,7 @@ extension Opentelemetry_Proto_Resource_V1_Resource: SwiftProtobuf.Message, Swift
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Resource_V1_Resource, rhs: Opentelemetry_Proto_Resource_V1_Resource) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Resource_V1_Resource, rhs: Opentelemetry_Proto_Resource_V1_Resource) -> Bool {
     if lhs.attributes != rhs.attributes {return false}
     if lhs.droppedAttributesCount != rhs.droppedAttributesCount {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}

--- a/Sources/OTLPCore/Generated/opentelemetry/proto/trace/v1/trace.pb.swift
+++ b/Sources/OTLPCore/Generated/opentelemetry/proto/trace/v1/trace.pb.swift
@@ -44,7 +44,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 ///
 /// When new fields are added into this message, the OTLP request MUST be updated
 /// as well.
-public struct Opentelemetry_Proto_Trace_V1_TracesData {
+package struct Opentelemetry_Proto_Trace_V1_TracesData {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -54,46 +54,46 @@ public struct Opentelemetry_Proto_Trace_V1_TracesData {
   /// one element. Intermediary nodes that receive data from multiple origins
   /// typically batch the data before forwarding further and in that case this
   /// array will contain multiple elements.
-  public var resourceSpans: [Opentelemetry_Proto_Trace_V1_ResourceSpans] = []
+  package var resourceSpans: [Opentelemetry_Proto_Trace_V1_ResourceSpans] = []
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 }
 
 /// A collection of ScopeSpans from a Resource.
-public struct Opentelemetry_Proto_Trace_V1_ResourceSpans {
+package struct Opentelemetry_Proto_Trace_V1_ResourceSpans {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// The resource for the spans in this message.
   /// If this field is not set then no resource info is known.
-  public var resource: Opentelemetry_Proto_Resource_V1_Resource {
+  package var resource: Opentelemetry_Proto_Resource_V1_Resource {
     get {return _resource ?? Opentelemetry_Proto_Resource_V1_Resource()}
     set {_resource = newValue}
   }
   /// Returns true if `resource` has been explicitly set.
-  public var hasResource: Bool {return self._resource != nil}
+  package var hasResource: Bool {return self._resource != nil}
   /// Clears the value of `resource`. Subsequent reads from it will return its default value.
-  public mutating func clearResource() {self._resource = nil}
+  package mutating func clearResource() {self._resource = nil}
 
   /// A list of ScopeSpans that originate from a resource.
-  public var scopeSpans: [Opentelemetry_Proto_Trace_V1_ScopeSpans] = []
+  package var scopeSpans: [Opentelemetry_Proto_Trace_V1_ScopeSpans] = []
 
   /// This schema_url applies to the data in the "resource" field. It does not apply
   /// to the data in the "scope_spans" field which have their own schema_url field.
-  public var schemaURL: String = String()
+  package var schemaURL: String = String()
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 
   fileprivate var _resource: Opentelemetry_Proto_Resource_V1_Resource? = nil
 }
 
 /// A collection of Spans produced by an InstrumentationScope.
-public struct Opentelemetry_Proto_Trace_V1_ScopeSpans {
+package struct Opentelemetry_Proto_Trace_V1_ScopeSpans {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -101,24 +101,24 @@ public struct Opentelemetry_Proto_Trace_V1_ScopeSpans {
   /// The instrumentation scope information for the spans in this message.
   /// Semantically when InstrumentationScope isn't set, it is equivalent with
   /// an empty instrumentation scope name (unknown).
-  public var scope: Opentelemetry_Proto_Common_V1_InstrumentationScope {
+  package var scope: Opentelemetry_Proto_Common_V1_InstrumentationScope {
     get {return _scope ?? Opentelemetry_Proto_Common_V1_InstrumentationScope()}
     set {_scope = newValue}
   }
   /// Returns true if `scope` has been explicitly set.
-  public var hasScope: Bool {return self._scope != nil}
+  package var hasScope: Bool {return self._scope != nil}
   /// Clears the value of `scope`. Subsequent reads from it will return its default value.
-  public mutating func clearScope() {self._scope = nil}
+  package mutating func clearScope() {self._scope = nil}
 
   /// A list of Spans that originate from an instrumentation scope.
-  public var spans: [Opentelemetry_Proto_Trace_V1_Span] = []
+  package var spans: [Opentelemetry_Proto_Trace_V1_Span] = []
 
   /// This schema_url applies to all spans and span events in the "spans" field.
-  public var schemaURL: String = String()
+  package var schemaURL: String = String()
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-  public init() {}
+  package init() {}
 
   fileprivate var _scope: Opentelemetry_Proto_Common_V1_InstrumentationScope? = nil
 }
@@ -126,7 +126,7 @@ public struct Opentelemetry_Proto_Trace_V1_ScopeSpans {
 /// A Span represents a single operation performed by a single component of the system.
 ///
 /// The next available field id is 17.
-public struct Opentelemetry_Proto_Trace_V1_Span {
+package struct Opentelemetry_Proto_Trace_V1_Span {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -137,7 +137,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// is zero-length and thus is also invalid).
   ///
   /// This field is required.
-  public var traceID: Data = Data()
+  package var traceID: Data = Data()
 
   /// A unique identifier for a span within a trace, assigned when the span
   /// is created. The ID is an 8-byte array. An ID with all zeroes OR of length
@@ -145,16 +145,16 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// is zero-length and thus is also invalid).
   ///
   /// This field is required.
-  public var spanID: Data = Data()
+  package var spanID: Data = Data()
 
   /// trace_state conveys information about request position in multiple distributed tracing graphs.
   /// It is a trace_state in w3c-trace-context format: https://www.w3.org/TR/trace-context/#tracestate-header
   /// See also https://github.com/w3c/distributed-tracing for more details about this field.
-  public var traceState: String = String()
+  package var traceState: String = String()
 
   /// The `span_id` of this span's parent span. If this is a root span, then this
   /// field must be empty. The ID is an 8-byte array.
-  public var parentSpanID: Data = Data()
+  package var parentSpanID: Data = Data()
 
   /// A description of the span's operation.
   ///
@@ -167,12 +167,12 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// Empty value is equivalent to an unknown span name.
   ///
   /// This field is required.
-  public var name: String = String()
+  package var name: String = String()
 
   /// Distinguishes between spans generated in a particular context. For example,
   /// two spans with the same name may be distinguished using `CLIENT` (caller)
   /// and `SERVER` (callee) to identify queueing latency associated with the span.
-  public var kind: Opentelemetry_Proto_Trace_V1_Span.SpanKind = .unspecified
+  package var kind: Opentelemetry_Proto_Trace_V1_Span.SpanKind = .unspecified
 
   /// start_time_unix_nano is the start time of the span. On the client side, this is the time
   /// kept by the local machine where the span execution starts. On the server side, this
@@ -180,7 +180,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   ///
   /// This field is semantically required and it is expected that end_time >= start_time.
-  public var startTimeUnixNano: UInt64 = 0
+  package var startTimeUnixNano: UInt64 = 0
 
   /// end_time_unix_nano is the end time of the span. On the client side, this is the time
   /// kept by the local machine where the span execution ends. On the server side, this
@@ -188,7 +188,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// Value is UNIX Epoch time in nanoseconds since 00:00:00 UTC on 1 January 1970.
   ///
   /// This field is semantically required and it is expected that end_time >= start_time.
-  public var endTimeUnixNano: UInt64 = 0
+  package var endTimeUnixNano: UInt64 = 0
 
   /// attributes is a collection of key/value pairs. Note, global attributes
   /// like server name can be set using the resource API. Examples of attributes:
@@ -202,45 +202,45 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
   /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/common/README.md#attribute
   /// Attribute keys MUST be unique (it is not allowed to have more than one
   /// attribute with the same key).
-  public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
+  package var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
   /// dropped_attributes_count is the number of attributes that were discarded. Attributes
   /// can be discarded because their keys are too long or because there are too many
   /// attributes. If this value is 0, then no attributes were dropped.
-  public var droppedAttributesCount: UInt32 = 0
+  package var droppedAttributesCount: UInt32 = 0
 
   /// events is a collection of Event items.
-  public var events: [Opentelemetry_Proto_Trace_V1_Span.Event] = []
+  package var events: [Opentelemetry_Proto_Trace_V1_Span.Event] = []
 
   /// dropped_events_count is the number of dropped events. If the value is 0, then no
   /// events were dropped.
-  public var droppedEventsCount: UInt32 = 0
+  package var droppedEventsCount: UInt32 = 0
 
   /// links is a collection of Links, which are references from this span to a span
   /// in the same or different trace.
-  public var links: [Opentelemetry_Proto_Trace_V1_Span.Link] = []
+  package var links: [Opentelemetry_Proto_Trace_V1_Span.Link] = []
 
   /// dropped_links_count is the number of dropped links after the maximum size was
   /// enforced. If this value is 0, then no links were dropped.
-  public var droppedLinksCount: UInt32 = 0
+  package var droppedLinksCount: UInt32 = 0
 
   /// An optional final status for this span. Semantically when Status isn't set, it means
   /// span's status code is unset, i.e. assume STATUS_CODE_UNSET (code = 0).
-  public var status: Opentelemetry_Proto_Trace_V1_Status {
+  package var status: Opentelemetry_Proto_Trace_V1_Status {
     get {return _status ?? Opentelemetry_Proto_Trace_V1_Status()}
     set {_status = newValue}
   }
   /// Returns true if `status` has been explicitly set.
-  public var hasStatus: Bool {return self._status != nil}
+  package var hasStatus: Bool {return self._status != nil}
   /// Clears the value of `status`. Subsequent reads from it will return its default value.
-  public mutating func clearStatus() {self._status = nil}
+  package mutating func clearStatus() {self._status = nil}
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// SpanKind is the type of span. Can be used to specify additional relationships between spans
   /// in addition to a parent/child relationship.
-  public enum SpanKind: SwiftProtobuf.Enum {
-    public typealias RawValue = Int
+  package enum SpanKind: SwiftProtobuf.Enum {
+    package typealias RawValue = Int
 
     /// Unspecified. Do NOT use as default.
     /// Implementations MAY assume SpanKind to be INTERNAL when receiving UNSPECIFIED.
@@ -269,11 +269,11 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
     case consumer // = 5
     case UNRECOGNIZED(Int)
 
-    public init() {
+    package init() {
       self = .unspecified
     }
 
-    public init?(rawValue: Int) {
+    package init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .unspecified
       case 1: self = .internal
@@ -285,7 +285,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
       }
     }
 
-    public var rawValue: Int {
+    package var rawValue: Int {
       switch self {
       case .unspecified: return 0
       case .internal: return 1
@@ -301,66 +301,66 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
 
   /// Event is a time-stamped annotation of the span, consisting of user-supplied
   /// text description and key-value pairs.
-  public struct Event {
+  package struct Event {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
 
     /// time_unix_nano is the time the event occurred.
-    public var timeUnixNano: UInt64 = 0
+    package var timeUnixNano: UInt64 = 0
 
     /// name of the event.
     /// This field is semantically required to be set to non-empty string.
-    public var name: String = String()
+    package var name: String = String()
 
     /// attributes is a collection of attribute key/value pairs on the event.
     /// Attribute keys MUST be unique (it is not allowed to have more than one
     /// attribute with the same key).
-    public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
+    package var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
     /// dropped_attributes_count is the number of dropped attributes. If the value is 0,
     /// then no attributes were dropped.
-    public var droppedAttributesCount: UInt32 = 0
+    package var droppedAttributesCount: UInt32 = 0
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+    package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public init() {}
+    package init() {}
   }
 
   /// A pointer from the current span to another span in the same trace or in a
   /// different trace. For example, this can be used in batching operations,
   /// where a single batch handler processes multiple requests from different
   /// traces or when the handler receives a request from a different project.
-  public struct Link {
+  package struct Link {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
 
     /// A unique identifier of a trace that this linked span is part of. The ID is a
     /// 16-byte array.
-    public var traceID: Data = Data()
+    package var traceID: Data = Data()
 
     /// A unique identifier for the linked span. The ID is an 8-byte array.
-    public var spanID: Data = Data()
+    package var spanID: Data = Data()
 
     /// The trace_state associated with the link.
-    public var traceState: String = String()
+    package var traceState: String = String()
 
     /// attributes is a collection of attribute key/value pairs on the link.
     /// Attribute keys MUST be unique (it is not allowed to have more than one
     /// attribute with the same key).
-    public var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
+    package var attributes: [Opentelemetry_Proto_Common_V1_KeyValue] = []
 
     /// dropped_attributes_count is the number of dropped attributes. If the value is 0,
     /// then no attributes were dropped.
-    public var droppedAttributesCount: UInt32 = 0
+    package var droppedAttributesCount: UInt32 = 0
 
-    public var unknownFields = SwiftProtobuf.UnknownStorage()
+    package var unknownFields = SwiftProtobuf.UnknownStorage()
 
-    public init() {}
+    package init() {}
   }
 
-  public init() {}
+  package init() {}
 
   fileprivate var _status: Opentelemetry_Proto_Trace_V1_Status? = nil
 }
@@ -369,7 +369,7 @@ public struct Opentelemetry_Proto_Trace_V1_Span {
 
 extension Opentelemetry_Proto_Trace_V1_Span.SpanKind: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Opentelemetry_Proto_Trace_V1_Span.SpanKind] = [
+  package static let allCases: [Opentelemetry_Proto_Trace_V1_Span.SpanKind] = [
     .unspecified,
     .internal,
     .server,
@@ -383,23 +383,23 @@ extension Opentelemetry_Proto_Trace_V1_Span.SpanKind: CaseIterable {
 
 /// The Status type defines a logical error model that is suitable for different
 /// programming environments, including REST APIs and RPC APIs.
-public struct Opentelemetry_Proto_Trace_V1_Status {
+package struct Opentelemetry_Proto_Trace_V1_Status {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// A developer-facing human readable error message.
-  public var message: String = String()
+  package var message: String = String()
 
   /// The status code.
-  public var code: Opentelemetry_Proto_Trace_V1_Status.StatusCode = .unset
+  package var code: Opentelemetry_Proto_Trace_V1_Status.StatusCode = .unset
 
-  public var unknownFields = SwiftProtobuf.UnknownStorage()
+  package var unknownFields = SwiftProtobuf.UnknownStorage()
 
   /// For the semantics of status codes see
   /// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status
-  public enum StatusCode: SwiftProtobuf.Enum {
-    public typealias RawValue = Int
+  package enum StatusCode: SwiftProtobuf.Enum {
+    package typealias RawValue = Int
 
     /// The default status.
     case unset // = 0
@@ -412,11 +412,11 @@ public struct Opentelemetry_Proto_Trace_V1_Status {
     case error // = 2
     case UNRECOGNIZED(Int)
 
-    public init() {
+    package init() {
       self = .unset
     }
 
-    public init?(rawValue: Int) {
+    package init?(rawValue: Int) {
       switch rawValue {
       case 0: self = .unset
       case 1: self = .ok
@@ -425,7 +425,7 @@ public struct Opentelemetry_Proto_Trace_V1_Status {
       }
     }
 
-    public var rawValue: Int {
+    package var rawValue: Int {
       switch self {
       case .unset: return 0
       case .ok: return 1
@@ -436,14 +436,14 @@ public struct Opentelemetry_Proto_Trace_V1_Status {
 
   }
 
-  public init() {}
+  package init() {}
 }
 
 #if swift(>=4.2)
 
 extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: CaseIterable {
   // The compiler won't synthesize support with the UNRECOGNIZED case.
-  public static let allCases: [Opentelemetry_Proto_Trace_V1_Status.StatusCode] = [
+  package static let allCases: [Opentelemetry_Proto_Trace_V1_Status.StatusCode] = [
     .unset,
     .ok,
     .error,
@@ -469,12 +469,12 @@ extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: @unchecked Sendable {}
 fileprivate let _protobuf_package = "opentelemetry.proto.trace.v1"
 
 extension Opentelemetry_Proto_Trace_V1_TracesData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".TracesData"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".TracesData"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "resource_spans"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -486,14 +486,14 @@ extension Opentelemetry_Proto_Trace_V1_TracesData: SwiftProtobuf.Message, SwiftP
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.resourceSpans.isEmpty {
       try visitor.visitRepeatedMessageField(value: self.resourceSpans, fieldNumber: 1)
     }
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Trace_V1_TracesData, rhs: Opentelemetry_Proto_Trace_V1_TracesData) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Trace_V1_TracesData, rhs: Opentelemetry_Proto_Trace_V1_TracesData) -> Bool {
     if lhs.resourceSpans != rhs.resourceSpans {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
@@ -501,14 +501,14 @@ extension Opentelemetry_Proto_Trace_V1_TracesData: SwiftProtobuf.Message, SwiftP
 }
 
 extension Opentelemetry_Proto_Trace_V1_ResourceSpans: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".ResourceSpans"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".ResourceSpans"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "resource"),
     2: .standard(proto: "scope_spans"),
     3: .standard(proto: "schema_url"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -522,7 +522,7 @@ extension Opentelemetry_Proto_Trace_V1_ResourceSpans: SwiftProtobuf.Message, Swi
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -539,7 +539,7 @@ extension Opentelemetry_Proto_Trace_V1_ResourceSpans: SwiftProtobuf.Message, Swi
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Trace_V1_ResourceSpans, rhs: Opentelemetry_Proto_Trace_V1_ResourceSpans) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Trace_V1_ResourceSpans, rhs: Opentelemetry_Proto_Trace_V1_ResourceSpans) -> Bool {
     if lhs._resource != rhs._resource {return false}
     if lhs.scopeSpans != rhs.scopeSpans {return false}
     if lhs.schemaURL != rhs.schemaURL {return false}
@@ -549,14 +549,14 @@ extension Opentelemetry_Proto_Trace_V1_ResourceSpans: SwiftProtobuf.Message, Swi
 }
 
 extension Opentelemetry_Proto_Trace_V1_ScopeSpans: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".ScopeSpans"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".ScopeSpans"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .same(proto: "scope"),
     2: .same(proto: "spans"),
     3: .standard(proto: "schema_url"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -570,7 +570,7 @@ extension Opentelemetry_Proto_Trace_V1_ScopeSpans: SwiftProtobuf.Message, SwiftP
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -587,7 +587,7 @@ extension Opentelemetry_Proto_Trace_V1_ScopeSpans: SwiftProtobuf.Message, SwiftP
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Trace_V1_ScopeSpans, rhs: Opentelemetry_Proto_Trace_V1_ScopeSpans) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Trace_V1_ScopeSpans, rhs: Opentelemetry_Proto_Trace_V1_ScopeSpans) -> Bool {
     if lhs._scope != rhs._scope {return false}
     if lhs.spans != rhs.spans {return false}
     if lhs.schemaURL != rhs.schemaURL {return false}
@@ -597,8 +597,8 @@ extension Opentelemetry_Proto_Trace_V1_ScopeSpans: SwiftProtobuf.Message, SwiftP
 }
 
 extension Opentelemetry_Proto_Trace_V1_Span: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".Span"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".Span"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "trace_id"),
     2: .standard(proto: "span_id"),
     3: .standard(proto: "trace_state"),
@@ -616,7 +616,7 @@ extension Opentelemetry_Proto_Trace_V1_Span: SwiftProtobuf.Message, SwiftProtobu
     15: .same(proto: "status"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -642,7 +642,7 @@ extension Opentelemetry_Proto_Trace_V1_Span: SwiftProtobuf.Message, SwiftProtobu
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     // The use of inline closures is to circumvent an issue where the compiler
     // allocates stack space for every if/case branch local when no optimizations
     // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
@@ -695,7 +695,7 @@ extension Opentelemetry_Proto_Trace_V1_Span: SwiftProtobuf.Message, SwiftProtobu
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Trace_V1_Span, rhs: Opentelemetry_Proto_Trace_V1_Span) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Trace_V1_Span, rhs: Opentelemetry_Proto_Trace_V1_Span) -> Bool {
     if lhs.traceID != rhs.traceID {return false}
     if lhs.spanID != rhs.spanID {return false}
     if lhs.traceState != rhs.traceState {return false}
@@ -717,7 +717,7 @@ extension Opentelemetry_Proto_Trace_V1_Span: SwiftProtobuf.Message, SwiftProtobu
 }
 
 extension Opentelemetry_Proto_Trace_V1_Span.SpanKind: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "SPAN_KIND_UNSPECIFIED"),
     1: .same(proto: "SPAN_KIND_INTERNAL"),
     2: .same(proto: "SPAN_KIND_SERVER"),
@@ -728,15 +728,15 @@ extension Opentelemetry_Proto_Trace_V1_Span.SpanKind: SwiftProtobuf._ProtoNamePr
 }
 
 extension Opentelemetry_Proto_Trace_V1_Span.Event: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = Opentelemetry_Proto_Trace_V1_Span.protoMessageName + ".Event"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = Opentelemetry_Proto_Trace_V1_Span.protoMessageName + ".Event"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "time_unix_nano"),
     2: .same(proto: "name"),
     3: .same(proto: "attributes"),
     4: .standard(proto: "dropped_attributes_count"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -751,7 +751,7 @@ extension Opentelemetry_Proto_Trace_V1_Span.Event: SwiftProtobuf.Message, SwiftP
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if self.timeUnixNano != 0 {
       try visitor.visitSingularFixed64Field(value: self.timeUnixNano, fieldNumber: 1)
     }
@@ -767,7 +767,7 @@ extension Opentelemetry_Proto_Trace_V1_Span.Event: SwiftProtobuf.Message, SwiftP
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Trace_V1_Span.Event, rhs: Opentelemetry_Proto_Trace_V1_Span.Event) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Trace_V1_Span.Event, rhs: Opentelemetry_Proto_Trace_V1_Span.Event) -> Bool {
     if lhs.timeUnixNano != rhs.timeUnixNano {return false}
     if lhs.name != rhs.name {return false}
     if lhs.attributes != rhs.attributes {return false}
@@ -778,8 +778,8 @@ extension Opentelemetry_Proto_Trace_V1_Span.Event: SwiftProtobuf.Message, SwiftP
 }
 
 extension Opentelemetry_Proto_Trace_V1_Span.Link: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = Opentelemetry_Proto_Trace_V1_Span.protoMessageName + ".Link"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = Opentelemetry_Proto_Trace_V1_Span.protoMessageName + ".Link"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     1: .standard(proto: "trace_id"),
     2: .standard(proto: "span_id"),
     3: .standard(proto: "trace_state"),
@@ -787,7 +787,7 @@ extension Opentelemetry_Proto_Trace_V1_Span.Link: SwiftProtobuf.Message, SwiftPr
     5: .standard(proto: "dropped_attributes_count"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -803,7 +803,7 @@ extension Opentelemetry_Proto_Trace_V1_Span.Link: SwiftProtobuf.Message, SwiftPr
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.traceID.isEmpty {
       try visitor.visitSingularBytesField(value: self.traceID, fieldNumber: 1)
     }
@@ -822,7 +822,7 @@ extension Opentelemetry_Proto_Trace_V1_Span.Link: SwiftProtobuf.Message, SwiftPr
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Trace_V1_Span.Link, rhs: Opentelemetry_Proto_Trace_V1_Span.Link) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Trace_V1_Span.Link, rhs: Opentelemetry_Proto_Trace_V1_Span.Link) -> Bool {
     if lhs.traceID != rhs.traceID {return false}
     if lhs.spanID != rhs.spanID {return false}
     if lhs.traceState != rhs.traceState {return false}
@@ -834,13 +834,13 @@ extension Opentelemetry_Proto_Trace_V1_Span.Link: SwiftProtobuf.Message, SwiftPr
 }
 
 extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
-  public static let protoMessageName: String = _protobuf_package + ".Status"
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let protoMessageName: String = _protobuf_package + ".Status"
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     2: .same(proto: "message"),
     3: .same(proto: "code"),
   ]
 
-  public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
+  package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
       // The use of inline closures is to circumvent an issue where the compiler
       // allocates stack space for every case branch when no optimizations are
@@ -853,7 +853,7 @@ extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProto
     }
   }
 
-  public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
+  package func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
     if !self.message.isEmpty {
       try visitor.visitSingularStringField(value: self.message, fieldNumber: 2)
     }
@@ -863,7 +863,7 @@ extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProto
     try unknownFields.traverse(visitor: &visitor)
   }
 
-  public static func ==(lhs: Opentelemetry_Proto_Trace_V1_Status, rhs: Opentelemetry_Proto_Trace_V1_Status) -> Bool {
+  package static func ==(lhs: Opentelemetry_Proto_Trace_V1_Status, rhs: Opentelemetry_Proto_Trace_V1_Status) -> Bool {
     if lhs.message != rhs.message {return false}
     if lhs.code != rhs.code {return false}
     if lhs.unknownFields != rhs.unknownFields {return false}
@@ -872,7 +872,7 @@ extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProto
 }
 
 extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: SwiftProtobuf._ProtoNameProviding {
-  public static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
+  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
     0: .same(proto: "STATUS_CODE_UNSET"),
     1: .same(proto: "STATUS_CODE_OK"),
     2: .same(proto: "STATUS_CODE_ERROR"),

--- a/Sources/OTLPCore/Tracing/OTelFinishedSpan+Proto.swift
+++ b/Sources/OTLPCore/Tracing/OTelFinishedSpan+Proto.swift
@@ -20,7 +20,7 @@ extension Opentelemetry_Proto_Trace_V1_Span {
     /// Create a span from an `OTelFinishedSpan`.
     ///
     /// - Parameter finishedSpan: The `OTelFinishedSpan` to cast.
-    public init(_ finishedSpan: OTelFinishedSpan) {
+    package init(_ finishedSpan: OTelFinishedSpan) {
         traceID = finishedSpan.spanContext.traceID.data
         spanID = finishedSpan.spanContext.spanID.data
 

--- a/Sources/OTLPCore/Tracing/SpanAttributes+Proto.swift
+++ b/Sources/OTLPCore/Tracing/SpanAttributes+Proto.swift
@@ -17,7 +17,7 @@ extension [Opentelemetry_Proto_Common_V1_KeyValue] {
     /// Create an array of key-value pairs from span attributes.
     ///
     /// - Parameter attributes: The span attributes to cast.
-    public init(_ attributes: SpanAttributes) {
+    package init(_ attributes: SpanAttributes) {
         var keyValuePairs = [Opentelemetry_Proto_Common_V1_KeyValue]()
 
         attributes.forEach { key, spanAttribute in
@@ -41,7 +41,7 @@ extension Opentelemetry_Proto_Common_V1_AnyValue {
     ///
     /// - Parameter attribute: The `SpanAttribute` to cast.
     /// - Returns: `nil` if the attribute is unsupported.
-    public init?(_ attribute: SpanAttribute) {
+    package init?(_ attribute: SpanAttribute) {
         switch attribute {
         case .int32(let int32):
             self = .value(Int64(int32), keyPath: \.intValue)

--- a/Sources/OTLPCore/Tracing/SpanEvent+Proto.swift
+++ b/Sources/OTLPCore/Tracing/SpanEvent+Proto.swift
@@ -17,7 +17,7 @@ extension Opentelemetry_Proto_Trace_V1_Span.Event {
     /// Create an event from a `SpanEvent`.
     ///
     /// - Parameter event: The `SpanEvent` to cast.
-    public init(_ event: SpanEvent) {
+    package init(_ event: SpanEvent) {
         name = event.name
         timeUnixNano = event.nanosecondsSinceEpoch
         attributes = .init(event.attributes)

--- a/Sources/OTLPCore/Tracing/SpanKind+Proto.swift
+++ b/Sources/OTLPCore/Tracing/SpanKind+Proto.swift
@@ -17,7 +17,7 @@ extension Opentelemetry_Proto_Trace_V1_Span.SpanKind {
     /// Create a span kind from a `SpanKind`.
     ///
     /// - Parameter kind: The `SpanKind` to cast.
-    public init(_ kind: SpanKind) {
+    package init(_ kind: SpanKind) {
         switch kind {
         case .server:
             self = .server

--- a/Sources/OTLPCore/Tracing/SpanLink+Proto.swift
+++ b/Sources/OTLPCore/Tracing/SpanLink+Proto.swift
@@ -19,7 +19,7 @@ extension Opentelemetry_Proto_Trace_V1_Span.Link {
     ///
     /// - Parameter link: The `SpanLink` to cast.
     /// - Returns: `nil` if the `SpanLink`s context does not contain a span context.
-    public init?(_ link: SpanLink) {
+    package init?(_ link: SpanLink) {
         guard let spanContext = link.context.spanContext else { return nil }
         self.traceID = spanContext.traceID.data
         self.spanID = spanContext.spanID.data

--- a/Sources/OTLPCore/Tracing/SpanStatus+Proto.swift
+++ b/Sources/OTLPCore/Tracing/SpanStatus+Proto.swift
@@ -17,7 +17,7 @@ extension Opentelemetry_Proto_Trace_V1_Status {
     /// Create a status by casting a `SpanStatus`.
     ///
     /// - Parameter status: The `SpanStatus` to cast.
-    public init(_ status: SpanStatus) {
+    package init(_ status: SpanStatus) {
         self = .with {
             switch status.code {
             case .ok:

--- a/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporter.swift
+++ b/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporter.swift
@@ -20,13 +20,13 @@ import OTelCore
 import OTLPCore
 
 /// Exports metrics to an OTel collector using OTLP/gRPC.
-public final class OTLPGRPCMetricExporter: OTelMetricExporter {
+package final class OTLPGRPCMetricExporter: OTelMetricExporter {
     private let configuration: OTLPGRPCMetricExporterConfiguration
     private let connection: ClientConnection
     private let client: Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceAsyncClient
     private let logger = Logger(label: String(describing: OTLPGRPCMetricExporter.self))
 
-    public convenience init(
+    package convenience init(
         configuration: OTLPGRPCMetricExporterConfiguration,
         group: any EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         requestLogger: Logger = ._otelDisabled,
@@ -87,7 +87,7 @@ public final class OTLPGRPCMetricExporter: OTelMetricExporter {
         )
     }
 
-    public func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {
+    package func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {
         if case .shutdown = connection.connectivity.state {
             logger.error("Attempted to export batch while already being shut down.")
             throw OTelMetricExporterAlreadyShutDownError()
@@ -99,11 +99,11 @@ public final class OTLPGRPCMetricExporter: OTelMetricExporter {
         _ = try await client.export(request)
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         // This exporter is a "push exporter" and so the OTel spec says that force flush should do nothing.
     }
 
-    public func shutdown() async {
+    package func shutdown() async {
         let promise = connection.eventLoop.makePromise(of: Void.self)
         connection.closeGracefully(deadline: .now() + .milliseconds(500), promise: promise)
         try? await promise.futureResult.get()

--- a/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporterConfiguration.swift
+++ b/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporterConfiguration.swift
@@ -17,7 +17,7 @@ import OTelCore
 /// Configuration for an ``OTLPGRPCMetricExporter``.
 ///
 /// - TODO: This can probably be refactored to share a bunch of common logic with ``OTLPGRPCSpanExporterConfiguration``.
-public struct OTLPGRPCMetricExporterConfiguration: Sendable {
+package struct OTLPGRPCMetricExporterConfiguration: Sendable {
     let endpoint: OTLPGRPCEndpoint
     let headers: HPACKHeaders
 
@@ -28,7 +28,7 @@ public struct OTLPGRPCMetricExporterConfiguration: Sendable {
     ///   - endpoint: An optional endpoint string that takes precedence over any environment values. Defaults to `localhost:4317` if `nil`.
     ///   - shouldUseAnInsecureConnection: Whether to use an insecure connection in the absence of a scheme inside an endpoint configuration value.
     ///   - headers: Optional headers that take precedence over any headers configured via environment values.
-    public init(
+    package init(
         environment: OTelEnvironment,
         endpoint: String? = nil,
         shouldUseAnInsecureConnection: Bool? = nil,

--- a/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporter.swift
+++ b/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporter.swift
@@ -22,7 +22,7 @@ import OTLPCore
 import Tracing
 
 /// A span exporter emitting span batches to an OTel collector via gRPC.
-public final class OTLPGRPCSpanExporter: OTelSpanExporter {
+package final class OTLPGRPCSpanExporter: OTelSpanExporter {
     private let configuration: OTLPGRPCSpanExporterConfiguration
     private let connection: ClientConnection
     private let client: Opentelemetry_Proto_Collector_Trace_V1_TraceServiceAsyncClient
@@ -35,7 +35,7 @@ public final class OTLPGRPCSpanExporter: OTelSpanExporter {
     ///   - group: The NIO event loop group to run the exporter in.
     ///   - requestLogger: Logs info about the underlying gRPC requests. Defaults to disabled, i.e. not emitting any logs.
     ///   - backgroundActivityLogger: Logs info about the underlying gRPC connection. Defaults to disabled, i.e. not emitting any logs.
-    public convenience init(
+    package convenience init(
         configuration: OTLPGRPCSpanExporterConfiguration,
         group: any EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         requestLogger: Logger = ._otelDisabled,
@@ -96,7 +96,7 @@ public final class OTLPGRPCSpanExporter: OTelSpanExporter {
         )
     }
 
-    public func export(_ batch: some Collection<OTelFinishedSpan>) async throws {
+    package func export(_ batch: some Collection<OTelFinishedSpan>) async throws {
         if case .shutdown = connection.connectivity.state {
             logger.error("Attempted to export batch while already being shut down.")
             throw OTelSpanExporterAlreadyShutDownError()
@@ -127,9 +127,9 @@ public final class OTLPGRPCSpanExporter: OTelSpanExporter {
     }
 
     /// ``OTLPGRPCSpanExporter`` sends batches of spans as soon as they are received, so this method is a no-op.
-    public func forceFlush() async throws {}
+    package func forceFlush() async throws {}
 
-    public func shutdown() async {
+    package func shutdown() async {
         let promise = connection.eventLoop.makePromise(of: Void.self)
 
         connection.closeGracefully(deadline: .now() + .milliseconds(500), promise: promise)

--- a/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporterConfiguration.swift
+++ b/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporterConfiguration.swift
@@ -15,7 +15,7 @@ import NIOHPACK
 import OTelCore
 
 /// Configuration of an ``OTLPGRPCSpanExporter``.
-public struct OTLPGRPCSpanExporterConfiguration: Sendable {
+package struct OTLPGRPCSpanExporterConfiguration: Sendable {
     let endpoint: OTLPGRPCEndpoint
     let headers: HPACKHeaders
 
@@ -26,7 +26,7 @@ public struct OTLPGRPCSpanExporterConfiguration: Sendable {
     ///   - endpoint: An optional endpoint string that takes precedence over any environment values. Defaults to `localhost:4317` if `nil`.
     ///   - shouldUseAnInsecureConnection: Whether to use an insecure connection in the absence of a scheme inside an endpoint configuration value.
     ///   - headers: Optional headers that take precedence over any headers configured via environment values.
-    public init(
+    package init(
         environment: OTelEnvironment,
         endpoint: String? = nil,
         shouldUseAnInsecureConnection: Bool? = nil,

--- a/Sources/OTelCore/Configuration/OTelEnvironment.swift
+++ b/Sources/OTelCore/Configuration/OTelEnvironment.swift
@@ -22,23 +22,23 @@
 import Foundation
 
 /// A wrapper for reading environment values.
-public struct OTelEnvironment: Sendable {
+package struct OTelEnvironment: Sendable {
     /// The key-value pairs in the environment.
     ///
     /// - Note: All keys are lowercased to enable case-insensitive lookup.
-    public let values: [String: String]
+    package let values: [String: String]
 
     /// Create an environment wrapping the given key-value pairs.
     ///
     /// - Parameter values: The key-value pairs to wrap.
-    public init(values: [String: String]) {
+    package init(values: [String: String]) {
         self.values = Dictionary(uniqueKeysWithValues: values.map { ($0.key.lowercased(), $0.value) })
     }
 
     /// Accesses the value associated with the given key for reading by ignoring its case.
     ///
     /// - Parameter key: The key to look up case-insensitively.
-    public subscript(key: String) -> String? {
+    package subscript(key: String) -> String? {
         values[key.lowercased()]
     }
 
@@ -57,7 +57,7 @@ public struct OTelEnvironment: Sendable {
     ///   - transformValue: A closure transforming an environment value into the given type.
     /// - Warning: This method crashes if transforming the environment value fails.
     /// - Returns: The configuration value with the highest specificity.
-    public func requiredValue<T>(
+    package func requiredValue<T>(
         programmaticOverride: T?,
         key: String,
         defaultValue: T,
@@ -89,7 +89,7 @@ public struct OTelEnvironment: Sendable {
     ///   - transformValue: A closure transforming an environment value into the given type.
     /// - Returns: The configuration value with the highest specificity, or `nil` if the value was not configured.
     /// - Throws: ``OTelEnvironmentValueError`` if an environment value could not be transformed into the given type.
-    public func value<T>(
+    package func value<T>(
         programmaticOverride: T?,
         key: String,
         transformValue: (_ value: String) -> T?
@@ -122,7 +122,7 @@ public struct OTelEnvironment: Sendable {
     ///
     /// - Returns: The configuration value with the highest specificity, or `nil` if the value was not configured.
     /// - Throws: ``OTelEnvironmentValueError`` is an environment value could not be transformed into the given type.
-    public func value<T>(
+    package func value<T>(
         programmaticOverride: T?,
         signalSpecificKey: String,
         sharedKey: String,
@@ -150,7 +150,7 @@ public struct OTelEnvironment: Sendable {
     ///
     /// - Returns: The configuration value with the highest specificity, or `nil` if the value was not configured.
     /// - Throws: ``OTelEnvironmentValueError`` is an environment value could not be transformed into the given type.
-    public func value(
+    package func value(
         programmaticOverride: Bool?,
         signalSpecificKey: String,
         sharedKey: String
@@ -174,7 +174,7 @@ public struct OTelEnvironment: Sendable {
     /// An ``OTelEnvironment`` exposing the process-wide environment values.
     ///
     /// - Returns: An ``OTelEnvironment`` exposing the process-wide environment values.
-    public static func detected() -> OTelEnvironment {
+    package static func detected() -> OTelEnvironment {
         let values = ProcessInfo.processInfo.environment
         return OTelEnvironment(values: Dictionary(uniqueKeysWithValues: values.map { ($0.key.lowercased(), $0.value) }))
     }
@@ -183,7 +183,7 @@ public struct OTelEnvironment: Sendable {
     ///
     /// - Parameter value: The value containing a comma-separated list of headers.
     /// - Returns: The extracted headers as an array of key-value pairs, or nil if parsing fails.
-    public static func headers(parsingValue value: String) -> [(key: String, value: String)]? {
+    package static func headers(parsingValue value: String) -> [(key: String, value: String)]? {
         var headers = [(key: String, value: String)]()
 
         let keyValuePairs = value.split(separator: ",")
@@ -215,7 +215,7 @@ public struct OTelEnvironment: Sendable {
 }
 
 extension OTelEnvironment: ExpressibleByDictionaryLiteral {
-    public init(dictionaryLiteral elements: (String, String)...) {
+    package init(dictionaryLiteral elements: (String, String)...) {
         values = [String: String](uniqueKeysWithValues: elements.map { ($0.0.lowercased(), $0.1) })
     }
 }

--- a/Sources/OTelCore/Configuration/OTelEnvironmentValueError.swift
+++ b/Sources/OTelCore/Configuration/OTelEnvironmentValueError.swift
@@ -12,15 +12,15 @@
 //===----------------------------------------------------------------------===//
 
 /// An error indicating that the value for a given key in an ``OTelEnvironment`` is malformed.
-public struct OTelEnvironmentValueError: Error, Equatable {
+package struct OTelEnvironmentValueError: Error, Equatable {
     /// The environment key.
-    public let key: String
+    package let key: String
 
     /// The malformed environment value.
-    public let value: String
+    package let value: String
 
     /// The name of the type ``value`` should have been transformed into.
-    public let valueTypeName: String
+    package let valueTypeName: String
 
     /// Create an ``OTelEnvironmentValueError`` with the given key and malformed value.
     ///
@@ -28,7 +28,7 @@ public struct OTelEnvironmentValueError: Error, Equatable {
     ///   - key: The environment key.
     ///   - value: The malformed environment value.
     ///   - valueType: The type the given should have been transformed into.
-    public init(key: String, value: String, valueType: Any.Type) {
+    package init(key: String, value: String, valueType: Any.Type) {
         self.key = key
         self.value = value
         valueTypeName = "\(valueType)"
@@ -36,7 +36,7 @@ public struct OTelEnvironmentValueError: Error, Equatable {
 }
 
 extension OTelEnvironmentValueError: CustomStringConvertible {
-    public var description: String {
+    package var description: String {
         #"Failed converting string value "\#(value)" into "\#(valueTypeName)"."#
     }
 }

--- a/Sources/OTelCore/Context/OTelIDGenerator.swift
+++ b/Sources/OTelCore/Context/OTelIDGenerator.swift
@@ -16,7 +16,7 @@ import W3CTraceContext
 /// An ID generator generates random trace and span IDs on demand.
 ///
 /// [OpenTelemetry Specification: ID generators](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/sdk.md#id-generators)
-public protocol OTelIDGenerator: Sendable {
+package protocol OTelIDGenerator: Sendable {
     /// Get a generated trace ID.
     ///
     /// - Returns: A generated trace ID.

--- a/Sources/OTelCore/Context/OTelRandomIDGenerator.swift
+++ b/Sources/OTelCore/Context/OTelRandomIDGenerator.swift
@@ -16,28 +16,28 @@ import W3CTraceContext
 
 /// The default ID generator,
 /// based on a [`RandomNumberGenerator`](https://developer.apple.com/documentation/swift/randomnumbergenerator).
-public struct OTelRandomIDGenerator<NumberGenerator: RandomNumberGenerator & Sendable>: OTelIDGenerator {
+package struct OTelRandomIDGenerator<NumberGenerator: RandomNumberGenerator & Sendable>: OTelIDGenerator {
     private let randomNumberGenerator: NIOLockedValueBox<NumberGenerator>
 
     /// Create a random ID generator with a given random number generator.
     ///
     /// - Parameter randomNumberGenerator: The random number generator, defaults to
     /// [`SystemRandomNumberGenerator`](https://developer.apple.com/documentation/swift/systemrandomnumbergenerator)
-    public init(randomNumberGenerator: NumberGenerator) {
+    package init(randomNumberGenerator: NumberGenerator) {
         self.randomNumberGenerator = NIOLockedValueBox(randomNumberGenerator)
     }
 
-    public func nextTraceID() -> TraceID {
+    package func nextTraceID() -> TraceID {
         randomNumberGenerator.withLockedValue { .random(using: &$0) }
     }
 
-    public func nextSpanID() -> SpanID {
+    package func nextSpanID() -> SpanID {
         randomNumberGenerator.withLockedValue { .random(using: &$0) }
     }
 }
 
 extension OTelRandomIDGenerator where NumberGenerator == SystemRandomNumberGenerator {
-    public init() {
+    package init() {
         randomNumberGenerator = NIOLockedValueBox(SystemRandomNumberGenerator())
     }
 }

--- a/Sources/OTelCore/Context/OTelSpanContext.swift
+++ b/Sources/OTelCore/Context/OTelSpanContext.swift
@@ -16,26 +16,26 @@ import W3CTraceContext
 /// Represents the portion of an ``OTelSpan`` which must be serialized and propagated across asynchronous boundaries.
 ///
 /// [OTel Spec: SpanContext](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/api.md#spancontext)
-public struct OTelSpanContext: Hashable, Sendable {
+package struct OTelSpanContext: Hashable, Sendable {
     private var traceContext: TraceContext
 
     /// The ID of the trace the span belongs to.
-    public var traceID: TraceID {
+    package var traceID: TraceID {
         traceContext.traceID
     }
 
     /// The unique ID of this span.
-    public var spanID: SpanID {
+    package var spanID: SpanID {
         traceContext.spanID
     }
 
     /// An 8-bit field controlling tracing flags such as sampling.
-    public var traceFlags: TraceFlags {
+    package var traceFlags: TraceFlags {
         traceContext.flags
     }
 
     /// Additional vendor-specific trace identification information.
-    public var traceState: TraceState {
+    package var traceState: TraceState {
         get {
             traceContext.state
         }
@@ -45,10 +45,10 @@ public struct OTelSpanContext: Hashable, Sendable {
     }
 
     /// The unique ID of the span's parent or `nil` if it's the root span.
-    public let parentSpanID: SpanID?
+    package let parentSpanID: SpanID?
 
     /// Whether this span context describes a span that originated on a different service.
-    public let isRemote: Bool
+    package let isRemote: Bool
 
     package var traceParentHeaderValue: String {
         traceContext.traceParentHeaderValue
@@ -67,7 +67,7 @@ public struct OTelSpanContext: Hashable, Sendable {
     ///   - traceFlags: An 8-bit field controlling tracing flags such as sampling.
     ///   - traceState: Additional vendor-specific trace identification information.
     /// - Returns: A span context describing a local span.
-    public static func local(
+    package static func local(
         traceID: TraceID,
         spanID: SpanID,
         parentSpanID: SpanID?,
@@ -90,7 +90,7 @@ public struct OTelSpanContext: Hashable, Sendable {
     ///
     /// - Parameter traceContext: The W3C Trace Context describing the remote span.
     /// - Returns: A span context describing a remote span.
-    public static func remote(traceContext: TraceContext) -> OTelSpanContext {
+    package static func remote(traceContext: TraceContext) -> OTelSpanContext {
         OTelSpanContext(traceContext: traceContext, parentSpanID: nil, isRemote: true)
     }
 

--- a/Sources/OTelCore/Context/ServiceContext+OTelSpanContext.swift
+++ b/Sources/OTelCore/Context/ServiceContext+OTelSpanContext.swift
@@ -16,7 +16,7 @@ import W3CTraceContext
 
 extension ServiceContext {
     /// The span context.
-    public internal(set) var spanContext: OTelSpanContext? {
+    package internal(set) var spanContext: OTelSpanContext? {
         get {
             self[SpanContextKey.self]
         }

--- a/Sources/OTelCore/Logging/Exporting/OTelLogRecordExporter.swift
+++ b/Sources/OTelCore/Logging/Exporting/OTelLogRecordExporter.swift
@@ -14,8 +14,7 @@
 /// A span exporter receives batches of processed logs to export them, e.g. by sending them over the network.
 ///
 /// [OpenTelemetry specification: Log exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/logs/sdk.md#logrecordexporter)
-@_spi(Logging)
-public protocol OTelLogRecordExporter: Sendable {
+package protocol OTelLogRecordExporter: Sendable {
     /// Export the given batch of logs.
     ///
     /// - Parameter batch: A batch of logs to export.

--- a/Sources/OTelCore/Logging/Logger+OTelDisabled.swift
+++ b/Sources/OTelCore/Logging/Logger+OTelDisabled.swift
@@ -14,7 +14,7 @@
 import Logging
 
 extension Logger {
-    public static let _otelDisabled = Logger(
+    package static let _otelDisabled = Logger(
         label: "swift-otel-logging-disabled",
         factory: { _ in SwiftLogNoOpLogHandler() }
     )

--- a/Sources/OTelCore/Logging/MetadataProvider+OTel.swift
+++ b/Sources/OTelCore/Logging/MetadataProvider+OTel.swift
@@ -25,7 +25,7 @@ extension Logger.MetadataProvider {
     ///   - traceFlagsKey: The metadata key of the trace flags. Defaults to `"trace_flags"`.
     ///   - parentSpanIDKey: The metadata key of the parent span ID. Defaults to `nil`, i.e. not included.
     /// - Returns: A metadata provider ready to use with Logging.
-    public static func otel(
+    package static func otel(
         traceIDKey: String = "trace_id",
         spanIDKey: String = "span_id",
         traceFlagsKey: String = "trace_flags",
@@ -46,5 +46,5 @@ extension Logger.MetadataProvider {
     }
 
     /// A metadata provider exposing the current trace and span ID.
-    public static let otel = Logger.MetadataProvider.otel()
+    package static let otel = Logger.MetadataProvider.otel()
 }

--- a/Sources/OTelCore/Logging/OTelLogHandler.swift
+++ b/Sources/OTelCore/Logging/OTelLogHandler.swift
@@ -17,15 +17,14 @@ import NIOConcurrencyHelpers
 import ServiceLifecycle
 import Tracing
 
-@_spi(Logging)
-public struct OTelLogHandler: Sendable, LogHandler {
-    public var metadata: Logger.Metadata
-    public var logLevel: Logger.Level
+package struct OTelLogHandler: Sendable, LogHandler {
+    package var metadata: Logger.Metadata
+    package var logLevel: Logger.Level
     private let processor: any OTelLogRecordProcessor
     private let resource: OTelResource
     private let nanosecondsSinceEpoch: @Sendable () -> UInt64
 
-    public init(
+    package init(
         processor: any OTelLogRecordProcessor,
         logLevel: Logger.Level,
         resource: OTelResource,
@@ -54,12 +53,12 @@ public struct OTelLogHandler: Sendable, LogHandler {
         self.nanosecondsSinceEpoch = nanosecondsSinceEpoch
     }
 
-    public subscript(metadataKey key: String) -> Logger.Metadata.Value? {
+    package subscript(metadataKey key: String) -> Logger.Metadata.Value? {
         get { metadata[key] }
         set { metadata[key] = newValue }
     }
 
-    public func log(
+    package func log(
         level: Logger.Level,
         message: Logger.Message,
         metadata: Logger.Metadata?,

--- a/Sources/OTelCore/Logging/OTelLogRecord.swift
+++ b/Sources/OTelCore/Logging/OTelLogRecord.swift
@@ -13,15 +13,14 @@
 
 import Logging
 
-@_spi(Logging)
-public struct OTelLogRecord: Equatable, Sendable {
-    public var body: Logger.Message
-    public var level: Logger.Level
-    public var metadata: Logger.Metadata
-    public var timeNanosecondsSinceEpoch: UInt64
+package struct OTelLogRecord: Equatable, Sendable {
+    package var body: Logger.Message
+    package var level: Logger.Level
+    package var metadata: Logger.Metadata
+    package var timeNanosecondsSinceEpoch: UInt64
 
-    public let resource: OTelResource
-    public let spanContext: OTelSpanContext?
+    package let resource: OTelResource
+    package let spanContext: OTelSpanContext?
 
     package init(
         body: Logger.Message,

--- a/Sources/OTelCore/Logging/Processing/Batch/OTelBatchLogRecordProcessorConfiguration.swift
+++ b/Sources/OTelCore/Logging/Processing/Batch/OTelBatchLogRecordProcessorConfiguration.swift
@@ -12,23 +12,22 @@
 //===----------------------------------------------------------------------===//
 
 /// The configuration options for an ``OTelBatchLogRecordProcessor``.
-@_spi(Logging)
-public struct OTelBatchLogRecordProcessorConfiguration: Sendable {
+package struct OTelBatchLogRecordProcessorConfiguration: Sendable {
     /// The maximum queue size.
     ///
     /// - Warning: After this size is reached log will be dropped.
-    public var maximumQueueSize: UInt
+    package var maximumQueueSize: UInt
 
     /// The maximum delay between two consecutive log exports.
-    public var scheduleDelay: Duration
+    package var scheduleDelay: Duration
 
     /// The maximum batch size of each export.
     ///
     /// - Note: If the queue reaches this size, a batch will be exported even if ``scheduleDelay`` has not elapsed.
-    public var maximumExportBatchSize: UInt
+    package var maximumExportBatchSize: UInt
 
     /// The duration a single export can run until it is cancelled.
-    public var exportTimeout: Duration
+    package var exportTimeout: Duration
 
     /// Create a batch log processor configuration.
     ///
@@ -38,7 +37,7 @@ public struct OTelBatchLogRecordProcessorConfiguration: Sendable {
     ///   - scheduleDelay: A schedule delay used even if `OTEL_BLRP_SCHEDULE_DELAY` is set. Defaults to `1` second if both are `nil`.
     ///   - maximumExportBatchSize: A maximum export batch size used even if `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE` is set. Defaults to `512` if both are `nil`.
     ///   - exportTimeout: An export timeout used even if `OTEL_BLRP_EXPORT_TIMEOUT` is set. Defaults to `30` seconds if both are `nil`.
-    public init(
+    package init(
         environment: OTelEnvironment,
         maximumQueueSize: UInt? = nil,
         scheduleDelay: Duration? = nil,

--- a/Sources/OTelCore/Logging/Processing/OTelLogRecordProcessor.swift
+++ b/Sources/OTelCore/Logging/Processing/OTelLogRecordProcessor.swift
@@ -22,8 +22,7 @@ import ServiceLifecycle
 /// ### Implementation Notes
 ///
 /// On shutdown, processors forwarding logs to an ``OTelLogRecordExporter`` MUST shutdown that exporter.
-@_spi(Logging)
-public protocol OTelLogRecordProcessor: Service & Sendable {
+package protocol OTelLogRecordProcessor: Service & Sendable {
     func onEmit(_ record: inout OTelLogRecord)
 
     /// Force log processors that batch logs to flush immediately.

--- a/Sources/OTelCore/Logging/Processing/OTelMultiplexLogRecordProcessor.swift
+++ b/Sources/OTelCore/Logging/Processing/OTelMultiplexLogRecordProcessor.swift
@@ -15,8 +15,7 @@ import ServiceContextModule
 import ServiceLifecycle
 
 /// A pseudo-``OTelLogRecordProcessor`` that may be used to process using multiple other ``OTelLogRecordProcessor``s.
-@_spi(Logging)
-public actor OTelMultiplexLogRecordProcessor: OTelLogRecordProcessor {
+package actor OTelMultiplexLogRecordProcessor: OTelLogRecordProcessor {
     private let processors: [any OTelLogRecordProcessor]
     private let shutdownStream: AsyncStream<Void>
     private let shutdownContinuation: AsyncStream<Void>.Continuation
@@ -25,12 +24,12 @@ public actor OTelMultiplexLogRecordProcessor: OTelLogRecordProcessor {
     ///
     /// - Parameter processors: An array of ``OTelLogRecordProcessor``s, each of which will be invoked on log events
     /// Processors are called sequentially and the order of this array defines the order in which they're being called.
-    public init(processors: [any OTelLogRecordProcessor]) {
+    package init(processors: [any OTelLogRecordProcessor]) {
         self.processors = processors
         (shutdownStream, shutdownContinuation) = AsyncStream.makeStream()
     }
 
-    public func run() async throws {
+    package func run() async throws {
         await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 var shutdowns = self.shutdownStream.makeAsyncIterator()
@@ -51,13 +50,13 @@ public actor OTelMultiplexLogRecordProcessor: OTelLogRecordProcessor {
         }
     }
 
-    public nonisolated func onEmit(_ record: inout OTelLogRecord) {
+    package nonisolated func onEmit(_ record: inout OTelLogRecord) {
         for processor in processors {
             processor.onEmit(&record)
         }
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         try await withThrowingTaskGroup(of: Void.self) { group in
             for processor in processors {
                 group.addTask { try await processor.forceFlush() }

--- a/Sources/OTelCore/Metrics/MetricStore/OTelMetricRegistry.swift
+++ b/Sources/OTelCore/Metrics/MetricStore/OTelMetricRegistry.swift
@@ -18,7 +18,7 @@ import struct NIOConcurrencyHelpers.NIOLockedValueBox
 ///
 /// The registry owns the mapping from instrument identfier and attributes to the stateful instrument for recording
 /// measurements.
-public final class OTelMetricRegistry: Sendable {
+package final class OTelMetricRegistry: Sendable {
     private let logger = Logger(label: "OTelMetricRegistry")
 
     struct Storage {
@@ -56,7 +56,7 @@ public final class OTelMetricRegistry: Sendable {
     ///
     /// A duplicate instrument registration occurs when more than one instrument of the same name is created with
     /// different _identifying fields_.
-    public struct DuplicateRegistrationBehavior: Sendable {
+    package struct DuplicateRegistrationBehavior: Sendable {
         enum Behavior: Sendable {
             case warn, crash
         }
@@ -64,10 +64,10 @@ public final class OTelMetricRegistry: Sendable {
         var behavior: Behavior
 
         /// Emits a log message at warning level.
-        public static let warn = Self(behavior: .warn)
+        package static let warn = Self(behavior: .warn)
 
         /// Crashes with a fatal error.
-        public static let crash = Self(behavior: .crash)
+        package static let crash = Self(behavior: .crash)
     }
 
     init(duplicateRegistrationHandler: some DuplicateRegistrationHandler) {
@@ -80,7 +80,7 @@ public final class OTelMetricRegistry: Sendable {
     ///     different identifying fields.
     ///
     /// - Seealso: ``OTelMetricRegistry/DuplicateRegistrationBehavior``.
-    public convenience init(onDuplicateRegistration: DuplicateRegistrationBehavior = .warn) {
+    package convenience init(onDuplicateRegistration: DuplicateRegistrationBehavior = .warn) {
         switch onDuplicateRegistration.behavior {
         case .warn:
             self.init(duplicateRegistrationHandler: WarningDuplicateRegistrationHandler.default)

--- a/Sources/OTelCore/Metrics/OTelMetricExporter/OTelConsoleMetricExporter.swift
+++ b/Sources/OTelCore/Metrics/OTelMetricExporter/OTelConsoleMetricExporter.swift
@@ -12,17 +12,17 @@
 //===----------------------------------------------------------------------===//
 
 /// A metric exporter that logs metrics to the console for debugging.
-public struct OTelConsoleMetricExporter: OTelMetricExporter {
+package struct OTelConsoleMetricExporter: OTelMetricExporter {
     /// Create a new ``OTelConsoleMetricExporter``.
-    public init() {}
+    package init() {}
 
-    public func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {
+    package func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {
         for metric in batch {
             print(metric)
         }
     }
 
-    public func forceFlush() async throws {}
+    package func forceFlush() async throws {}
 
-    public func shutdown() async {}
+    package func shutdown() async {}
 }

--- a/Sources/OTelCore/Metrics/OTelMetricExporter/OTelMetricExporter.swift
+++ b/Sources/OTelCore/Metrics/OTelMetricExporter/OTelMetricExporter.swift
@@ -14,7 +14,7 @@
 /// Exports a batch of metrics.
 ///
 /// - Seealso: [OTel Specification for Metric Exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/metrics/sdk.md#metricexporter)
-public protocol OTelMetricExporter: Sendable {
+package protocol OTelMetricExporter: Sendable {
     /// Export the given batch of metrics.
     ///
     /// - Parameter batch: A batch of metrics to export.
@@ -32,6 +32,6 @@ public protocol OTelMetricExporter: Sendable {
 }
 
 /// An error indicating that an exporter has already been shut down but has been asked to export a batch of metrics.
-public struct OTelMetricExporterAlreadyShutDownError: Error {
+package struct OTelMetricExporterAlreadyShutDownError: Error {
     package init() {}
 }

--- a/Sources/OTelCore/Metrics/OTelMetricExporter/OTelMultiplexMetricExporter.swift
+++ b/Sources/OTelCore/Metrics/OTelMetricExporter/OTelMultiplexMetricExporter.swift
@@ -12,17 +12,17 @@
 //===----------------------------------------------------------------------===//
 
 /// A metric exporter that delegates to multiple other exports.
-public struct OTelMultiplexMetricExporter: OTelMetricExporter {
+package struct OTelMultiplexMetricExporter: OTelMetricExporter {
     private let exporters: [any OTelMetricExporter]
 
     /// Initialize an ``OTelMultiplexMetricExporter``.
     ///
     /// - Parameter exporters: An array of ``OTelMetricExporter``s, each of which will receive the batches to export.
-    public init(exporters: [any OTelMetricExporter]) {
+    package init(exporters: [any OTelMetricExporter]) {
         self.exporters = exporters
     }
 
-    public func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {
+    package func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {
         try await withThrowingTaskGroup(of: Void.self) { group in
             for exporter in exporters {
                 group.addTask { try await exporter.export(batch) }
@@ -31,7 +31,7 @@ public struct OTelMultiplexMetricExporter: OTelMetricExporter {
         }
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         try await withThrowingTaskGroup(of: Void.self) { group in
             for exporter in exporters {
                 group.addTask { try await exporter.forceFlush() }
@@ -40,7 +40,7 @@ public struct OTelMultiplexMetricExporter: OTelMetricExporter {
         }
     }
 
-    public func shutdown() async {
+    package func shutdown() async {
         await withTaskGroup(of: Void.self) { group in
             for exporter in exporters {
                 group.addTask { await exporter.shutdown() }

--- a/Sources/OTelCore/Metrics/OTelMetricProducer/OTLPMetricsDataModel.swift
+++ b/Sources/OTelCore/Metrics/OTelMetricProducer/OTLPMetricsDataModel.swift
@@ -33,28 +33,28 @@
 ///
 /// The types in this file represent the subset of the OTLP datamodel that we use, which map over the protobuf types.
 
-public struct OTelResourceMetrics: Equatable, Sendable {
-    public var resource: OTelResource?
-    public var scopeMetrics: [OTelScopeMetrics]
+package struct OTelResourceMetrics: Equatable, Sendable {
+    package var resource: OTelResource?
+    package var scopeMetrics: [OTelScopeMetrics]
 }
 
-public struct OTelScopeMetrics: Equatable, Sendable {
-    public var scope: OTelInstrumentationScope?
-    public var metrics: [OTelMetricPoint]
+package struct OTelScopeMetrics: Equatable, Sendable {
+    package var scope: OTelInstrumentationScope?
+    package var metrics: [OTelMetricPoint]
 }
 
-public struct OTelInstrumentationScope: Equatable, Sendable {
-    public var name: String?
-    public var version: String?
-    public var attributes: [OTelAttribute]
-    public var droppedAttributeCount: Int32
+package struct OTelInstrumentationScope: Equatable, Sendable {
+    package var name: String?
+    package var version: String?
+    package var attributes: [OTelAttribute]
+    package var droppedAttributeCount: Int32
 }
 
-public struct OTelMetricPoint: Equatable, Sendable {
-    public var name: String
-    public var description: String
-    public var unit: String
-    public struct OTelMetricData: Equatable, Sendable {
+package struct OTelMetricPoint: Equatable, Sendable {
+    package var name: String
+    package var description: String
+    package var unit: String
+    package struct OTelMetricData: Equatable, Sendable {
         package enum Data: Equatable, Sendable {
             case gauge(OTelGauge)
             case sum(OTelSum)
@@ -63,35 +63,35 @@ public struct OTelMetricPoint: Equatable, Sendable {
 
         package var data: Data
 
-        public static func gauge(_ data: OTelGauge) -> Self { self.init(data: .gauge(data)) }
-        public static func sum(_ data: OTelSum) -> Self { self.init(data: .sum(data)) }
-        public static func histogram(_ data: OTelHistogram) -> Self { self.init(data: .histogram(data)) }
+        package static func gauge(_ data: OTelGauge) -> Self { self.init(data: .gauge(data)) }
+        package static func sum(_ data: OTelSum) -> Self { self.init(data: .sum(data)) }
+        package static func histogram(_ data: OTelHistogram) -> Self { self.init(data: .histogram(data)) }
     }
 
-    public var data: OTelMetricData
+    package var data: OTelMetricData
 }
 
-public struct OTelSum: Equatable, Sendable {
-    public var points: [OTelNumberDataPoint]
-    public var aggregationTemporality: OTelAggregationTemporality
-    public var monotonic: Bool
+package struct OTelSum: Equatable, Sendable {
+    package var points: [OTelNumberDataPoint]
+    package var aggregationTemporality: OTelAggregationTemporality
+    package var monotonic: Bool
 }
 
-public struct OTelGauge: Equatable, Sendable {
-    public var points: [OTelNumberDataPoint]
+package struct OTelGauge: Equatable, Sendable {
+    package var points: [OTelNumberDataPoint]
 }
 
-public struct OTelHistogram: Equatable, Sendable {
-    public var aggregationTemporality: OTelAggregationTemporality
-    public var points: [OTelHistogramDataPoint]
+package struct OTelHistogram: Equatable, Sendable {
+    package var aggregationTemporality: OTelAggregationTemporality
+    package var points: [OTelHistogramDataPoint]
 }
 
-public struct OTelAttribute: Hashable, Equatable, Sendable {
-    public var key: String
-    public var value: String
+package struct OTelAttribute: Hashable, Equatable, Sendable {
+    package var key: String
+    package var value: String
 }
 
-public struct OTelAggregationTemporality: Equatable, Sendable {
+package struct OTelAggregationTemporality: Equatable, Sendable {
     package enum Temporality: Equatable, Sendable {
         case delta
         case cumulative
@@ -99,15 +99,15 @@ public struct OTelAggregationTemporality: Equatable, Sendable {
 
     package var temporality: Temporality
 
-    public static let delta: Self = .init(temporality: .delta)
-    public static let cumulative: Self = .init(temporality: .cumulative)
+    package static let delta: Self = .init(temporality: .delta)
+    package static let cumulative: Self = .init(temporality: .cumulative)
 }
 
-public struct OTelNumberDataPoint: Equatable, Sendable {
-    public var attributes: [OTelAttribute]
-    public var startTimeNanosecondsSinceEpoch: UInt64?
-    public var timeNanosecondsSinceEpoch: UInt64
-    public struct Value: Equatable, Sendable {
+package struct OTelNumberDataPoint: Equatable, Sendable {
+    package var attributes: [OTelAttribute]
+    package var startTimeNanosecondsSinceEpoch: UInt64?
+    package var timeNanosecondsSinceEpoch: UInt64
+    package struct Value: Equatable, Sendable {
         package enum Value: Equatable, Sendable {
             case int64(Int64)
             case double(Double)
@@ -115,25 +115,25 @@ public struct OTelNumberDataPoint: Equatable, Sendable {
 
         package var value: Value
 
-        public static func int64(_ value: Int64) -> Self { self.init(value: .int64(value)) }
-        public static func double(_ value: Double) -> Self { self.init(value: .double(value)) }
+        package static func int64(_ value: Int64) -> Self { self.init(value: .int64(value)) }
+        package static func double(_ value: Double) -> Self { self.init(value: .double(value)) }
     }
 
-    public var value: Value
+    package var value: Value
 }
 
-public struct OTelHistogramDataPoint: Equatable, Sendable {
-    public struct Bucket: Equatable, Sendable {
-        public var upperBound: Double
-        public var count: UInt64
+package struct OTelHistogramDataPoint: Equatable, Sendable {
+    package struct Bucket: Equatable, Sendable {
+        package var upperBound: Double
+        package var count: UInt64
     }
 
-    public var attributes: [OTelAttribute]
-    public var startTimeNanosecondsSinceEpoch: UInt64?
-    public var timeNanosecondsSinceEpoch: UInt64
-    public var count: UInt64
-    public var sum: Double?
-    public var min: Double?
-    public var max: Double?
-    public var buckets: [Bucket]
+    package var attributes: [OTelAttribute]
+    package var startTimeNanosecondsSinceEpoch: UInt64?
+    package var timeNanosecondsSinceEpoch: UInt64
+    package var count: UInt64
+    package var sum: Double?
+    package var min: Double?
+    package var max: Double?
+    package var buckets: [Bucket]
 }

--- a/Sources/OTelCore/Metrics/OTelMetricProducer/OTelMetricProducer.swift
+++ b/Sources/OTelCore/Metrics/OTelMetricProducer/OTelMetricProducer.swift
@@ -15,7 +15,7 @@
 /// aggregated metric data.
 ///
 /// - Seealso: [OTel specification for Metric Producer](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/sdk.md#metricproducer)
-public protocol OTelMetricProducer: Sendable {
+package protocol OTelMetricProducer: Sendable {
     /// Provides metrics from the MetricProducer to the caller.
     ///
     /// - Returns: a batch of metric points.

--- a/Sources/OTelCore/Metrics/OTelMetricProducer/OTelMetricRegistry+Produce.swift
+++ b/Sources/OTelCore/Metrics/OTelMetricProducer/OTelMetricRegistry+Produce.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 extension OTelMetricRegistry: OTelMetricProducer {
-    public func produce() -> [OTelMetricPoint] {
+    package func produce() -> [OTelMetricPoint] {
         let metrics = storage.withLockedValue { $0 }
         var buffer: [OTelMetricPoint] = []
         buffer.reserveCapacity(1024) // TODO: Make this configurable? Also, does this overlap with OTel "cardinality"?

--- a/Sources/OTelCore/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReader.swift
+++ b/Sources/OTelCore/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReader.swift
@@ -15,7 +15,7 @@ import AsyncAlgorithms
 import Logging
 import ServiceLifecycle
 
-public struct OTelPeriodicExportingMetricsReader<Clock: _Concurrency.Clock> where Clock.Duration == Duration {
+package struct OTelPeriodicExportingMetricsReader<Clock: _Concurrency.Clock> where Clock.Duration == Duration {
     private let logger = Logger(label: "OTelPeriodicExportingMetricsReader")
 
     var resource: OTelResource
@@ -64,9 +64,9 @@ public struct OTelPeriodicExportingMetricsReader<Clock: _Concurrency.Clock> wher
 }
 
 extension OTelPeriodicExportingMetricsReader: CustomStringConvertible, Service {
-    public var description: String { "OTelPeriodicExportingMetricsReader" }
+    package var description: String { "OTelPeriodicExportingMetricsReader" }
 
-    public func run() async throws {
+    package func run() async throws {
         let interval = configuration.exportInterval
         logger.info("Started periodic loop.", metadata: ["interval": "\(interval)"])
         for try await _ in AsyncTimerSequence.repeating(every: interval, clock: clock).cancelOnGracefulShutdown() {
@@ -84,7 +84,7 @@ extension OTelPeriodicExportingMetricsReader where Clock == ContinuousClock {
     ///   - producer: The producer used to periodically read metrics.
     ///   - exporter: The exporter to use to export the metrics.
     ///   - configuration: The configuration options for the periodic exporting reader.
-    public init(
+    package init(
         resource: OTelResource,
         producer: OTelMetricProducer,
         exporter: OTelMetricExporter,

--- a/Sources/OTelCore/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderConfiguration.swift
+++ b/Sources/OTelCore/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderConfiguration.swift
@@ -12,12 +12,12 @@
 //===----------------------------------------------------------------------===//
 
 /// The configuration options for an ``OTelPeriodicExportingMetricsReader``.
-public struct OTelPeriodicExportingMetricsReaderConfiguration: Sendable {
+package struct OTelPeriodicExportingMetricsReaderConfiguration: Sendable {
     /// The time interval between the start of two export attempts.
-    public var exportInterval: Duration
+    package var exportInterval: Duration
 
     /// The maximum allowed time to export data.
-    public var exportTimeout: Duration
+    package var exportTimeout: Duration
 
     /// Create a configuration for a periodic metrics reader.
     ///
@@ -27,7 +27,7 @@ public struct OTelPeriodicExportingMetricsReaderConfiguration: Sendable {
     ///     Defaults to the value of `OTEL_METRIC_EXPORT_INTERVAL`, or 60 seconds, if the environment variable is unset.
     ///   - exportTimeout: The maximum allowed time to export data.
     ///     Defaults to the value of `OTEL_METRIC_EXPORT_TIMEOUT`, or 30 seconds, if the environment variable is unset.
-    public init(
+    package init(
         environment: OTelEnvironment,
         exportInterval: Duration? = nil,
         exportTimeout: Duration? = nil

--- a/Sources/OTelCore/Metrics/SwiftMetricsFactory/OTLPMetricsFactory.swift
+++ b/Sources/OTelCore/Metrics/SwiftMetricsFactory/OTLPMetricsFactory.swift
@@ -27,11 +27,11 @@
 import CoreMetrics
 
 /// A Swift Metrics `MetricsFactory` implementation backed by ``OTelMetricRegistry``.
-public struct OTLPMetricsFactory: Sendable {
+package struct OTLPMetricsFactory: Sendable {
     private static let _defaultRegistry = OTelMetricRegistry()
 
     /// The shared, default registry.
-    public static var defaultRegistry: OTelMetricRegistry {
+    package static var defaultRegistry: OTelMetricRegistry {
         _defaultRegistry
     }
 
@@ -47,7 +47,7 @@ public struct OTLPMetricsFactory: Sendable {
     ///   - configuration: Configuration options for the factory.
     ///
     /// - Seealso: ``OTLPMetricsFactory/Configuration``.
-    public init(registry: OTelMetricRegistry = defaultRegistry, configuration: Configuration = .default) {
+    package init(registry: OTelMetricRegistry = defaultRegistry, configuration: Configuration = .default) {
         self.registry = registry
         self.configuration = configuration
     }
@@ -57,18 +57,18 @@ extension OTLPMetricsFactory {
     /// Configuration options for the metrics factory.
     ///
     /// - Seealso: See the static property ``default`` for details on the default configuration values.
-    public struct Configuration: Sendable {
+    package struct Configuration: Sendable {
         /// The default bucket upper bounds for duration histograms created for a Swift Metrics `Timer`.
-        public var defaultDurationHistogramBuckets: [Duration]
+        package var defaultDurationHistogramBuckets: [Duration]
 
         /// The bucket upper bounds for duration histograms created for a Swift Metrics `Timer` with a specific label.
-        public var durationHistogramBuckets: [String: [Duration]]
+        package var durationHistogramBuckets: [String: [Duration]]
 
         /// The default bucket upper bounds for value histograms created for a Swift Metrics `Recorder`.
-        public var defaultValueHistogramBuckets: [Double]
+        package var defaultValueHistogramBuckets: [Double]
 
         /// The bucket upper bounds for value histograms created for a Swift Metrics `Recorder` with a specific label.
-        public var valueHistogramBuckets: [String: [Double]]
+        package var valueHistogramBuckets: [String: [Double]]
 
         /// A closure to drop or modify metric registration made using the Swift Metrics API.
         ///
@@ -76,7 +76,7 @@ extension OTLPMetricsFactory {
         ///
         /// The closure will be called for each registration with the `label` and `dimensions` provided to the Swift Metrics
         /// API and should return the label and dimensions to actually use, or `nil` if this metric should be dropped.
-        public var registrationPreprocessor: @Sendable (_ label: String, _ dimensions: [(String, String)]) -> (String, [(String, String)])?
+        package var registrationPreprocessor: @Sendable (_ label: String, _ dimensions: [(String, String)]) -> (String, [(String, String)])?
 
         /// The default bucket upper bounds for histograms defined by the [OTel specification].
         ///
@@ -92,7 +92,7 @@ extension OTLPMetricsFactory {
         ///   specific metrics created using the Swift Metrics `Recorder` and `Timer` APIs respectively.
         ///
         ///  [OTel specification]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/sdk.md#explicit-bucket-histogram-aggregation
-        public static let defaultOTelHistogramBuckets: [Double] = [
+        package static let defaultOTelHistogramBuckets: [Double] = [
             0,
             5,
             10,
@@ -146,7 +146,7 @@ extension OTLPMetricsFactory {
         ///
         /// [0]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/sdk.md#explicit-bucket-histogram-aggregation
         /// [1]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/sdk.md#duplicate-instrument-registration
-        public static let `default` = Self(
+        package static let `default` = Self(
             defaultDurationHistogramBuckets: defaultOTelHistogramBuckets.map(Duration.milliseconds),
             durationHistogramBuckets: [:],
             defaultValueHistogramBuckets: defaultOTelHistogramBuckets,
@@ -157,7 +157,7 @@ extension OTLPMetricsFactory {
 }
 
 extension OTLPMetricsFactory: CoreMetrics.MetricsFactory {
-    public func makeCounter(label: String, dimensions: [(String, String)]) -> CoreMetrics.CounterHandler {
+    package func makeCounter(label: String, dimensions: [(String, String)]) -> CoreMetrics.CounterHandler {
         guard let (label, dimensions) = configuration.registrationPreprocessor(label, dimensions) else {
             return NOOPMetricsHandler.instance.makeCounter(label: label, dimensions: dimensions)
         }
@@ -165,7 +165,7 @@ extension OTLPMetricsFactory: CoreMetrics.MetricsFactory {
         return registry.makeCounter(name: label, unit: unit, description: description, attributes: attributes)
     }
 
-    public func makeFloatingPointCounter(label: String, dimensions: [(String, String)]) -> CoreMetrics.FloatingPointCounterHandler {
+    package func makeFloatingPointCounter(label: String, dimensions: [(String, String)]) -> CoreMetrics.FloatingPointCounterHandler {
         guard let (label, dimensions) = configuration.registrationPreprocessor(label, dimensions) else {
             return NOOPMetricsHandler.instance.makeFloatingPointCounter(label: label, dimensions: dimensions)
         }
@@ -173,7 +173,7 @@ extension OTLPMetricsFactory: CoreMetrics.MetricsFactory {
         return registry.makeFloatingPointCounter(name: label, unit: unit, description: description, attributes: attributes)
     }
 
-    public func makeRecorder(
+    package func makeRecorder(
         label: String,
         dimensions: [(String, String)],
         aggregate: Bool
@@ -189,7 +189,7 @@ extension OTLPMetricsFactory: CoreMetrics.MetricsFactory {
         return registry.makeValueHistogram(name: label, unit: unit, description: description, attributes: attributes, buckets: buckets)
     }
 
-    public func makeMeter(label: String, dimensions: [(String, String)]) -> CoreMetrics.MeterHandler {
+    package func makeMeter(label: String, dimensions: [(String, String)]) -> CoreMetrics.MeterHandler {
         guard let (label, dimensions) = configuration.registrationPreprocessor(label, dimensions) else {
             return NOOPMetricsHandler.instance.makeMeter(label: label, dimensions: dimensions)
         }
@@ -197,7 +197,7 @@ extension OTLPMetricsFactory: CoreMetrics.MetricsFactory {
         return registry.makeGauge(name: label, unit: unit, description: description, attributes: attributes)
     }
 
-    public func makeTimer(label: String, dimensions: [(String, String)]) -> CoreMetrics.TimerHandler {
+    package func makeTimer(label: String, dimensions: [(String, String)]) -> CoreMetrics.TimerHandler {
         guard let (label, dimensions) = configuration.registrationPreprocessor(label, dimensions) else {
             return NOOPMetricsHandler.instance.makeTimer(label: label, dimensions: dimensions)
         }
@@ -206,21 +206,21 @@ extension OTLPMetricsFactory: CoreMetrics.MetricsFactory {
         return registry.makeDurationHistogram(name: label, unit: unit, description: description, attributes: attributes, buckets: buckets)
     }
 
-    public func destroyCounter(_ handler: CoreMetrics.CounterHandler) {
+    package func destroyCounter(_ handler: CoreMetrics.CounterHandler) {
         guard let counter = handler as? Counter else {
             return
         }
         registry.unregisterCounter(counter)
     }
 
-    public func destroyFloatingPointCounter(_ handler: FloatingPointCounterHandler) {
+    package func destroyFloatingPointCounter(_ handler: FloatingPointCounterHandler) {
         guard let counter = handler as? FloatingPointCounter else {
             return
         }
         registry.unregisterFloatingPointCounter(counter)
     }
 
-    public func destroyRecorder(_ handler: CoreMetrics.RecorderHandler) {
+    package func destroyRecorder(_ handler: CoreMetrics.RecorderHandler) {
         switch handler {
         case let gauge as Gauge:
             registry.unregisterGauge(gauge)
@@ -231,14 +231,14 @@ extension OTLPMetricsFactory: CoreMetrics.MetricsFactory {
         }
     }
 
-    public func destroyMeter(_ handler: CoreMetrics.MeterHandler) {
+    package func destroyMeter(_ handler: CoreMetrics.MeterHandler) {
         guard let gauge = handler as? Gauge else {
             return
         }
         registry.unregisterGauge(gauge)
     }
 
-    public func destroyTimer(_ handler: CoreMetrics.TimerHandler) {
+    package func destroyTimer(_ handler: CoreMetrics.TimerHandler) {
         guard let histogram = handler as? Histogram<Duration> else {
             return
         }

--- a/Sources/OTelCore/OTelLibrary.swift
+++ b/Sources/OTelCore/OTelLibrary.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Information describing the `swift-otel` library itself.
-public enum OTelLibrary {
+package enum OTelLibrary {
     /// The current project version of `swift-otel`.
-    public static let version = "1.0.0"
+    package static let version = "1.0.0"
 }

--- a/Sources/OTelCore/Resource/OTelEnvironmentResourceDetector.swift
+++ b/Sources/OTelCore/Resource/OTelEnvironmentResourceDetector.swift
@@ -15,18 +15,18 @@ import Logging
 import Tracing
 
 /// A resource detector parsing resource attributes from the `OTEL_RESOURCE_ATTRIBUTES` environment variable.
-public struct OTelEnvironmentResourceDetector: OTelResourceDetector, CustomStringConvertible {
-    public let description = "environment"
+package struct OTelEnvironmentResourceDetector: OTelResourceDetector, CustomStringConvertible {
+    package let description = "environment"
     private let environment: OTelEnvironment
 
     /// Create an environment resource detector.
     ///
     /// - Parameter environment: The environment to read `OTEL_RESOURCE_ATTRIBUTES` from.
-    public init(environment: OTelEnvironment) {
+    package init(environment: OTelEnvironment) {
         self.environment = environment
     }
 
-    public func resource(logger: Logger) throws -> OTelResource {
+    package func resource(logger: Logger) throws -> OTelResource {
         let environmentKey = "OTEL_RESOURCE_ATTRIBUTES"
         guard let environmentValue = environment[environmentKey] else { return OTelResource() }
 
@@ -49,11 +49,10 @@ public struct OTelEnvironmentResourceDetector: OTelResourceDetector, CustomStrin
     }
 }
 
-@_spi(Testing)
-public struct OTelEnvironmentResourceAttributeParsingError: Error, Equatable {
-    public let keyValuePair: [Substring]
+package struct OTelEnvironmentResourceAttributeParsingError: Error, Equatable {
+    package let keyValuePair: [Substring]
 
-    public init(keyValuePair: [Substring]) {
+    package init(keyValuePair: [Substring]) {
         self.keyValuePair = keyValuePair
     }
 }

--- a/Sources/OTelCore/Resource/OTelManualResourceDetector.swift
+++ b/Sources/OTelCore/Resource/OTelManualResourceDetector.swift
@@ -14,15 +14,15 @@
 import Logging
 
 @_documentation(visibility: private)
-public struct OTelManualResourceDetector: OTelResourceDetector, CustomStringConvertible {
-    public let description = "manual"
+package struct OTelManualResourceDetector: OTelResourceDetector, CustomStringConvertible {
+    package let description = "manual"
     private let _resource: OTelResource
 
     init(resource: OTelResource) {
         _resource = resource
     }
 
-    public func resource(logger: Logger) -> OTelResource {
+    package func resource(logger: Logger) -> OTelResource {
         _resource
     }
 }
@@ -35,7 +35,7 @@ extension OTelResourceDetector where Self == OTelManualResourceDetector {
     ///
     /// - Parameter resource: The resource to return from ``OTelResourceDetector/resource(logger:)``.
     /// - Returns: A resource detector returning the given resource.
-    public static func manual(_ resource: OTelResource) -> OTelManualResourceDetector {
+    package static func manual(_ resource: OTelResource) -> OTelManualResourceDetector {
         OTelManualResourceDetector(resource: resource)
     }
 }

--- a/Sources/OTelCore/Resource/OTelProcessResourceDetector.swift
+++ b/Sources/OTelCore/Resource/OTelProcessResourceDetector.swift
@@ -16,8 +16,8 @@ import Logging
 import Tracing
 
 /// A resource detector retrieving process-related attributes.
-public struct OTelProcessResourceDetector: OTelResourceDetector, CustomStringConvertible {
-    public let description = "process"
+package struct OTelProcessResourceDetector: OTelResourceDetector, CustomStringConvertible {
+    package let description = "process"
 
     private let processIdentifier: @Sendable () -> Int32
     private let executableName: @Sendable () -> String
@@ -27,7 +27,7 @@ public struct OTelProcessResourceDetector: OTelResourceDetector, CustomStringCon
     private let owner: @Sendable () -> String?
 
     /// Create a process resource detector.
-    public init() {
+    package init() {
         self.init(
             processIdentifier: { ProcessInfo.processInfo.processIdentifier },
             executableName: { ProcessInfo.processInfo.processName },
@@ -44,8 +44,7 @@ public struct OTelProcessResourceDetector: OTelResourceDetector, CustomStringCon
         )
     }
 
-    @_spi(Testing)
-    public init(
+    package init(
         processIdentifier: @escaping @Sendable () -> Int32,
         executableName: @escaping @Sendable () -> String,
         executablePath: @escaping @Sendable () -> String,
@@ -61,7 +60,7 @@ public struct OTelProcessResourceDetector: OTelResourceDetector, CustomStringCon
         self.owner = owner
     }
 
-    public func resource(logger: Logger) -> OTelResource {
+    package func resource(logger: Logger) -> OTelResource {
         var attributes: SpanAttributes = [:]
 
         attributes["process.pid"] = SpanAttribute.int32(processIdentifier())

--- a/Sources/OTelCore/Resource/OTelResource.swift
+++ b/Sources/OTelCore/Resource/OTelResource.swift
@@ -18,14 +18,14 @@ import Tracing
 /// Resources are immutable, but multiple resources may be merged using ``merging(_:)``.
 ///
 /// [OpenTelemetry Specification: Resource](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/resource/sdk.md#resource-sdk)
-public struct OTelResource: Sendable, Equatable {
+package struct OTelResource: Sendable, Equatable {
     /// The attributes describing this resource.
-    public let attributes: SpanAttributes
+    package let attributes: SpanAttributes
 
     /// Create a resource described by the given attributes.
     ///
     /// - Parameter attributes: The attributes describing this resource. Defaults to no attributes.
-    public init(attributes: SpanAttributes = [:]) {
+    package init(attributes: SpanAttributes = [:]) {
         self.attributes = attributes
     }
 
@@ -38,7 +38,7 @@ public struct OTelResource: Sendable, Equatable {
     /// - Returns: A new ``OTelResource`` combining the attributes from both resources.
     ///
     /// [OpenTelemetry Specification: Merge Resources](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/resource/sdk.md#merge)
-    public func merging(_ other: OTelResource) -> OTelResource {
+    package func merging(_ other: OTelResource) -> OTelResource {
         var attributes = attributes
         attributes.merge(other.attributes)
         return OTelResource(attributes: attributes)

--- a/Sources/OTelCore/Resource/OTelResourceDetection.swift
+++ b/Sources/OTelCore/Resource/OTelResourceDetection.swift
@@ -15,17 +15,16 @@ import Logging
 import Tracing
 
 /// A type facilitating the resource detection process using a configurable set of resource detectors.
-public struct OTelResourceDetection<Clock: _Concurrency.Clock>: Sendable where Clock.Duration == Duration {
+package struct OTelResourceDetection<Clock: _Concurrency.Clock>: Sendable where Clock.Duration == Duration {
     /// The resource detectors to be run when calling ``resource(environment:logLevel:)``.
-    public var detectors: [any OTelResourceDetector]
+    package var detectors: [any OTelResourceDetector]
 
     /// A timeout after which resource detection will be cancelled. Defaults to `3` seconds.
-    public var timeout: Duration
+    package var timeout: Duration
 
     private let clock: Clock
 
-    @_spi(Testing)
-    public init(detectors: [any OTelResourceDetector], timeout: Duration, clock: Clock) {
+    package init(detectors: [any OTelResourceDetector], timeout: Duration, clock: Clock) {
         self.detectors = detectors
         self.timeout = timeout
         self.clock = clock
@@ -38,7 +37,7 @@ public struct OTelResourceDetection<Clock: _Concurrency.Clock>: Sendable where C
     ///   - logLevel: The minimum log level used during resource detection. Defaults to `.info`.
     ///
     /// - Returns: The combined resource from running all configured resource detectors.
-    public func resource(environment: OTelEnvironment, logLevel: Logger.Level = .info) async -> OTelResource {
+    package func resource(environment: OTelEnvironment, logLevel: Logger.Level = .info) async -> OTelResource {
         let sdkResource = OTelResource(attributes: [
             "telemetry.sdk.name": "opentelemetry",
             "telemetry.sdk.language": "swift",
@@ -138,7 +137,7 @@ extension OTelResourceDetection where Clock == ContinuousClock {
     ///   - detectors: A set of resource detectors to run.
     ///   Duplicate resource attributes will be resolved in the provided order, i.e. later resource detectors will override values from earlier ones.
     ///   - timeout: A timeout after which resource detection will be cancelled. Defaults to `3` seconds.
-    public init(detectors: [any OTelResourceDetector], timeout: Duration = .seconds(3)) {
+    package init(detectors: [any OTelResourceDetector], timeout: Duration = .seconds(3)) {
         self.init(detectors: detectors, timeout: timeout, clock: .continuous)
     }
 }

--- a/Sources/OTelCore/Resource/OTelResourceDetector.swift
+++ b/Sources/OTelCore/Resource/OTelResourceDetector.swift
@@ -16,7 +16,7 @@ import Logging
 /// A resource detector asynchronously detects attributes describing an ``OTelResource``.
 ///
 /// [OTel Specification: Resource Creation](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/resource/sdk.md#resource-creation)
-public protocol OTelResourceDetector: Sendable {
+package protocol OTelResourceDetector: Sendable {
     /// Detect attributes describing a resource.
     ///
     /// - Important: A successful detection of zero attributes **should not** result in an error being thrown.

--- a/Sources/OTelCore/Tracing/Exporting/OTelMultiplexSpanExporter.swift
+++ b/Sources/OTelCore/Tracing/Exporting/OTelMultiplexSpanExporter.swift
@@ -12,17 +12,17 @@
 //===----------------------------------------------------------------------===//
 
 /// A pseudo-``OTelSpanExporter`` that may be used to export using multiple other ``OTelSpanExporter``s.
-public struct OTelMultiplexSpanExporter: OTelSpanExporter {
+package struct OTelMultiplexSpanExporter: OTelSpanExporter {
     private let exporters: [any OTelSpanExporter]
 
     /// Initialize an ``OTelMultiplexSpanExporter``.
     ///
     /// - Parameter exporters: An array of ``OTelSpanExporter``s, each of which will receive the exported batches.
-    public init(exporters: [any OTelSpanExporter]) {
+    package init(exporters: [any OTelSpanExporter]) {
         self.exporters = exporters
     }
 
-    public func export(_ batch: some Collection<OTelFinishedSpan> & Sendable) async throws {
+    package func export(_ batch: some Collection<OTelFinishedSpan> & Sendable) async throws {
         try await withThrowingTaskGroup(of: Void.self) { group in
             for exporter in exporters {
                 group.addTask { try await exporter.export(batch) }
@@ -32,7 +32,7 @@ public struct OTelMultiplexSpanExporter: OTelSpanExporter {
         }
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         try await withThrowingTaskGroup(of: Void.self) { group in
             for exporter in exporters {
                 group.addTask { try await exporter.forceFlush() }
@@ -42,7 +42,7 @@ public struct OTelMultiplexSpanExporter: OTelSpanExporter {
         }
     }
 
-    public func shutdown() async {
+    package func shutdown() async {
         await withTaskGroup(of: Void.self) { group in
             for exporter in exporters {
                 group.addTask { await exporter.shutdown() }

--- a/Sources/OTelCore/Tracing/Exporting/OTelNoOpSpanExporter.swift
+++ b/Sources/OTelCore/Tracing/Exporting/OTelNoOpSpanExporter.swift
@@ -12,19 +12,19 @@
 //===----------------------------------------------------------------------===//
 
 /// A span exporter that ignores all operations, used when no spans should be exported.
-public struct OTelNoOpSpanExporter: OTelSpanExporter {
+package struct OTelNoOpSpanExporter: OTelSpanExporter {
     /// Initialize a no-op span exporter.
-    public init() {}
+    package init() {}
 
-    public func export(_ batch: some Collection<OTelFinishedSpan>) async throws {
+    package func export(_ batch: some Collection<OTelFinishedSpan>) async throws {
         // no-op
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         // no-op
     }
 
-    public func shutdown() async {
+    package func shutdown() async {
         // no-op
     }
 }

--- a/Sources/OTelCore/Tracing/Exporting/OTelSpanExporter.swift
+++ b/Sources/OTelCore/Tracing/Exporting/OTelSpanExporter.swift
@@ -14,7 +14,7 @@
 /// A span exporter receives batches of processed spans to export them, e.g. by sending them over the network.
 ///
 /// [OpenTelemetry specification: Span exporter](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/sdk.md#span-exporter)
-public protocol OTelSpanExporter: Sendable {
+package protocol OTelSpanExporter: Sendable {
     /// Export the given batch of spans.
     ///
     /// - Parameter batch: A batch of spans to export.
@@ -32,7 +32,7 @@ public protocol OTelSpanExporter: Sendable {
 }
 
 /// An error indicating that a given exporter has already been shut down while receiving an additional batch of spans to export.
-public struct OTelSpanExporterAlreadyShutDownError: Error {
+package struct OTelSpanExporterAlreadyShutDownError: Error {
     /// Initialize the error.
-    public init() {}
+    package init() {}
 }

--- a/Sources/OTelCore/Tracing/OTelFinishedSpan.swift
+++ b/Sources/OTelCore/Tracing/OTelFinishedSpan.swift
@@ -14,38 +14,38 @@
 import Tracing
 
 /// A read-only representation of an ended ``OTelSpan``.
-public struct OTelFinishedSpan: Sendable {
+package struct OTelFinishedSpan: Sendable {
     /// The context of this span.
-    public let spanContext: OTelSpanContext
+    package let spanContext: OTelSpanContext
 
     /// The spans operation name.
-    public let operationName: String
+    package let operationName: String
 
     /// The spans kind.
-    public let kind: SpanKind
+    package let kind: SpanKind
 
     /// The spans status.
-    public let status: SpanStatus?
+    package let status: SpanStatus?
 
     /// The time when the span started in nanoseconds since epoch.
-    public let startTimeNanosecondsSinceEpoch: UInt64
+    package let startTimeNanosecondsSinceEpoch: UInt64
 
     /// The time when the span ended in nanoseconds since epoch.
-    public let endTimeNanosecondsSinceEpoch: UInt64
+    package let endTimeNanosecondsSinceEpoch: UInt64
 
     /// The attributes added to the span.
-    public let attributes: SpanAttributes
+    package let attributes: SpanAttributes
 
     /// The resource this span instrumented.
-    public let resource: OTelResource
+    package let resource: OTelResource
 
     /// The events added to the span.
-    public let events: [SpanEvent]
+    package let events: [SpanEvent]
 
     /// The links from this span to other spans.
-    public let links: [SpanLink]
+    package let links: [SpanLink]
 
-    public init(
+    package init(
         spanContext: OTelSpanContext,
         operationName: String,
         kind: SpanKind,

--- a/Sources/OTelCore/Tracing/OTelSpan.swift
+++ b/Sources/OTelCore/Tracing/OTelSpan.swift
@@ -15,10 +15,10 @@ import NIOConcurrencyHelpers
 import Tracing
 
 /// A distributed tracing span, conforming to the [OpenTelemetry specification](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/api.md#span).
-public final class OTelSpan: Span {
+package final class OTelSpan: Span {
     private let underlying: Underlying
 
-    public var context: ServiceContext {
+    package var context: ServiceContext {
         switch underlying {
         case .noOp(let span):
             return span.context
@@ -27,7 +27,7 @@ public final class OTelSpan: Span {
         }
     }
 
-    public var isRecording: Bool {
+    package var isRecording: Bool {
         switch underlying {
         case .noOp:
             return false
@@ -36,7 +36,7 @@ public final class OTelSpan: Span {
         }
     }
 
-    public var operationName: String {
+    package var operationName: String {
         get {
             switch underlying {
             case .noOp(let span):
@@ -56,7 +56,7 @@ public final class OTelSpan: Span {
         }
     }
 
-    public var attributes: SpanAttributes {
+    package var attributes: SpanAttributes {
         get {
             switch underlying {
             case .noOp:
@@ -76,7 +76,7 @@ public final class OTelSpan: Span {
         }
     }
 
-    public var events: [SpanEvent] {
+    package var events: [SpanEvent] {
         switch underlying {
         case .noOp:
             return []
@@ -85,7 +85,7 @@ public final class OTelSpan: Span {
         }
     }
 
-    public var links: [SpanLink] {
+    package var links: [SpanLink] {
         switch underlying {
         case .noOp:
             return []
@@ -94,7 +94,7 @@ public final class OTelSpan: Span {
         }
     }
 
-    public var status: SpanStatus? {
+    package var status: SpanStatus? {
         switch underlying {
         case .noOp:
             return nil
@@ -103,7 +103,7 @@ public final class OTelSpan: Span {
         }
     }
 
-    public var endTimeNanosecondsSinceEpoch: UInt64? {
+    package var endTimeNanosecondsSinceEpoch: UInt64? {
         switch underlying {
         case .noOp:
             return nil
@@ -112,7 +112,7 @@ public final class OTelSpan: Span {
         }
     }
 
-    public func setStatus(_ status: SpanStatus) {
+    package func setStatus(_ status: SpanStatus) {
         switch underlying {
         case .noOp:
             break
@@ -122,7 +122,7 @@ public final class OTelSpan: Span {
         }
     }
 
-    public func addEvent(_ event: Tracing.SpanEvent) {
+    package func addEvent(_ event: Tracing.SpanEvent) {
         switch underlying {
         case .noOp:
             break
@@ -132,7 +132,7 @@ public final class OTelSpan: Span {
         }
     }
 
-    public func recordError(
+    package func recordError(
         _ error: Error,
         attributes: SpanAttributes,
         at instant: @autoclosure () -> some TracerInstant
@@ -146,7 +146,7 @@ public final class OTelSpan: Span {
         }
     }
 
-    public func addLink(_ link: SpanLink) {
+    package func addLink(_ link: SpanLink) {
         switch underlying {
         case .noOp:
             break
@@ -156,7 +156,7 @@ public final class OTelSpan: Span {
         }
     }
 
-    public func end(at instant: @autoclosure () -> some TracerInstant) {
+    package func end(at instant: @autoclosure () -> some TracerInstant) {
         switch underlying {
         case .noOp:
             break

--- a/Sources/OTelCore/Tracing/OTelTracer.swift
+++ b/Sources/OTelCore/Tracing/OTelTracer.swift
@@ -20,7 +20,7 @@ import W3CTraceContext
 /// An OpenTelemetry tracer implementing the Swift Distributed Tracing `Tracer` protocol.
 ///
 /// [OpenTelemetry Specification: Tracer](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/api.md#tracer)
-public final class OTelTracer<
+package final class OTelTracer<
     IDGenerator: OTelIDGenerator,
     Sampler: OTelSampler,
     Propagator: OTelPropagator,
@@ -38,8 +38,7 @@ public final class OTelTracer<
     private let eventStreamContinuation: AsyncStream<Event>.Continuation
     private let recordingSpans = NIOLockedValueBox([OTelSpanContext: OTelSpan]())
 
-    @_spi(Testing)
-    public init(
+    package init(
         idGenerator: IDGenerator,
         sampler: Sampler,
         propagator: Propagator,
@@ -74,7 +73,7 @@ extension OTelTracer where Clock == ContinuousClock {
     ///   - processor: The processor handling started/ended spans.
     ///   - environment: The environment variables.
     ///   - resource: Attributes about the resource being traced. Should be obtained using <doc:resource-detection>.
-    public convenience init(
+    package convenience init(
         idGenerator: IDGenerator,
         sampler: Sampler,
         propagator: Propagator,
@@ -95,7 +94,7 @@ extension OTelTracer where Clock == ContinuousClock {
 }
 
 extension OTelTracer: Service {
-    public func run() async throws {
+    package func run() async throws {
         try await withGracefulShutdownHandler {
             try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask {
@@ -133,7 +132,7 @@ extension OTelTracer: Service {
 }
 
 extension OTelTracer: Tracer {
-    public func startSpan(
+    package func startSpan(
         _ operationName: String,
         context: @autoclosure () -> ServiceContext,
         ofKind kind: SpanKind,
@@ -201,7 +200,7 @@ extension OTelTracer: Tracer {
         return span
     }
 
-    public func forceFlush() {
+    package func forceFlush() {
         eventStreamContinuation.yield(.forceFlushed)
     }
 
@@ -222,7 +221,7 @@ extension OTelTracer: Tracer {
         eventStreamContinuation.yield(.spanEnded(finishedSpan))
     }
 
-    public func activeSpan(identifiedBy context: ServiceContext) -> OTelSpan? {
+    package func activeSpan(identifiedBy context: ServiceContext) -> OTelSpan? {
         guard let spanContext = context.spanContext else { return nil }
         guard let recordingSpan = recordingSpans.withLockedValue({ $0[spanContext] }) else { return nil }
         return recordingSpan
@@ -230,7 +229,7 @@ extension OTelTracer: Tracer {
 }
 
 extension OTelTracer: Instrument {
-    public func inject<Carrier, Inject>(
+    package func inject<Carrier, Inject>(
         _ context: ServiceContext,
         into carrier: inout Carrier,
         using injector: Inject
@@ -239,7 +238,7 @@ extension OTelTracer: Instrument {
         propagator.inject(spanContext, into: &carrier, using: injector)
     }
 
-    public func extract<Carrier, Extract>(
+    package func extract<Carrier, Extract>(
         _ carrier: Carrier,
         into context: inout ServiceContext,
         using extractor: Extract
@@ -257,5 +256,5 @@ extension OTelTracer: Instrument {
 }
 
 extension OTelTracer: CustomStringConvertible {
-    public var description: String { "OTelTracer" }
+    package var description: String { "OTelTracer" }
 }

--- a/Sources/OTelCore/Tracing/OTelTracing+Benchmarking.swift
+++ b/Sources/OTelCore/Tracing/OTelTracing+Benchmarking.swift
@@ -14,8 +14,7 @@
 import ServiceContextModule
 
 extension ServiceContext {
-    @_spi(OTelBenchmarking)
-    public static func withSpanContext(_ spanContext: OTelSpanContext) -> Self {
+    package static func withSpanContext(_ spanContext: OTelSpanContext) -> Self {
         var context = ServiceContext.topLevel
         context.spanContext = spanContext
         return context

--- a/Sources/OTelCore/Tracing/Processing/Batch/OTelBatchSpanProcessorConfiguration.swift
+++ b/Sources/OTelCore/Tracing/Processing/Batch/OTelBatchSpanProcessorConfiguration.swift
@@ -12,22 +12,22 @@
 //===----------------------------------------------------------------------===//
 
 /// The configuration options for an ``OTelBatchSpanProcessor``.
-public struct OTelBatchSpanProcessorConfiguration: Sendable {
+package struct OTelBatchSpanProcessorConfiguration: Sendable {
     /// The maximum queue size.
     ///
     /// - Warning: After this size is reached spans will be dropped.
-    public var maximumQueueSize: UInt
+    package var maximumQueueSize: UInt
 
     /// The maximum delay between two consecutive span exports.
-    public var scheduleDelay: Duration
+    package var scheduleDelay: Duration
 
     /// The maximum batch size of each export.
     ///
     /// - Note: If the queue reaches this size, a batch will be exported even if ``scheduleDelay`` has not elapsed.
-    public var maximumExportBatchSize: UInt
+    package var maximumExportBatchSize: UInt
 
     /// The duration a single export can run until it is cancelled.
-    public var exportTimeout: Duration
+    package var exportTimeout: Duration
 
     /// Create a batch span processor configuration.
     ///
@@ -37,7 +37,7 @@ public struct OTelBatchSpanProcessorConfiguration: Sendable {
     ///   - scheduleDelay: A schedule delay used even if `OTEL_BSP_SCHEDULE_DELAY` is set. Defaults to `5` seconds if both are `nil`.
     ///   - maximumExportBatchSize: A maximum export batch size used even if `OTEL_BSP_MAX_EXPORT_BATCH_SIZE` is set. Defaults to `512` if both are `nil`.
     ///   - exportTimeout: An export timeout used even if `OTEL_BSP_EXPORT_TIMEOUT` is set. Defaults to `30` seconds if both are `nil`.
-    public init(
+    package init(
         environment: OTelEnvironment,
         maximumQueueSize: UInt? = nil,
         scheduleDelay: Duration? = nil,

--- a/Sources/OTelCore/Tracing/Processing/OTelMultiplexSpanProcessor.swift
+++ b/Sources/OTelCore/Tracing/Processing/OTelMultiplexSpanProcessor.swift
@@ -15,7 +15,7 @@ import ServiceContextModule
 import ServiceLifecycle
 
 /// A pseudo-``OTelSpanProcessor`` that may be used to process using multiple other ``OTelSpanProcessor``s.
-public actor OTelMultiplexSpanProcessor: OTelSpanProcessor {
+package actor OTelMultiplexSpanProcessor: OTelSpanProcessor {
     private let processors: [any OTelSpanProcessor]
     private let shutdownStream: AsyncStream<Void>
     private let shutdownContinuation: AsyncStream<Void>.Continuation
@@ -24,12 +24,12 @@ public actor OTelMultiplexSpanProcessor: OTelSpanProcessor {
     ///
     /// - Parameter processors: An array of ``OTelSpanProcessor``s, each of which will be invoked on start and end of spans.
     /// Processors are called sequentially and the order of this array defines the order in which they're being called.
-    public init(processors: [any OTelSpanProcessor]) {
+    package init(processors: [any OTelSpanProcessor]) {
         self.processors = processors
         (shutdownStream, shutdownContinuation) = AsyncStream.makeStream()
     }
 
-    public func run() async throws {
+    package func run() async throws {
         await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {
                 var shutdowns = self.shutdownStream.makeAsyncIterator()
@@ -50,19 +50,19 @@ public actor OTelMultiplexSpanProcessor: OTelSpanProcessor {
         }
     }
 
-    public func onStart(_ span: OTelSpan, parentContext: ServiceContext) async {
+    package func onStart(_ span: OTelSpan, parentContext: ServiceContext) async {
         for processor in processors {
             await processor.onStart(span, parentContext: parentContext)
         }
     }
 
-    public func onEnd(_ span: OTelFinishedSpan) async {
+    package func onEnd(_ span: OTelFinishedSpan) async {
         for processor in processors {
             await processor.onEnd(span)
         }
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         try await withThrowingTaskGroup(of: Void.self) { group in
             for processor in processors {
                 group.addTask { try await processor.forceFlush() }

--- a/Sources/OTelCore/Tracing/Processing/OTelNoOpSpanProcessor.swift
+++ b/Sources/OTelCore/Tracing/Processing/OTelNoOpSpanProcessor.swift
@@ -14,30 +14,30 @@
 import ServiceContextModule
 
 /// A span processor that ignores all operations, used when no spans should be processed.
-public struct OTelNoOpSpanProcessor: OTelSpanProcessor, CustomStringConvertible {
-    public let description = "OTelNoOpSpanProcessor"
+package struct OTelNoOpSpanProcessor: OTelSpanProcessor, CustomStringConvertible {
+    package let description = "OTelNoOpSpanProcessor"
 
     private let stream: AsyncStream<Void>
     private let continuation: AsyncStream<Void>.Continuation
 
     /// Initialize a no-op span processor.
-    public init() {
+    package init() {
         (stream, continuation) = AsyncStream.makeStream()
     }
 
-    public func run() async {
+    package func run() async {
         for await _ in stream.cancelOnGracefulShutdown() {}
     }
 
-    public func onStart(_ span: OTelSpan, parentContext: ServiceContext) {
+    package func onStart(_ span: OTelSpan, parentContext: ServiceContext) {
         // no-op
     }
 
-    public func onEnd(_ span: OTelFinishedSpan) {
+    package func onEnd(_ span: OTelFinishedSpan) {
         // no-op
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         // no-op
     }
 }

--- a/Sources/OTelCore/Tracing/Processing/OTelSimpleSpanProcessor.swift
+++ b/Sources/OTelCore/Tracing/Processing/OTelSimpleSpanProcessor.swift
@@ -20,7 +20,7 @@ import ServiceContextModule
 /// since it will lead to an unnecessary amount of network calls within the exporter. Instead it is recommended
 /// to use a batching span processor such as ``OTelBatchSpanProcessor`` that will forward multiple spans
 /// to the exporter at once.
-public struct OTelSimpleSpanProcessor<Exporter: OTelSpanExporter>: OTelSpanProcessor {
+package struct OTelSimpleSpanProcessor<Exporter: OTelSpanExporter>: OTelSpanProcessor {
     private let exporter: Exporter
     private let stream: AsyncStream<OTelFinishedSpan>
     private let continuation: AsyncStream<OTelFinishedSpan>.Continuation
@@ -30,12 +30,12 @@ public struct OTelSimpleSpanProcessor<Exporter: OTelSpanExporter>: OTelSpanProce
     ///
     /// - Parameter exporter: The exporter to receive finished spans.
     /// On processor shutdown this exporter will also automatically be shut down.
-    public init(exporter: Exporter) {
+    package init(exporter: Exporter) {
         self.exporter = exporter
         (stream, continuation) = AsyncStream.makeStream()
     }
 
-    public func run() async throws {
+    package func run() async throws {
         for try await span in stream.cancelOnGracefulShutdown() {
             do {
                 logger.trace("Received ended span.", metadata: ["span_id": "\(span.spanContext.spanID)"])
@@ -46,20 +46,20 @@ public struct OTelSimpleSpanProcessor<Exporter: OTelSpanExporter>: OTelSpanProce
         }
     }
 
-    public func onStart(_ span: OTelSpan, parentContext: ServiceContext) {
+    package func onStart(_ span: OTelSpan, parentContext: ServiceContext) {
         // no-op
     }
 
-    public func onEnd(_ span: OTelFinishedSpan) {
+    package func onEnd(_ span: OTelFinishedSpan) {
         guard span.spanContext.traceFlags.contains(.sampled) else { return }
         continuation.yield(span)
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         try await exporter.forceFlush()
     }
 
-    public func shutdown() async throws {
+    package func shutdown() async throws {
         await exporter.shutdown()
     }
 }

--- a/Sources/OTelCore/Tracing/Processing/OTelSpanProcessor.swift
+++ b/Sources/OTelCore/Tracing/Processing/OTelSpanProcessor.swift
@@ -22,7 +22,7 @@ import ServiceLifecycle
 /// ### Implementation Notes
 ///
 /// On shutdown, processors forwarding spans to an ``OTelSpanExporter`` MUST shutdown that exporter.
-public protocol OTelSpanProcessor: Service & Sendable {
+package protocol OTelSpanProcessor: Service & Sendable {
     /// Called whenever a new recording span was started.
     ///
     /// - Parameters:
@@ -40,5 +40,5 @@ public protocol OTelSpanProcessor: Service & Sendable {
 }
 
 extension OTelSpanProcessor {
-    public func onStart(_ span: OTelSpan, parentContext: ServiceContext) async {}
+    package func onStart(_ span: OTelSpan, parentContext: ServiceContext) async {}
 }

--- a/Sources/OTelCore/Tracing/Propagating/OTelMultiplexPropagator.swift
+++ b/Sources/OTelCore/Tracing/Propagating/OTelMultiplexPropagator.swift
@@ -15,7 +15,7 @@ import Instrumentation
 
 /// A pseudo-`OTelPropagator` that may be used to instrument using
 /// multiple other `OTelPropagator`s across a common `OTelSpanContext`.
-public struct OTelMultiplexPropagator: OTelPropagator {
+package struct OTelMultiplexPropagator: OTelPropagator {
     private let propagators: [OTelPropagator]
 
     /// Create a `MultiplexPropagator`.
@@ -28,11 +28,11 @@ public struct OTelMultiplexPropagator: OTelPropagator {
     ///
     /// - Parameter propagators: An array of `OTelPropagator`s, each of which
     /// will be used to `inject`/`extract` through the same `SpanContext`.
-    public init(_ propagators: [OTelPropagator]) {
+    package init(_ propagators: [OTelPropagator]) {
         self.propagators = propagators
     }
 
-    public func extractSpanContext<Carrier, Extract>(
+    package func extractSpanContext<Carrier, Extract>(
         from carrier: Carrier,
         using extractor: Extract
     ) throws -> OTelSpanContext? where Extract: Extractor, Carrier == Extract.Carrier {
@@ -46,7 +46,7 @@ public struct OTelMultiplexPropagator: OTelPropagator {
         return spanContext
     }
 
-    public func inject<Carrier, Inject>(
+    package func inject<Carrier, Inject>(
         _ spanContext: OTelSpanContext,
         into carrier: inout Carrier,
         using injector: Inject

--- a/Sources/OTelCore/Tracing/Propagating/OTelPropagator.swift
+++ b/Sources/OTelCore/Tracing/Propagating/OTelPropagator.swift
@@ -14,7 +14,7 @@
 import Instrumentation
 
 /// A propagator carries span context over asynchronous boundaries such as HTTP calls.
-public protocol OTelPropagator: Sendable {
+package protocol OTelPropagator: Sendable {
     /// Try to extract a span context from the given carrier.
     ///
     /// - Parameters:

--- a/Sources/OTelCore/Tracing/Propagating/OTelW3CPropagator.swift
+++ b/Sources/OTelCore/Tracing/Propagating/OTelW3CPropagator.swift
@@ -15,15 +15,15 @@ import Instrumentation
 import W3CTraceContext
 
 /// A propagator which operates on HTTP headers using the [W3C TraceContext](https://www.w3.org/TR/2020/REC-trace-context-1-20200206/).
-public struct OTelW3CPropagator: OTelPropagator {
+package struct OTelW3CPropagator: OTelPropagator {
     private static let traceParentHeaderName = "traceparent"
     private static let traceStateHeaderName = "tracestate"
     private static let dash = UInt8(ascii: "-")
 
     /// Initialize a `W3CPropagator`.
-    public init() {}
+    package init() {}
 
-    public func extractSpanContext<Carrier, Extract>(
+    package func extractSpanContext<Carrier, Extract>(
         from carrier: Carrier,
         using extractor: Extract
     ) throws -> OTelSpanContext? where Extract: Extractor, Carrier == Extract.Carrier {
@@ -39,7 +39,7 @@ public struct OTelW3CPropagator: OTelPropagator {
         return .remote(traceContext: traceContext)
     }
 
-    public func inject<Carrier, Inject>(
+    package func inject<Carrier, Inject>(
         _ spanContext: OTelSpanContext,
         into carrier: inout Carrier,
         using injector: Inject

--- a/Sources/OTelCore/Tracing/Sampling/OTelConstantSampler.swift
+++ b/Sources/OTelCore/Tracing/Sampling/OTelConstantSampler.swift
@@ -15,13 +15,13 @@ import Tracing
 import W3CTraceContext
 
 /// A sampler that always takes the same sampling decision.
-public struct OTelConstantSampler: OTelSampler {
+package struct OTelConstantSampler: OTelSampler {
     private let decision: OTelSamplingResult.Decision
 
     /// Create a sampler that always takes the given decision.
     ///
     /// - Parameter decision: The decision to take.
-    public init(decision: OTelSamplingResult.Decision) {
+    package init(decision: OTelSamplingResult.Decision) {
         self.decision = decision
     }
 
@@ -33,11 +33,11 @@ public struct OTelConstantSampler: OTelSampler {
     /// - Parameter isOn: Whether to always decides to
     /// ``OTelSamplingResult/Decision-swift.enum/recordAndSample`` or
     /// ``OTelSamplingResult/Decision-swift.enum/drop``.
-    public init(isOn: Bool) {
+    package init(isOn: Bool) {
         decision = isOn ? .recordAndSample : .drop
     }
 
-    public func samplingResult(
+    package func samplingResult(
         operationName: String,
         kind: SpanKind,
         traceID: TraceID,

--- a/Sources/OTelCore/Tracing/Sampling/OTelParentBasedSampler.swift
+++ b/Sources/OTelCore/Tracing/Sampling/OTelParentBasedSampler.swift
@@ -25,21 +25,21 @@ import W3CTraceContext
 /// | ✅ | ✅ | ❌ | ``remoteParentNotSampledSampler`` |
 /// | ✅ | ❌ | ✅ | ``localParentSampledSampler`` |
 /// | ✅ | ❌ | ❌ | ``localParentNotSampledSampler`` |
-public struct OTelParentBasedSampler: OTelSampler {
+package struct OTelParentBasedSampler: OTelSampler {
     /// The sampler invoked if a given span does not have a parent.
-    public let rootSampler: any OTelSampler
+    package let rootSampler: any OTelSampler
 
     /// The sampler invoked if a given span has a remote parent span that's sampled.
-    public let remoteParentSampledSampler: any OTelSampler
+    package let remoteParentSampledSampler: any OTelSampler
 
     /// The sampler invoked if a given span has a remote parent span that's not sampled.
-    public let remoteParentNotSampledSampler: any OTelSampler
+    package let remoteParentNotSampledSampler: any OTelSampler
 
     /// The sampler invoked if a given span has a local parent span that's sampled.
-    public let localParentSampledSampler: any OTelSampler
+    package let localParentSampledSampler: any OTelSampler
 
     /// The sampler invoked if a given span has a local parent span that's not sampled.
-    public let localParentNotSampledSampler: any OTelSampler
+    package let localParentNotSampledSampler: any OTelSampler
 
     /// Create a parent-based sampler delegating to the given samplers.
     ///
@@ -53,7 +53,7 @@ public struct OTelParentBasedSampler: OTelSampler {
     ///   Defaults to a constantly sampling sampler.
     ///   - localParentNotSampledSampler: The sampler to invoke if a given span has a local parent span that's not sampled.
     ///   Defaults to a constantly dropping sampler.
-    public init(
+    package init(
         rootSampler: any OTelSampler,
         remoteParentSampledSampler: any OTelSampler = OTelConstantSampler(isOn: true),
         remoteParentNotSampledSampler: any OTelSampler = OTelConstantSampler(isOn: false),
@@ -67,7 +67,7 @@ public struct OTelParentBasedSampler: OTelSampler {
         self.localParentNotSampledSampler = localParentNotSampledSampler
     }
 
-    public func samplingResult(
+    package func samplingResult(
         operationName: String,
         kind: SpanKind,
         traceID: TraceID,

--- a/Sources/OTelCore/Tracing/Sampling/OTelSampler.swift
+++ b/Sources/OTelCore/Tracing/Sampling/OTelSampler.swift
@@ -15,7 +15,7 @@ import Tracing
 import W3CTraceContext
 
 /// Decides whether a given span should be sampled.
-public protocol OTelSampler: Sendable {
+package protocol OTelSampler: Sendable {
     /// Request a sampling result for the given span values.
     ///
     /// - Note: The received values are all captured at the time of span creation.

--- a/Sources/OTelCore/Tracing/Sampling/OTelSamplingResult.swift
+++ b/Sources/OTelCore/Tracing/Sampling/OTelSamplingResult.swift
@@ -14,19 +14,19 @@
 import Tracing
 
 /// The result returned by ``OTelSampler``s.
-public struct OTelSamplingResult: Equatable, Sendable {
+package struct OTelSamplingResult: Equatable, Sendable {
     /// The decision on whether a span should be recorded/sampled.
-    public let decision: Decision
+    package let decision: Decision
 
     /// Additional attributes describing the sampling decision to be included in the span's attributes.
-    public let attributes: SpanAttributes
+    package let attributes: SpanAttributes
 
     /// Create a sampling result with the given decision and attributes.
     ///
     /// Parameters:
     ///   - decision: Whether the span should be recorded/sampled.
     ///   - attributes: Additional attributes describing the sampling decision.
-    public init(decision: OTelSamplingResult.Decision, attributes: SpanAttributes = [:]) {
+    package init(decision: OTelSamplingResult.Decision, attributes: SpanAttributes = [:]) {
         self.decision = decision
         self.attributes = attributes
     }
@@ -38,7 +38,7 @@ public struct OTelSamplingResult: Equatable, Sendable {
     /// | ``Decision/drop`` | ❌ | ❌ |
     /// | ``Decision/record`` | ✅ | ❌ |
     /// | ``Decision/recordAndSample`` | ✅ | ✅ |
-    public enum Decision: Equatable, Sendable {
+    package enum Decision: Equatable, Sendable {
         /// Don't record the span and drop all events and attributes.
         case drop
 

--- a/Sources/OTelCore/Tracing/Sampling/OTelTraceIDRatioBasedSampler.swift
+++ b/Sources/OTelCore/Tracing/Sampling/OTelTraceIDRatioBasedSampler.swift
@@ -17,14 +17,14 @@ import W3CTraceContext
 /// An `OTelSampler` based on a given `TraceID` and `ratio`.
 ///
 /// [OpenTelemetry Specification: TraceIDRatioBased Sampler](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/sdk.md#traceidratiobased)
-public struct OTelTraceIDRatioBasedSampler: OTelSampler, Equatable, Hashable, CustomStringConvertible {
+package struct OTelTraceIDRatioBasedSampler: OTelSampler, Equatable, Hashable, CustomStringConvertible {
     let idUpperBound: UInt64
-    public let ratio: Double
+    package let ratio: Double
 
     /// Create a trace id ratio based sampler with the given sampling `ratio`.
     ///
     /// - Parameter ratio: The sampling ratio. Must be between 0.0 and 1.0.
-    public init(ratio: Double) {
+    package init(ratio: Double) {
         precondition(ratio >= 0.0 && ratio <= 1.0, "ratio must be between 0.0 and 1.0")
 
         self.ratio = ratio
@@ -37,7 +37,7 @@ public struct OTelTraceIDRatioBasedSampler: OTelSampler, Equatable, Hashable, Cu
         }
     }
 
-    public func samplingResult(
+    package func samplingResult(
         operationName: String,
         kind: SpanKind,
         traceID: TraceID,
@@ -63,15 +63,15 @@ public struct OTelTraceIDRatioBasedSampler: OTelSampler, Equatable, Hashable, Cu
         }
     }
 
-    public static func == (lhs: Self, rhs: Self) -> Bool {
+    package static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.idUpperBound == rhs.idUpperBound
     }
 
-    public func hash(into hasher: inout Hasher) {
+    package func hash(into hasher: inout Hasher) {
         hasher.combine(idUpperBound)
     }
 
-    public var description: String {
+    package var description: String {
         "TraceIdRatioBased{\(ratio)}"
     }
 }

--- a/Sources/OTelTesting/LoggingSystem+BootstrapLogLevel.swift
+++ b/Sources/OTelTesting/LoggingSystem+BootstrapLogLevel.swift
@@ -17,7 +17,7 @@ extension LoggingSystem {
     /// Bootstraps the logging system for testing with a minimum log level.
     ///
     /// - Parameter logLevel: The minimum log level.
-    public static func bootstrapInternal(logLevel: Logger.Level) {
+    package static func bootstrapInternal(logLevel: Logger.Level) {
         LoggingSystem.bootstrapInternal { label in
             var handler = StreamLogHandler.standardOutput(label: label)
             handler.logLevel = logLevel

--- a/Sources/OTelTesting/OTelConstantIDGenerator.swift
+++ b/Sources/OTelTesting/OTelConstantIDGenerator.swift
@@ -14,20 +14,20 @@
 import OTelCore
 import W3CTraceContext
 
-public struct OTelConstantIDGenerator: OTelIDGenerator {
+package struct OTelConstantIDGenerator: OTelIDGenerator {
     private let _traceID: TraceID
     private let _spanID: SpanID
 
-    public init(traceID: TraceID, spanID: SpanID) {
+    package init(traceID: TraceID, spanID: SpanID) {
         _traceID = traceID
         _spanID = spanID
     }
 
-    public func nextTraceID() -> TraceID {
+    package func nextTraceID() -> TraceID {
         _traceID
     }
 
-    public func nextSpanID() -> SpanID {
+    package func nextSpanID() -> SpanID {
         _spanID
     }
 }

--- a/Sources/OTelTesting/OTelFinishedSpan+Stub.swift
+++ b/Sources/OTelTesting/OTelFinishedSpan+Stub.swift
@@ -36,7 +36,7 @@ extension OTelFinishedSpan {
     ///   - links: Defaults to no links.
     ///
     /// - Returns: A finished span stub.
-    public static func stub(
+    package static func stub(
         traceID: TraceID = .allZeroes,
         spanID: SpanID = .allZeroes,
         parentSpanID: SpanID? = nil,

--- a/Sources/OTelTesting/OTelInMemoryLogRecordExporter.swift
+++ b/Sources/OTelTesting/OTelInMemoryLogRecordExporter.swift
@@ -12,22 +12,21 @@
 //===----------------------------------------------------------------------===//
 
 import NIOConcurrencyHelpers
-@_spi(Logging) import OTelCore
+import OTelCore
 
-@_spi(Logging)
-public actor OTelInMemoryLogRecordExporter: OTelLogRecordExporter {
-    public private(set) var exportedBatches = [[OTelLogRecord]]()
-    public private(set) var numberOfShutdowns = 0
-    public private(set) var numberOfForceFlushes = 0
-    public private(set) var numberOfExportCancellations = 0
+package actor OTelInMemoryLogRecordExporter: OTelLogRecordExporter {
+    package private(set) var exportedBatches = [[OTelLogRecord]]()
+    package private(set) var numberOfShutdowns = 0
+    package private(set) var numberOfForceFlushes = 0
+    package private(set) var numberOfExportCancellations = 0
 
     private let exportDelay: Duration
 
-    public init(exportDelay: Duration = .zero) {
+    package init(exportDelay: Duration = .zero) {
         self.exportDelay = exportDelay
     }
 
-    public func export(_ batch: some Collection<OTelLogRecord> & Sendable) async throws {
+    package func export(_ batch: some Collection<OTelLogRecord> & Sendable) async throws {
         if exportDelay != .zero {
             do {
                 try await Task.sleep(for: exportDelay)
@@ -40,11 +39,11 @@ public actor OTelInMemoryLogRecordExporter: OTelLogRecordExporter {
         exportedBatches.append(Array(batch))
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         numberOfForceFlushes += 1
     }
 
-    public func shutdown() async {
+    package func shutdown() async {
         numberOfShutdowns += 1
     }
 }

--- a/Sources/OTelTesting/OTelInMemoryLogRecordProcessor.swift
+++ b/Sources/OTelTesting/OTelInMemoryLogRecordProcessor.swift
@@ -12,37 +12,36 @@
 //===----------------------------------------------------------------------===//
 
 import NIOConcurrencyHelpers
-@_spi(Logging) import OTelCore
+import OTelCore
 
 /// An in-memory log record processor, collecting emitted log records into ``onEmit(_:)``.
-@_spi(Logging)
-public final class OTelInMemoryLogRecordProcessor: OTelLogRecordProcessor {
-    public var records: [OTelLogRecord] { _records.withLockedValue { $0 } }
+package final class OTelInMemoryLogRecordProcessor: OTelLogRecordProcessor {
+    package var records: [OTelLogRecord] { _records.withLockedValue { $0 } }
     private let _records = NIOLockedValueBox<[OTelLogRecord]>([])
 
-    public var numberOfShutdowns: Int { _numberOfShutdowns.withLockedValue { $0 } }
+    package var numberOfShutdowns: Int { _numberOfShutdowns.withLockedValue { $0 } }
     private let _numberOfShutdowns = NIOLockedValueBox<Int>(0)
 
-    public var numberOfForceFlushes: Int { _numberOfForceFlushes.withLockedValue { $0 } }
+    package var numberOfForceFlushes: Int { _numberOfForceFlushes.withLockedValue { $0 } }
     private let _numberOfForceFlushes = NIOLockedValueBox<Int>(0)
 
     private let stream: AsyncStream<Void>
     private let continuation: AsyncStream<Void>.Continuation
 
-    public init() {
+    package init() {
         (stream, continuation) = AsyncStream.makeStream()
     }
 
-    public func run() async throws {
+    package func run() async throws {
         for await _ in stream.cancelOnGracefulShutdown() {}
         _numberOfShutdowns.withLockedValue { $0 += 1 }
     }
 
-    public nonisolated func onEmit(_ record: inout OTelLogRecord) {
+    package nonisolated func onEmit(_ record: inout OTelLogRecord) {
         _records.withLockedValue { $0.append(record) }
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         _numberOfForceFlushes.withLockedValue { $0 += 1 }
     }
 }

--- a/Sources/OTelTesting/OTelInMemoryPropagator.swift
+++ b/Sources/OTelTesting/OTelInMemoryPropagator.swift
@@ -15,19 +15,19 @@ import Instrumentation
 import NIOConcurrencyHelpers
 import OTelCore
 
-public final class OTelInMemoryPropagator: OTelPropagator, Sendable {
+package final class OTelInMemoryPropagator: OTelPropagator, Sendable {
     private let _injectedSpanContexts = NIOLockedValueBox([OTelSpanContext]())
-    public var injectedSpanContexts: [OTelSpanContext] { _injectedSpanContexts.withLockedValue { $0 } }
+    package var injectedSpanContexts: [OTelSpanContext] { _injectedSpanContexts.withLockedValue { $0 } }
 
     private let _extractedCarriers = NIOLockedValueBox([any Sendable]())
-    public var extractedCarriers: [any Sendable] { _extractedCarriers.withLockedValue { $0 } }
+    package var extractedCarriers: [any Sendable] { _extractedCarriers.withLockedValue { $0 } }
     private let extractionResult: Result<OTelSpanContext, Error>?
 
-    public init(extractionResult: Result<OTelSpanContext, Error>? = nil) {
+    package init(extractionResult: Result<OTelSpanContext, Error>? = nil) {
         self.extractionResult = extractionResult
     }
 
-    public func inject<Carrier, Inject>(
+    package func inject<Carrier, Inject>(
         _ spanContext: OTelSpanContext,
         into carrier: inout Carrier,
         using injector: Inject
@@ -35,7 +35,7 @@ public final class OTelInMemoryPropagator: OTelPropagator, Sendable {
         _injectedSpanContexts.withLockedValue { $0.append(spanContext) }
     }
 
-    public func extractSpanContext<Carrier, Extract>(
+    package func extractSpanContext<Carrier, Extract>(
         from carrier: Carrier,
         using extractor: Extract
     ) throws -> OTelSpanContext? where Carrier == Extract.Carrier, Extract: Extractor {

--- a/Sources/OTelTesting/OTelInMemorySpanExporter.swift
+++ b/Sources/OTelTesting/OTelInMemorySpanExporter.swift
@@ -14,29 +14,29 @@
 import OTelCore
 
 /// An in-memory span exporter, collecting exported batches into ``OTelInMemorySpanExporter/exportedBatches``.
-public final actor OTelInMemorySpanExporter: OTelSpanExporter {
-    public private(set) var exportedBatches = [[OTelFinishedSpan]]()
-    public private(set) var numberOfShutdowns = 0
-    public private(set) var numberOfForceFlushes = 0
+package final actor OTelInMemorySpanExporter: OTelSpanExporter {
+    package private(set) var exportedBatches = [[OTelFinishedSpan]]()
+    package private(set) var numberOfShutdowns = 0
+    package private(set) var numberOfForceFlushes = 0
 
     private let exportDelay: Duration
 
-    public init(exportDelay: Duration = .zero) {
+    package init(exportDelay: Duration = .zero) {
         self.exportDelay = exportDelay
     }
 
-    public func export(_ batch: some Collection<OTelFinishedSpan>) async throws {
+    package func export(_ batch: some Collection<OTelFinishedSpan>) async throws {
         if exportDelay != .zero {
             try await Task.sleep(for: exportDelay)
         }
         exportedBatches.append(Array(batch))
     }
 
-    public func shutdown() async {
+    package func shutdown() async {
         numberOfShutdowns += 1
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         numberOfForceFlushes += 1
     }
 }

--- a/Sources/OTelTesting/OTelInMemorySpanProcessor.swift
+++ b/Sources/OTelTesting/OTelInMemorySpanProcessor.swift
@@ -16,33 +16,33 @@ import ServiceContextModule
 
 /// An in-memory span processor, collecting started spans into ``OTelInMemorySpanProcessor/startedSpans``
 /// and finished spans into ``OTelInMemorySpanProcessor/finishedSpans``.
-public final actor OTelInMemorySpanProcessor: OTelSpanProcessor {
-    public private(set) var startedSpans = [(span: OTelSpan, parentContext: ServiceContext)]()
-    public private(set) var finishedSpans = [OTelFinishedSpan]()
-    public private(set) var numberOfForceFlushes = 0
-    public private(set) var numberOfShutdowns = 0
+package final actor OTelInMemorySpanProcessor: OTelSpanProcessor {
+    package private(set) var startedSpans = [(span: OTelSpan, parentContext: ServiceContext)]()
+    package private(set) var finishedSpans = [OTelFinishedSpan]()
+    package private(set) var numberOfForceFlushes = 0
+    package private(set) var numberOfShutdowns = 0
 
     private let stream: AsyncStream<Void>
     private let continuation: AsyncStream<Void>.Continuation
 
-    public init() {
+    package init() {
         (stream, continuation) = AsyncStream.makeStream()
     }
 
-    public func run() async throws {
+    package func run() async throws {
         for await _ in stream.cancelOnGracefulShutdown() {}
         numberOfShutdowns += 1
     }
 
-    public func onStart(_ span: OTelSpan, parentContext: ServiceContext) async {
+    package func onStart(_ span: OTelSpan, parentContext: ServiceContext) async {
         startedSpans.append((span, parentContext))
     }
 
-    public func onEnd(_ span: OTelFinishedSpan) async {
+    package func onEnd(_ span: OTelFinishedSpan) async {
         finishedSpans.append(span)
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         numberOfForceFlushes += 1
     }
 }

--- a/Sources/OTelTesting/OTelInlineSampler.swift
+++ b/Sources/OTelTesting/OTelInlineSampler.swift
@@ -15,7 +15,7 @@ import OTelCore
 import Tracing
 import W3CTraceContext
 
-public struct OTelInlineSampler: OTelSampler {
+package struct OTelInlineSampler: OTelSampler {
     private let onSamplingResult: @Sendable (
         _ operationName: String,
         _ kind: SpanKind,
@@ -25,7 +25,7 @@ public struct OTelInlineSampler: OTelSampler {
         _ parentContext: ServiceContext
     ) -> OTelSamplingResult
 
-    public init(
+    package init(
         onSamplingResult: @escaping @Sendable (
             _ operationName: String,
             _ spanKind: SpanKind,
@@ -38,7 +38,7 @@ public struct OTelInlineSampler: OTelSampler {
         self.onSamplingResult = onSamplingResult
     }
 
-    public func samplingResult(
+    package func samplingResult(
         operationName: String,
         kind: SpanKind,
         traceID: TraceID,

--- a/Sources/OTelTesting/OTelLogRecord+Stub.swift
+++ b/Sources/OTelTesting/OTelLogRecord+Stub.swift
@@ -13,11 +13,10 @@
 
 import Foundation
 import Logging
-@_spi(Logging) import OTelCore
+import OTelCore
 
-@_spi(Logging)
 extension OTelLogRecord {
-    public static func stub(
+    package static func stub(
         body: Logger.Message = "🏎️",
         level: Logger.Level = .info,
         metadata: Logger.Metadata = [:],

--- a/Sources/OTelTesting/OTelSimpleLogRecordProcessor.swift
+++ b/Sources/OTelTesting/OTelSimpleLogRecordProcessor.swift
@@ -11,20 +11,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(Logging) import OTelCore
+import OTelCore
 
-@_spi(Logging)
-public struct OTelSimpleLogRecordProcessor<Exporter: OTelLogRecordExporter>: OTelLogRecordProcessor {
+package struct OTelSimpleLogRecordProcessor<Exporter: OTelLogRecordExporter>: OTelLogRecordProcessor {
     private let exporter: Exporter
     private let stream: AsyncStream<OTelLogRecord>
     private let continuation: AsyncStream<OTelLogRecord>.Continuation
 
-    public init(exporter: Exporter) {
+    package init(exporter: Exporter) {
         self.exporter = exporter
         (stream, continuation) = AsyncStream.makeStream()
     }
 
-    public func run() async throws {
+    package func run() async throws {
         for try await record in stream.cancelOnGracefulShutdown() {
             do {
                 try await exporter.export([record])
@@ -34,15 +33,15 @@ public struct OTelSimpleLogRecordProcessor<Exporter: OTelLogRecordExporter>: OTe
         }
     }
 
-    public func onEmit(_ record: inout OTelLogRecord) {
+    package func onEmit(_ record: inout OTelLogRecord) {
         continuation.yield(record)
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         try await exporter.forceFlush()
     }
 
-    public func shutdown() async throws {
+    package func shutdown() async throws {
         await exporter.shutdown()
     }
 }

--- a/Sources/OTelTesting/OTelSpan+Stub.swift
+++ b/Sources/OTelTesting/OTelSpan+Stub.swift
@@ -21,7 +21,7 @@ extension OTelSpan {
     /// - Parameter context: Defaults to `ServiceContext.topLevel`.
     ///
     /// - Returns: A no-op span stub.
-    public static func noOpStub(context: ServiceContext = .topLevel) -> OTelSpan {
+    package static func noOpStub(context: ServiceContext = .topLevel) -> OTelSpan {
         .noOp(.init(context: context))
     }
 
@@ -37,7 +37,7 @@ extension OTelSpan {
     ///   - onEnd: Defaults to a no-op closure.
     ///
     /// - Returns: A recording span stub.
-    public static func recordingStub(
+    package static func recordingStub(
         operationName: String = "test",
         kind: SpanKind = .internal,
         context: ServiceContext = .topLevel,

--- a/Sources/OTelTesting/OTelSpanContext+Stub.swift
+++ b/Sources/OTelTesting/OTelSpanContext+Stub.swift
@@ -25,7 +25,7 @@ extension OTelSpanContext {
     ///   - traceState: Defaults to no trace state.
     ///
     /// - Returns: A span context stub.
-    public static func localStub(
+    package static func localStub(
         traceID: TraceID = .allZeroes,
         spanID: SpanID = .allZeroes,
         parentSpanID: SpanID? = nil,
@@ -50,7 +50,7 @@ extension OTelSpanContext {
     ///   - traceState: Defaults to no trace state.
     ///
     /// - Returns: A span context stub.
-    public static func remoteStub(
+    package static func remoteStub(
         traceID: TraceID = .allZeroes,
         spanID: SpanID = .allZeroes,
         traceFlags: TraceFlags = [],

--- a/Sources/OTelTesting/OTelSpanID+Stub.swift
+++ b/Sources/OTelTesting/OTelSpanID+Stub.swift
@@ -15,8 +15,8 @@ import W3CTraceContext
 
 extension SpanID {
     /// A stub span ID for testing with bytes from one to eight.
-    public static let oneToEight = SpanID(bytes: .init((1, 2, 3, 4, 5, 6, 7, 8)))
+    package static let oneToEight = SpanID(bytes: .init((1, 2, 3, 4, 5, 6, 7, 8)))
 
     /// A stub span ID for testing with all bytes being zero.
-    public static let allZeroes = SpanID(bytes: .init((0, 0, 0, 0, 0, 0, 0, 0)))
+    package static let allZeroes = SpanID(bytes: .init((0, 0, 0, 0, 0, 0, 0, 0)))
 }

--- a/Sources/OTelTesting/OTelStreamingLogRecordProcessor.swift
+++ b/Sources/OTelTesting/OTelStreamingLogRecordProcessor.swift
@@ -11,27 +11,26 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(Logging) import OTelCore
+import OTelCore
 
 /// A log record exporter streaming exported batches via an async sequence.
-@_spi(Logging)
-public final actor OTelStreamingLogRecordExporter: OTelLogRecordExporter {
-    public let batches: AsyncStream<[OTelLogRecord]>
+package final actor OTelStreamingLogRecordExporter: OTelLogRecordExporter {
+    package let batches: AsyncStream<[OTelLogRecord]>
     private let batchContinuation: AsyncStream<[OTelLogRecord]>.Continuation
     private var errorDuringNextExport: (any Error)?
 
-    public private(set) var numberOfShutdowns = 0
-    public private(set) var numberOfForceFlushes = 0
+    package private(set) var numberOfShutdowns = 0
+    package private(set) var numberOfForceFlushes = 0
 
-    public init() {
+    package init() {
         (batches, batchContinuation) = AsyncStream<[OTelLogRecord]>.makeStream()
     }
 
-    public func setErrorDuringNextExport(_ error: some Error) {
+    package func setErrorDuringNextExport(_ error: some Error) {
         errorDuringNextExport = error
     }
 
-    public func export(_ batch: some Collection<OTelLogRecord>) async throws {
+    package func export(_ batch: some Collection<OTelLogRecord>) async throws {
         batchContinuation.yield(Array(batch))
         if let errorDuringNextExport {
             self.errorDuringNextExport = nil
@@ -39,11 +38,11 @@ public final actor OTelStreamingLogRecordExporter: OTelLogRecordExporter {
         }
     }
 
-    public func shutdown() async {
+    package func shutdown() async {
         numberOfShutdowns += 1
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         numberOfForceFlushes += 1
     }
 }

--- a/Sources/OTelTesting/OTelStreamingSpanExporter.swift
+++ b/Sources/OTelTesting/OTelStreamingSpanExporter.swift
@@ -14,23 +14,23 @@
 import OTelCore
 
 /// A span exporter, streaming exported batches via an async sequence.
-public final actor OTelStreamingSpanExporter: OTelSpanExporter {
-    public let batches: AsyncStream<[OTelFinishedSpan]>
+package final actor OTelStreamingSpanExporter: OTelSpanExporter {
+    package let batches: AsyncStream<[OTelFinishedSpan]>
     private let batchContinuation: AsyncStream<[OTelFinishedSpan]>.Continuation
     private var errorDuringNextExport: (any Error)?
 
-    public private(set) var numberOfShutdowns = 0
-    public private(set) var numberOfForceFlushes = 0
+    package private(set) var numberOfShutdowns = 0
+    package private(set) var numberOfForceFlushes = 0
 
-    public init() {
+    package init() {
         (batches, batchContinuation) = AsyncStream<[OTelFinishedSpan]>.makeStream()
     }
 
-    public func setErrorDuringNextExport(_ error: some Error) {
+    package func setErrorDuringNextExport(_ error: some Error) {
         errorDuringNextExport = error
     }
 
-    public func export(_ batch: some Collection<OTelFinishedSpan>) async throws {
+    package func export(_ batch: some Collection<OTelFinishedSpan>) async throws {
         batchContinuation.yield(Array(batch))
         if let errorDuringNextExport {
             self.errorDuringNextExport = nil
@@ -38,11 +38,11 @@ public final actor OTelStreamingSpanExporter: OTelSpanExporter {
         }
     }
 
-    public func shutdown() async {
+    package func shutdown() async {
         numberOfShutdowns += 1
     }
 
-    public func forceFlush() async throws {
+    package func forceFlush() async throws {
         numberOfForceFlushes += 1
     }
 }

--- a/Sources/OTelTesting/OTelTraceID+Stub.swift
+++ b/Sources/OTelTesting/OTelTraceID+Stub.swift
@@ -15,8 +15,8 @@ import W3CTraceContext
 
 extension TraceID {
     /// A trace ID stub with bytes from one to sixteen.
-    public static let oneToSixteen = TraceID(bytes: .init((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)))
+    package static let oneToSixteen = TraceID(bytes: .init((1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)))
 
     /// A trace ID stub with all bytes being zero.
-    public static let allZeroes = TraceID(bytes: .init((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)))
+    package static let allZeroes = TraceID(bytes: .init((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)))
 }

--- a/Sources/OTelTesting/ServiceContext+Stub.swift
+++ b/Sources/OTelTesting/ServiceContext+Stub.swift
@@ -19,7 +19,7 @@ private enum StubContextKey: ServiceContextKey {
 
 extension ServiceContext {
     /// A stub integer value used for testing.
-    public var stubValue: Int? {
+    package var stubValue: Int? {
         get {
             self[StubContextKey.self]
         }
@@ -32,7 +32,7 @@ extension ServiceContext {
     ///
     /// - Parameter value: The value to use for ``stubValue``.
     /// - Returns: A top-level service context with `stubValue` set to the given value.
-    public static func withStubValue(_ value: Int) -> ServiceContext {
+    package static func withStubValue(_ value: Int) -> ServiceContext {
         var context = ServiceContext.topLevel
         context.stubValue = value
         return context

--- a/Sources/OTelTesting/TestClock.swift
+++ b/Sources/OTelTesting/TestClock.swift
@@ -13,49 +13,49 @@
 
 import NIOConcurrencyHelpers
 
-public final class TestClock: Clock, @unchecked Sendable {
-    public struct Instant: InstantProtocol {
-        public var offset: Duration
+package final class TestClock: Clock, @unchecked Sendable {
+    package struct Instant: InstantProtocol {
+        package var offset: Duration
 
-        public init(offset: Duration = .zero) {
+        package init(offset: Duration = .zero) {
             self.offset = offset
         }
 
-        public func advanced(by duration: Duration) -> Self {
+        package func advanced(by duration: Duration) -> Self {
             .init(offset: offset + duration)
         }
 
-        public func duration(to other: Self) -> Duration {
+        package func duration(to other: Self) -> Duration {
             other.offset - offset
         }
 
-        public static func < (lhs: Self, rhs: Self) -> Bool {
+        package static func < (lhs: Self, rhs: Self) -> Bool {
             lhs.offset < rhs.offset
         }
 
-        public static func minutes(_ minutes: some BinaryInteger) -> Self {
+        package static func minutes(_ minutes: some BinaryInteger) -> Self {
             .init(offset: .seconds(minutes * 60))
         }
 
-        public static func seconds(_ seconds: some BinaryInteger) -> Self {
+        package static func seconds(_ seconds: some BinaryInteger) -> Self {
             .init(offset: .seconds(seconds))
         }
 
-        public static func milliseconds(_ milliseconds: some BinaryInteger) -> Self {
+        package static func milliseconds(_ milliseconds: some BinaryInteger) -> Self {
             .init(offset: .milliseconds(milliseconds))
         }
 
-        public static func microseconds(_ microseconds: some BinaryInteger) -> Self {
+        package static func microseconds(_ microseconds: some BinaryInteger) -> Self {
             .init(offset: .microseconds(microseconds))
         }
 
-        public static func nanoseconds(_ nanoseconds: some BinaryInteger) -> Self {
+        package static func nanoseconds(_ nanoseconds: some BinaryInteger) -> Self {
             .init(offset: .nanoseconds(nanoseconds))
         }
     }
 
-    public var minimumResolution: Duration = .zero
-    public var now: Instant {
+    package var minimumResolution: Duration = .zero
+    package var now: Instant {
         state.withLockedValue { $0.now }
     }
 
@@ -65,19 +65,19 @@ public final class TestClock: Clock, @unchecked Sendable {
         var now: Instant
     }
 
-    public let sleepCalls: AsyncStream<Void>
+    package let sleepCalls: AsyncStream<Void>
     private let sleepCallsContinuation: AsyncStream<Void>.Continuation
 
     private let state = NIOLockedValueBox(State(continuations: [], now: .init()))
 
-    public init(now: Instant = .init()) {
+    package init(now: Instant = .init()) {
         state.withLockedValue { $0.now = now }
         let (stream, continunation) = AsyncStream<Void>.makeStream()
         sleepCalls = stream
         sleepCallsContinuation = continunation
     }
 
-    public func sleep(until deadline: Instant, tolerance: Duration? = nil) async throws {
+    package func sleep(until deadline: Instant, tolerance: Duration? = nil) async throws {
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 enum Action {
@@ -116,7 +116,7 @@ public final class TestClock: Clock, @unchecked Sendable {
         }
     }
 
-    public func advance(by duration: Duration = .zero) {
+    package func advance(by duration: Duration = .zero) {
         let continuationsToResume = state.withLockedValue { state in
             let deadline = state.now.advanced(by: duration)
             precondition(state.now < deadline)
@@ -131,7 +131,7 @@ public final class TestClock: Clock, @unchecked Sendable {
         }
     }
 
-    public func advance(to deadline: Instant) {
+    package func advance(to deadline: Instant) {
         let continuationsToResume = state.withLockedValue { state in
             precondition(state.now < deadline)
             state.now = deadline

--- a/Sources/OTelTesting/TracerInstant+Stub.swift
+++ b/Sources/OTelTesting/TracerInstant+Stub.swift
@@ -13,10 +13,10 @@
 
 import Tracing
 
-public struct StubInstant: TracerInstant {
-    public var nanosecondsSinceEpoch: UInt64
+package struct StubInstant: TracerInstant {
+    package var nanosecondsSinceEpoch: UInt64
 
-    public static func < (lhs: StubInstant, rhs: StubInstant) -> Bool {
+    package static func < (lhs: StubInstant, rhs: StubInstant) -> Bool {
         lhs.nanosecondsSinceEpoch < rhs.nanosecondsSinceEpoch
     }
 }
@@ -26,7 +26,7 @@ extension TracerInstant where Self == StubInstant {
     ///
     /// - Parameter nanosecondsSinceEpoch: The fixed nanoseconds since epoch.
     /// - Returns: A tracer instant with the given nanoseconds since epoch.
-    public static func constant(_ nanosecondsSinceEpoch: UInt64) -> StubInstant {
+    package static func constant(_ nanosecondsSinceEpoch: UInt64) -> StubInstant {
         StubInstant(nanosecondsSinceEpoch: nanosecondsSinceEpoch)
     }
 }

--- a/Sources/OTelTesting/XCTAssertThrowsEquatableError.swift
+++ b/Sources/OTelTesting/XCTAssertThrowsEquatableError.swift
@@ -14,7 +14,7 @@
 #if canImport(XCTest)
     import XCTest
 
-    public func XCTAssertThrowsError<E: Error & Equatable>(_ expression: @autoclosure () throws -> some Any, _ error: E) {
+    package func XCTAssertThrowsError<E: Error & Equatable>(_ expression: @autoclosure () throws -> some Any, _ error: E) {
         do {
             let value = try expression()
             XCTFail("Expected error but received value: \(value)")

--- a/Sources/OTelTesting/XCTestCase+Linux.swift
+++ b/Sources/OTelTesting/XCTestCase+Linux.swift
@@ -36,7 +36,7 @@
         /// - Note: If you do not specify a timeout when calling this function, it
         ///     is recommended that you enable test timeouts to prevent a runaway
         ///     expectation from hanging the test.
-        public func fulfillment(
+        package func fulfillment(
             of expectations: [XCTestExpectation],
             timeout: TimeInterval,
             enforceOrder: Bool = false

--- a/Tests/OTelCoreTests/Logging/OTelLogHandlerTests.swift
+++ b/Tests/OTelCoreTests/Logging/OTelLogHandlerTests.swift
@@ -12,9 +12,8 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Logging
-@_spi(Logging) import OTelCore
-@_spi(Logging) import OTelTesting
-@_spi(Logging) import OTelCore
+import OTelCore
+import OTelTesting
 import XCTest
 
 final class OTelLogHandlerTests: XCTestCase {

--- a/Tests/OTelCoreTests/Logging/Processing/OTelBatchLogRecordProcessorConfigurationTests.swift
+++ b/Tests/OTelCoreTests/Logging/Processing/OTelBatchLogRecordProcessorConfigurationTests.swift
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(Logging) import OTelCore
+import OTelCore
 import XCTest
 
 final class OTelBatchLogRecordProcessorConfigurationTests: XCTestCase {

--- a/Tests/OTelCoreTests/Logging/Processing/OTelBatchLogRecordProcessorTests.swift
+++ b/Tests/OTelCoreTests/Logging/Processing/OTelBatchLogRecordProcessorTests.swift
@@ -12,8 +12,8 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Logging
-@_spi(Logging) @_spi(Testing) @testable import OTelCore
-@_spi(Logging) import OTelTesting
+@testable import OTelCore
+import OTelTesting
 import ServiceLifecycle
 import XCTest
 

--- a/Tests/OTelCoreTests/Logging/Processing/OTelMultiplexLogRecordProcessorTests.swift
+++ b/Tests/OTelCoreTests/Logging/Processing/OTelMultiplexLogRecordProcessorTests.swift
@@ -12,8 +12,8 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Logging
-@_spi(Logging) import OTelCore
-@_spi(Logging) import OTelTesting
+import OTelCore
+import OTelTesting
 import ServiceLifecycle
 import XCTest
 

--- a/Tests/OTelCoreTests/Resource/OTelEnvironmentResourceDetectorTests.swift
+++ b/Tests/OTelCoreTests/Resource/OTelEnvironmentResourceDetectorTests.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
-@_spi(Testing) import OTelCore
+import OTelCore
 import Tracing
 import XCTest
 

--- a/Tests/OTelCoreTests/Resource/OTelProcessResourceDetectorTests.swift
+++ b/Tests/OTelCoreTests/Resource/OTelProcessResourceDetectorTests.swift
@@ -13,8 +13,8 @@
 
 import Foundation
 import Logging
+import OTelCore
 import OTelTesting
-@_spi(Testing) import OTelCore
 import XCTest
 
 final class OTelProcessResourceDetectorTests: XCTestCase {

--- a/Tests/OTelCoreTests/Resource/OTelResourceDetectionTests.swift
+++ b/Tests/OTelCoreTests/Resource/OTelResourceDetectionTests.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
-@_spi(Testing) import OTelCore
+import OTelCore
 import OTelTesting
 import XCTest
 

--- a/Tests/OTelCoreTests/Tracing/OTelTracerTests.swift
+++ b/Tests/OTelCoreTests/Tracing/OTelTracerTests.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
-@testable @_spi(Testing) import OTelCore
+@testable import OTelCore
 import OTelTesting
 import ServiceContextModule
 import ServiceLifecycle

--- a/Tests/OTelCoreTests/Tracing/Processing/Batch/OTelBatchSpanProcessorTests.swift
+++ b/Tests/OTelCoreTests/Tracing/Processing/Batch/OTelBatchSpanProcessorTests.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 @testable import Logging
-@_spi(Testing) import OTelCore
+import OTelCore
 import OTelTesting
 import ServiceLifecycle
 import XCTest


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we need to reduce the public API surface to reflect the accepted proposal (#205).

## Modifications

- Replace all `public` and `@_spi(...) public` access with `package` access
- Update Makefile to generate Swift from proto with package visibility

## Result

There is no longer any `public` symbols in the repo:

```console
% git grep public Sources/ | wc -l
0

% git grep package Sources/ | wc -l
1032
```

This gives us a ground-zero from which to add new public API surface to the new `OTel` module.

## Notes

To keep this PR targeted and easy to review, this is a very mechanical change. _Everything_ that was `public` is now `package`. If we want to discuss further changing the visibility, e.g. to `internal` for some symbols, this is deferred for now.