### PR TITLE
Have OTelPeriodicExportingMetricsReader read and export on graceful shutdown

### DIFF
--- a/Sources/OTelCore/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReader.swift
+++ b/Sources/OTelCore/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReader.swift
@@ -73,6 +73,13 @@ extension OTelPeriodicExportingMetricsReader: CustomStringConvertible, Service {
             logger.trace("Timer fired.", metadata: ["interval": "\(interval)"])
             await tick()
         }
+
+        logger.debug("Shutting down.")
+        // Unlike traces, force-flush is just a regular tick for metrics; no need for a different function.
+        await tick()
+        try await exporter.forceFlush()
+        await exporter.shutdown()
+        logger.debug("Shut down.")
     }
 }
 


### PR DESCRIPTION
## Motivation

During the implementation of the OTLP/HTTP exporters, I discovered a bug with the `OTelPeriodicExportingMetricsReader`: during graceful shutdown it did not perform a final read from the producer and export, as required by the spec[^1]. The desired behaviour is similar to what exists in the `BatchSpanProcessor`, which _does_ do this on graceful shutdown, and for which there is a test.

## Modifications

- Have `OTelPeriodicExportingMetricsReader` read and export on graceful shutdown
- Add a test that exercises graceful shutdown and checks for the expected number of `Producer.produce`, `Exporter.forceFlush`, and `Exporter.shutdown` calls

## Result

`OTelPeriodicExportingMetricsReader` performs a final read and export on graceful shutdown.

[^1]: https://opentelemetry.io/docs/specs/otel/metrics/sdk/
