### PR TITLE
Add internal `Configuration.applyEnvironmentOverrides` helpers

### DIFF
--- a/Sources/OTelCore/OTel+Configuration+Environment.swift
+++ b/Sources/OTelCore/OTel+Configuration+Environment.swift
@@ -1,0 +1,193 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension OTel.Configuration {
+    /// An environment variable key used to lookup OTel configuration overrides.
+    internal enum Key {
+        internal enum Signal { case traces, metrics, logs }
+        /// A key for an option configured using a single key.
+        ///
+        case single(OTel.Configuration.Key.GeneralKey)
+
+        /// A key for an option configured with a singal-specific key, and a shared fallback key.
+        case signalSpecific(OTel.Configuration.Key.SignalSpecificKey, Signal)
+
+        struct GeneralKey {
+            var key: String
+        }
+
+        struct SignalSpecificKey {
+            var shared: String
+            var traces: String
+            var metrics: String
+            var logs: String
+        }
+    }
+}
+
+extension OTel.Configuration.Key.GeneralKey {
+    static let resourceAttributes = Self(key: "OTEL_RESOURCE_ATTRIBUTES")
+    static let serviceName = Self(key: "OTEL_SERVICE_NAME")
+    static let logLevel = Self(key: "OTEL_LOG_LEVEL")
+    static let tracesExporter = Self(key: "OTEL_TRACES_EXPORTER")
+    static let metricsExporter = Self(key: "OTEL_METRICS_EXPORTER")
+    static let metricExportInterval = Self(key: "OTEL_METRIC_EXPORT_INTERVAL")
+    static let metricExportTimeout = Self(key: "OTEL_METRIC_EXPORT_TIMEOUT")
+    static let logsExporter = Self(key: "OTEL_LOGS_EXPORTER")
+    static let propagators = Self(key: "OTEL_PROPARGATORS")
+    static let batchSpanProcessorScheduleDelay = Self(key: "OTEL_BSP_SCHEDULE_DELAY")
+    static let batchSpanProcessorExportTimeout = Self(key: "OTEL_BSP_EXPORT_TIMEOUT")
+    static let batchSpanProcessorMaxQueueSize = Self(key: "OTEL_BSP_MAX_QUEUE_SIZE")
+    static let batchSpanProcessorExportBatchSize = Self(key: "OTEL_BSP_EXPORT_BATCH_SIZE")
+}
+
+extension OTel.Configuration.Key.SignalSpecificKey {
+    private static func otlpExporterKey(suffix: String) -> Self {
+        Self(
+            shared: "OTEL_EXPORTER_OTLP_\(suffix)",
+            traces: "OTEL_EXPORTER_OTLP_TRACES_\(suffix)",
+            metrics: "OTEL_EXPORTER_OTLP_METRICS_\(suffix)",
+            logs: "OTEL_EXPORTER_OTLP_LOGS_\(suffix)"
+        )
+    }
+
+    static let otlpExporterEndpoint = Self.otlpExporterKey(suffix: "ENDPOINT")
+    static let otlpExporterInsecure = Self.otlpExporterKey(suffix: "INSECURE")
+    static let otlpExporterCertificate = Self.otlpExporterKey(suffix: "CERTIFICATE")
+    static let otlpExporterClientKey = Self.otlpExporterKey(suffix: "CLIENT_KEY")
+    static let otlpExporterClientCertificate = Self.otlpExporterKey(suffix: "CLIENT_CERTIFICATE")
+    static let otlpExporterHeaders = Self.otlpExporterKey(suffix: "HEADERS")
+    static let otlpExporterCompression = Self.otlpExporterKey(suffix: "COMPRESSION")
+    static let otlpExporterTimeout = Self.otlpExporterKey(suffix: "TIMEOUT")
+    static let otlpExporterProtocol = Self.otlpExporterKey(suffix: "PROTOCOL")
+}
+
+extension [String: String] {
+    func getStringValue(_ lookup: OTel.Configuration.Key) -> String? {
+        switch lookup {
+        case .single(let generalKey):
+            self.getStringValue(generalKey)
+        case .signalSpecific(let signalSpecificKey, let signal):
+            self.getStringValue(signalSpecificKey, signal: signal)
+        }
+    }
+
+    func getBoolValue(_ key: OTel.Configuration.Key) -> Bool? {
+        // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#boolean
+        getStringValue(key)?.lowercased() == "true"
+    }
+
+    func getIntegerValue(_ key: OTel.Configuration.Key) -> Int? {
+        // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#integer
+        guard let value = getStringValue(key).flatMap(Int.init), value >= 0 else {
+            return nil
+        }
+        return value
+    }
+
+    func getDurationValue(_ key: OTel.Configuration.Key) -> Duration? {
+        // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#duration
+        guard let value = getIntegerValue(key) else {
+            return nil
+        }
+        return .milliseconds(value)
+    }
+
+    func getTimeoutValue(_ key: OTel.Configuration.Key) -> Duration? {
+        // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#timeout
+        let value = getDurationValue(key)
+        if value == .zero {
+            return .seconds(Int.max)
+        }
+        return value
+    }
+
+    func getHeadersValue(_ key: OTel.Configuration.Key) -> [(String, String)]? {
+        // https://opentelemetry.io/docs/specs/otel/protocol/exporter/#specifying-headers-via-environment-variables
+        guard let value = getStringValue(key) else { return nil }
+        let headers = value.utf8.split(separator: .init(ascii: ","))
+        return headers.compactMap { header in
+            let pair = header.split(separator: .init(ascii: "="), maxSplits: 1, omittingEmptySubsequences: true)
+            guard let key = pair.first, let value = pair.dropFirst().first else { return nil }
+            return (String(decoding: key, as: UTF8.self), String(decoding: value, as: UTF8.self))
+        }
+    }
+
+    func getEnumValue<E: RawRepresentable<String>>(of type: E.Type = E.self, _ key: OTel.Configuration.Key) -> E? {
+        guard let rawValue = getStringValue(key) else { return nil }
+        return E(rawValue: rawValue)
+    }
+}
+
+/// Overloads for general and signal-specific keys to simplify lookups at the callsite.
+extension [String: String] {
+    func getStringValue(_ key: OTel.Configuration.Key.GeneralKey) -> String? {
+        self[key.key]
+    }
+
+    func getStringValue(_ key: OTel.Configuration.Key.SignalSpecificKey, signal: OTel.Configuration.Key.Signal) -> String? {
+        switch signal {
+        case .traces: self[key.traces] ?? self[key.shared]
+        case .metrics: self[key.metrics] ?? self[key.shared]
+        case .logs: self[key.logs] ?? self[key.shared]
+        }
+    }
+
+    func getBoolValue(_ key: OTel.Configuration.Key.GeneralKey) -> Bool? {
+        getBoolValue(.single(key))
+    }
+
+    func getBoolValue(_ key: OTel.Configuration.Key.SignalSpecificKey, signal: OTel.Configuration.Key.Signal) -> Bool? {
+        getBoolValue(.signalSpecific(key, signal))
+    }
+
+    func getIntegerValue(_ key: OTel.Configuration.Key.GeneralKey) -> Int? {
+        getIntegerValue(.single(key))
+    }
+
+    func getIntegerValue(_ key: OTel.Configuration.Key.SignalSpecificKey, signal: OTel.Configuration.Key.Signal) -> Int? {
+        getIntegerValue(.signalSpecific(key, signal))
+    }
+
+    func getDurationValue(_ key: OTel.Configuration.Key.GeneralKey) -> Duration? {
+        getDurationValue(.single(key))
+    }
+
+    func getDurationValue(_ key: OTel.Configuration.Key.SignalSpecificKey, signal: OTel.Configuration.Key.Signal) -> Duration? {
+        getDurationValue(.signalSpecific(key, signal))
+    }
+
+    func getTimeoutValue(_ key: OTel.Configuration.Key.GeneralKey) -> Duration? {
+        getDurationValue(.single(key))
+    }
+
+    func getTimeoutValue(_ key: OTel.Configuration.Key.SignalSpecificKey, signal: OTel.Configuration.Key.Signal) -> Duration? {
+        getDurationValue(.signalSpecific(key, signal))
+    }
+
+    func getHeadersValue(_ key: OTel.Configuration.Key.GeneralKey) -> [(String, String)]? {
+        getHeadersValue(.single(key))
+    }
+
+    func getHeadersValue(_ key: OTel.Configuration.Key.SignalSpecificKey, signal: OTel.Configuration.Key.Signal) -> [(String, String)]? {
+        getHeadersValue(.signalSpecific(key, signal))
+    }
+
+    func getEnumValue<E: RawRepresentable<String>>(of type: E.Type = E.self, _ key: OTel.Configuration.Key.GeneralKey) -> E? {
+        getEnumValue(of: type, .single(key))
+    }
+
+    func getEnumValue<E: RawRepresentable<String>>(of type: E.Type = E.self, _ key: OTel.Configuration.Key.SignalSpecificKey, signal: OTel.Configuration.Key.Signal) -> E? {
+        getEnumValue(of: type, .signalSpecific(key, signal))
+    }
+}

--- a/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
+++ b/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
@@ -1,0 +1,204 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension OTel.Configuration {
+    internal mutating func applyEnvironmentOverrides(environment: [String: String]) {
+        if let resourceAttributes = environment.getHeadersValue(.resourceAttributes) {
+            // https://opentelemetry.io/docs/specs/otel/resource/sdk/#specifying-resource-information-via-an-environment-variable
+            let incomingAttributes = Dictionary(resourceAttributes, uniquingKeysWith: { _, second in second })
+            self.resourceAttributes.merge(incomingAttributes, uniquingKeysWith: { current, _ in current })
+        }
+        if let serviceName = environment.getStringValue(.serviceName) {
+            self.serviceName = serviceName
+        }
+        if let logLevel = environment.getEnumValue(of: OTel.Configuration.LogLevel.Backing.self, .logLevel) {
+            self.logLevel = .init(backing: logLevel)
+        }
+        if let propagators = environment.getStringValue(.propagators) {
+            self.propagators.removeAll()
+            for propagator in propagators.split(separator: ",") {
+                switch propagator {
+                case "tracecontext":
+                    self.propagators.append(.traceContext)
+                case "baggage":
+                    self.propagators.append(.baggage)
+                case "b3":
+                    self.propagators.append(.b3)
+                case "b3multi":
+                    self.propagators.append(.b3Multi)
+                case "jaeger":
+                    self.propagators.append(.jaeger)
+                case "xray":
+                    self.propagators.append(.xray)
+                case "ottrace":
+                    self.propagators.append(.otTrace)
+                case "none":
+                    self.propagators.removeAll()
+                default:
+                    continue
+                }
+            }
+        }
+        traces.applyEnvironmentOverrides(environment: environment)
+        metrics.applyEnvironmentOverrides(environment: environment)
+        logs.applyEnvironmentOverrides(environment: environment)
+    }
+}
+
+extension OTel.Configuration.TracesConfiguration {
+    internal mutating func applyEnvironmentOverrides(environment: [String: String]) {
+        batchSpanProcessor.applyEnvironmentOverrides(environment: environment)
+        if let tracesExporter = environment.getStringValue(.tracesExporter) {
+            switch tracesExporter {
+            case "none":
+                enabled = false
+            case "jaeger":
+                exporter = .jaeger
+            case "zipkin":
+                exporter = .zipkin
+            case "console":
+                exporter = .console
+            case "otlp":
+                exporter = .otlp
+            default:
+                exporter = .otlp
+            }
+        }
+        otlpExporter.applyEnvironmentOverrides(environment: environment, signal: .traces)
+    }
+}
+
+extension OTel.Configuration.MetricsConfiguration {
+    internal mutating func applyEnvironmentOverrides(environment: [String: String]) {
+        if let metricExportInterval = environment.getDurationValue(.metricExportInterval) {
+            exportInterval = metricExportInterval
+        }
+        if let metricExportTimeout = environment.getDurationValue(.metricExportTimeout) {
+            exportTimeout = metricExportTimeout
+        }
+        if let metricsExporter = environment.getStringValue(.metricsExporter) {
+            switch metricsExporter {
+            case "none":
+                enabled = false
+            case "prometheus":
+                exporter = .prometheus
+            case "console":
+                exporter = .console
+            case "otlp":
+                exporter = .otlp
+            default:
+                exporter = .otlp
+            }
+        }
+        otlpExporter.applyEnvironmentOverrides(environment: environment, signal: .metrics)
+    }
+}
+
+extension OTel.Configuration.LogsConfiguration {
+    internal mutating func applyEnvironmentOverrides(environment: [String: String]) {
+        if let logsExporter = environment.getStringValue(.logsExporter) {
+            switch logsExporter {
+            case "none":
+                enabled = false
+            case "console":
+                exporter = .console
+            case "otlp":
+                exporter = .otlp
+            default:
+                exporter = .otlp
+            }
+        }
+        otlpExporter.applyEnvironmentOverrides(environment: environment, signal: .logs)
+    }
+}
+
+extension OTel.Configuration.TracesConfiguration.BatchSpanProcessorConfiguration {
+    internal mutating func applyEnvironmentOverrides(environment: [String: String]) {
+        if let scheduleDelay = environment.getDurationValue(.batchSpanProcessorScheduleDelay) {
+            self.scheduleDelay = scheduleDelay
+        }
+        if let exportTimeout = environment.getTimeoutValue(.batchSpanProcessorExportTimeout) {
+            self.exportTimeout = exportTimeout
+        }
+        if let maxQueueSize = environment.getIntegerValue(.batchSpanProcessorMaxQueueSize) {
+            self.maxQueueSize = maxQueueSize
+        }
+        if let exportBatchSize = environment.getIntegerValue(.batchSpanProcessorExportBatchSize) {
+            maxExportBatchSize = exportBatchSize
+        }
+    }
+}
+
+extension OTel.Configuration.OTLPExporterConfiguration {
+    internal mutating func applyEnvironmentOverrides(environment: [String: String], signal: OTel.Configuration.Key.Signal) {
+        if let endpoint = environment.getStringValue(.otlpExporterEndpoint, signal: signal) {
+            self.endpoint = endpoint
+        }
+        if let insecure = environment.getBoolValue(.otlpExporterInsecure, signal: signal) {
+            self.insecure = insecure
+        }
+        if let certificateFilePath = environment.getStringValue(.otlpExporterCertificate, signal: signal) {
+            self.certificateFilePath = certificateFilePath
+        }
+        if let clientKeyFilePath = environment.getStringValue(.otlpExporterClientKey, signal: signal) {
+            self.clientKeyFilePath = clientKeyFilePath
+        }
+        if let clientCertificateFilePath = environment.getStringValue(.otlpExporterClientCertificate, signal: signal) {
+            self.clientCertificateFilePath = clientCertificateFilePath
+        }
+        if let headers = environment.getHeadersValue(.otlpExporterHeaders, signal: signal) {
+            self.headers = headers
+        }
+        if let compression = environment.getStringValue(.otlpExporterCompression, signal: signal) {
+            switch compression {
+            case "gzip":
+                self.compression = .gzip
+            case "none":
+                self.compression = .none
+            default:
+                self.compression = .none
+            }
+        }
+        if let timeout = environment.getTimeoutValue(.otlpExporterTimeout, signal: signal) {
+            self.timeout = timeout
+        }
+        if let `protocol` = environment.getStringValue(.otlpExporterProtocol, signal: signal) {
+            switch `protocol` {
+            case "http/json":
+                #if OTLPHTTP
+                    self.protocol = .httpJSON
+                #else // OTLPHTTP
+                    fatalError("Using the OTLP/HTTP + JSON exporter requires the `OTLPHTTP` trait enabled.")
+                #endif
+            case "grpc":
+                #if OTLPGRPC
+                    self.protocol = .grpc
+                #else // OTLPGRPC
+                    fatalError("Using the OTLP/GRPC exporter requires the `OTLPGRPC` trait enabled.")
+                #endif
+            case "http/protobuf":
+                #if OTLPHTTP
+                    self.protocol = .httpProtobuf
+                #else // OTLPHTTP
+                    fatalError("Using the OTLP/HTTP + Protobuf exporter requires the `OTLPHTTP` trait enabled.")
+                #endif
+            default:
+                #if OTLPHTTP
+                    self.protocol = .httpProtobuf
+                #else // OTLPHTTP
+                    fatalError("Using the OTLP/HTTP + Protobuf exporter requires the `OTLPHTTP` trait enabled.")
+                #endif
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we have introduced a new centralized configuration API as part of the API proposal (#205). The implementation also needs to support applying overrides from environment variables as described in the OTel spec.

## Modifications

- Add internal `Configuration.applyEnvironmentOverrides` helpers

## Result

Internal helper functions exist for overriding config using environment variables, which can be used to implement the backend APIs.

## Notes

There's a note in the roadmap to discuss how we would like to handle unsupported configuration values that are detected in the environment variable. Right now they are handled as follows:

1. Unrecognised values revert to default. This is in line with the OTel spec, although I have added an item to our roadmap to discuss whether we want a strict mode. They should also be logged with the "internal diagnostic" logger, which we don't have yet.
2. The trait-based options, which _could_ be supported if the trait were enabled currently error if the trait is not enabled. It's likely that we'll want to treat this similarly to (1)—that is, we'll log an error diagnostic and continue, or we could throw an actual error.