### PR TITLE
Implement OTel.bootstrap API in terms of backend APIs

### DIFF
--- a/Sources/OTel/OTel+Bootstrap.swift
+++ b/Sources/OTel/OTel+Bootstrap.swift
@@ -44,7 +44,7 @@ extension OTel {
             try services.append(bootstrapTraces(configuration: configuration))
         }
 
-        return ServiceGroup(services: services, gracefulShutdownSignals: [.sigterm], logger: Logger(label: "OTelServiceGroup"))
+        return ServiceGroup(services: services, logger: Logger(label: "OTelServiceGroup"))
     }
 
     internal static func bootstrapTraces(configuration: OTel.Configuration) throws -> some Service {

--- a/Sources/OTel/OTel+Bootstrap.swift
+++ b/Sources/OTel/OTel+Bootstrap.swift
@@ -11,13 +11,57 @@
 //
 //===----------------------------------------------------------------------===//
 
+import class Foundation.ProcessInfo
+import Logging
+import Metrics
 import ServiceLifecycle
+import Tracing
+
+// MARK: - API
 
 extension OTel {
     public static func bootstrap(configuration: Configuration = .default) throws -> some Service {
-        throw NotImplementedError()
-        // The following placeholder code exists only to type check the opaque return type.
-        let service: ServiceGroup! = nil
-        return service
+        try Self.bootstrap(configuration: configuration, environment: ProcessInfo.processInfo.environment)
+    }
+}
+
+// MARK: - Internal
+
+extension OTel {
+    internal static func bootstrap(configuration: Configuration = .default, environment: [String: String]) throws -> some Service {
+        var configuration = configuration
+        configuration.applyEnvironmentOverrides(environment: environment)
+
+        var services: [Service] = []
+
+        if configuration.logs.enabled {
+            try services.append(bootstrapLogs(configuration: configuration))
+        }
+        if configuration.metrics.enabled {
+            try services.append(bootstrapMetrics(configuration: configuration))
+        }
+        if configuration.traces.enabled {
+            try services.append(bootstrapTraces(configuration: configuration))
+        }
+
+        return ServiceGroup(services: services, gracefulShutdownSignals: [.sigterm], logger: Logger(label: "OTelServiceGroup"))
+    }
+
+    internal static func bootstrapTraces(configuration: OTel.Configuration) throws -> some Service {
+        let backend = try makeTracingBackend(configuration: configuration)
+        InstrumentationSystem.bootstrap(backend.factory)
+        return backend.service
+    }
+
+    internal static func bootstrapMetrics(configuration: OTel.Configuration) throws -> some Service {
+        let backend = try makeMetricsBackend(configuration: configuration)
+        MetricsSystem.bootstrap(backend.factory)
+        return backend.service
+    }
+
+    internal static func bootstrapLogs(configuration: OTel.Configuration) throws -> some Service {
+        let backend = try makeLoggingBackend(configuration: configuration)
+        LoggingSystem.bootstrap(backend.factory)
+        return backend.service
     }
 }

--- a/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
+++ b/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
@@ -12,7 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 extension OTel.Configuration {
-    internal mutating func applyEnvironmentOverrides(environment: [String: String]) {
+    package mutating func applyEnvironmentOverrides(environment: [String: String]) {
         if let resourceAttributes = environment.getHeadersValue(.resourceAttributes) {
             // https://opentelemetry.io/docs/specs/otel/resource/sdk/#specifying-resource-information-via-an-environment-variable
             let incomingAttributes = Dictionary(resourceAttributes, uniquingKeysWith: { _, second in second })


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we're providing a simplified bootstrap API (#205). This is composed on top of the configuration and make backend APIs, all of which were stubbed out in #210. This PR implements the main, front-door API, `OTel.bootstrap(configuration:)` API in terms of the other APIs.

## Modifications

- Implement bootstrap APIs in terms of backend APIs

## Result

The bootstrap API is fully implemented, although it it still based on the backend APIs, which remain unimplemented.

## Notes

- The PRs to create the backends will follow.
- The PR to add API docs to this function will follow (since they will likely have more bike-shedding).