### PR TITLE
Add API docs to OTel.Configuration

### DIFF
--- a/Sources/OTelCore/OTel+Configuration.swift
+++ b/Sources/OTelCore/OTel+Configuration.swift
@@ -169,6 +169,8 @@ extension OTel.Configuration {
     /// Log level for internal diagnostic messages.
     ///
     /// Controls the minimum severity level for diagnostic output.
+    ///
+    /// This option is ignored for custom loggers.
     public struct LogLevel: Sendable {
         package enum Backing: String, Sendable {
             case error


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we added the configuration API from the proposal (#205). This was added #210 but deliberately deferred adding the documentation, which would likely attract more discussion during review. This PR adds the API docs for the configuration API types.

## Modifications

- Add API docs to `OTel.Configuration` and friends.

## Result

The API types nested in `OTel.Configuration` have API documentation.

## Notes

It would be nice to make use of Snippets for code examples used in DocC documentation to CI them. There's an item on the roadmap to investigate this.