### PR TITLE
Implement OTel.makeMetricsBackend

### DIFF
--- a/Sources/OTel/OTel+Backends.swift
+++ b/Sources/OTel/OTel+Backends.swift
@@ -32,12 +32,37 @@ extension OTel {
         return (factory, service)
     }
 
-    public static func makeMetricsBackend(configuration: OTel.Configuration = .default) throws -> (factory: any CoreMetrics.MetricsFactory, service: some Service) {
-        throw NotImplementedError()
-        // The following placeholder code exists only to type check the opaque return type.
-        let factory: (any CoreMetrics.MetricsFactory)! = nil
-        let service: ServiceGroup! = nil
-        return (factory, service)
+    public static func makeMetricsBackend(configuration: OTel.Configuration = .default) throws -> (factory: any MetricsFactory, service: some Service) {
+        let resource = OTelResource(configuration: configuration)
+        let registry = OTelMetricRegistry()
+        let metricsExporter: OTelMetricExporter
+        switch configuration.metrics.exporter.backing {
+        case .otlp:
+            switch configuration.metrics.otlpExporter.protocol.backing {
+            case .grpc:
+                #if OTLPGRPC
+                    metricsExporter = try OTLPGRPCMetricExporter(configuration: configuration.metrics.otlpExporter)
+                #else // OTLPGRPC
+                    fatalError("Using the OTLP/GRPC exporter requires the `OTLPGRPC` trait enabled.")
+                #endif
+            case .httpProtobuf, .httpJSON:
+                #if OTLPHTTP
+                    metricsExporter = try OTLPHTTPMetricExporter(configuration: configuration.metrics.otlpExporter)
+                #else
+                    fatalError("Using the OTLP/HTTP + Protobuf exporter requires the `OTLPHTTP` trait enabled.")
+                #endif
+            }
+        case .console:
+            metricsExporter = OTelConsoleMetricExporter()
+        case .prometheus:
+            fatalError("Swift OTel does not support Prometheus exporter")
+        }
+
+        let readerConfig = OTelPeriodicExportingMetricsReaderConfiguration(configuration: configuration.metrics)
+
+        let reader = OTelPeriodicExportingMetricsReader(resource: resource, producer: registry, exporter: metricsExporter, configuration: readerConfig)
+
+        return (OTLPMetricsFactory(registry: registry), reader)
     }
 
     public static func makeTracingBackend(configuration: OTel.Configuration = .default) throws -> (factory: any Tracing.Tracer, service: some Service) {

--- a/Tests/OTelTests/OTelPublicAPITests.swift
+++ b/Tests/OTelTests/OTelPublicAPITests.swift
@@ -29,11 +29,8 @@ import Testing
         #expect((error as? CustomStringConvertible)?.description == "Not implemented")
     }
 
-    @Test func testMakeMetricsBackend() {
-        let error = #expect(throws: (any Error).self) {
-            try OTel.makeMetricsBackend()
-        }
-        #expect((error as? CustomStringConvertible)?.description == "Not implemented")
+    @Test func testMakeMetricsBackend() throws {
+        _ = try OTel.makeMetricsBackend()
     }
 
     @Test func testMakeTracingBackend() {


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we're providing APIs to make backends for the Swift observability APIs (#205). These were stubbed out in #210. This PR implements the `OTel.makeMetricsBackend(configuration:)` API.

## Modifications

- Implement bootstrap APIs in terms of backend APIs
- Update the test such that this is not expected to fail

## Result

The metrics backend can now be used via `OTel.makeMetricsBackend` or by `OTel.bootstrap`.

## Notes

- Related to #219.
- The PR to add API docs to this function will follow (since they will likely have more bike-shedding).
- There's an upcoming PR that will add end-to-end tests once this one and the tracing one land.
