### PR TITLE
Add shims to initialize internal types from new configuration type

### DIFF
--- a/Sources/OTLPGRPC/OTLPGRPC+ConfigurationShims.swift
+++ b/Sources/OTLPGRPC/OTLPGRPC+ConfigurationShims.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import OTelCore
+
+extension OTLPGRPCMetricExporterConfiguration {
+    package init(configuration: OTel.Configuration.OTLPExporterConfiguration) throws {
+        try self.init(
+            environment: [:],
+            endpoint: configuration.endpoint,
+            shouldUseAnInsecureConnection: configuration.insecure,
+            headers: .init(configuration.headers)
+        )
+    }
+}
+
+extension OTLPGRPCMetricExporter {
+    package convenience init(configuration: OTel.Configuration.OTLPExporterConfiguration) throws {
+        try self.init(configuration: .init(configuration: configuration))
+    }
+}
+
+extension OTLPGRPCSpanExporterConfiguration {
+    package init(configuration: OTel.Configuration.OTLPExporterConfiguration) throws {
+        try self.init(
+            environment: [:],
+            endpoint: configuration.endpoint,
+            shouldUseAnInsecureConnection: configuration.insecure,
+            headers: .init(configuration.headers)
+        )
+    }
+}
+
+extension OTLPGRPCSpanExporter {
+    package convenience init(configuration: OTel.Configuration.OTLPExporterConfiguration) throws {
+        try self.init(configuration: .init(configuration: configuration))
+    }
+}

--- a/Sources/OTelCore/OTelCore+ConfigurationShims.swift
+++ b/Sources/OTelCore/OTelCore+ConfigurationShims.swift
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Tracing
+
+extension OTelResource {
+    package init(configuration: OTel.Configuration) {
+        let attributes = configuration.resourceAttributes.mapValues { $0.toSpanAttribute() }
+        self.init(attributes: SpanAttributes(attributes))
+    }
+}
+
+extension OTelPeriodicExportingMetricsReaderConfiguration {
+    package init(configuration: OTel.Configuration.MetricsConfiguration) {
+        self.init(
+            environment: [:],
+            exportInterval: configuration.exportInterval,
+            exportTimeout: configuration.exportTimeout
+        )
+    }
+}
+
+extension OTelBatchSpanProcessorConfiguration {
+    package init(configuration: OTel.Configuration.TracesConfiguration.BatchSpanProcessorConfiguration) {
+        self.init(
+            environment: [:],
+            maximumQueueSize: UInt(configuration.maxQueueSize),
+            scheduleDelay: configuration.scheduleDelay,
+            maximumExportBatchSize: UInt(configuration.maxExportBatchSize),
+            exportTimeout: configuration.exportTimeout
+        )
+    }
+}


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we have introduced a new centralized configuration API as part of the API proposal (#205). The plan is to continue to make use of all the (now-)internal types to implement the API, and many of these had some level of configuration, either with a different configuration type (which will also now be internal), or by initializer parameters, which are no longer reachable by API. We need a way to construct the hierarchy of internal types from the new, user-provided `OTel.Configuration` type.

## Modifications

-  Add `init(_: OTel.Configuration)` shims for existing types.

## Result

Can now construct all the types needed to create and bootstrap backends from an `OTel.Configuration` value.

## Notes

To keep this PR targeted and easy to review, the following are out of scope, and will be provided in future PRs:

1. Supporting a wider range of configuration. Specifically, the new `OTel.Configuration` type allows for expressing more configuration than the previous API supported. This PR only wires up what was previously supported.

2. Removing the internal existing initializer or configuration APIs. A future PR might remove any obsolete configuration APIs.