### PR TITLE
Implement OTel.makeTracingBackend

### DIFF
--- a/Sources/OTel/OTel+Backends.swift
+++ b/Sources/OTel/OTel+Backends.swift
@@ -40,11 +40,60 @@ extension OTel {
         return (factory, service)
     }
 
-    public static func makeTracingBackend(configuration: OTel.Configuration = .default) throws -> (factory: any Tracing.Tracer, service: some Service) {
-        throw NotImplementedError()
-        // The following placeholder code exists only to type check the opaque return type.
-        let factory: (any Tracing.Tracer)! = nil
-        let service: ServiceGroup! = nil
-        return (factory, service)
+    public static func makeTracingBackend(configuration: OTel.Configuration = .default) throws -> (factory: any Tracer, service: some Service) {
+        /// This dance is necessary if we want to continue to return `some Service` (vs. returning `any Service`).
+        ///
+        /// This is also only necessary for tracing because the Tracer is generic over the processor, which, in turn, is
+        /// generic over the exporter. The metrics internals use an existential exporter.
+        ///
+        /// For now, in order to preserve the shape of both metrics and traces types, and because there's only a closed
+        /// set of types that are expressible by config, we'll return an enum wrapper as our opaque return type.
+        struct TracerWrapper: Service {
+            var wrapped: any Service
+            func run() async throws {
+                try await wrapped.run()
+            }
+        }
+
+        let resource = OTelResource(configuration: configuration)
+        switch configuration.traces.exporter.backing {
+        case .otlp:
+            switch configuration.traces.otlpExporter.protocol.backing {
+            case .grpc:
+                #if OTLPGRPC
+                    let exporter = try OTLPGRPCSpanExporter(configuration: configuration.traces.otlpExporter)
+                    let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(configuration: configuration.traces.batchSpanProcessor))
+                    let tracer = OTelTracer(
+                        idGenerator: OTelRandomIDGenerator(),
+                        sampler: OTelConstantSampler(isOn: true),
+                        propagator: OTelW3CPropagator(),
+                        processor: processor,
+                        environment: .detected(),
+                        resource: resource
+                    )
+                    return (tracer, TracerWrapper(wrapped: tracer))
+                #else // OTLPGRPC
+                    fatalError("Using the OTLP/GRPC exporter requires the `OTLPGRPC` trait enabled.")
+                #endif
+            case .httpProtobuf, .httpJSON:
+                #if OTLPHTTP
+                    let exporter = try OTLPHTTPSpanExporter(configuration: configuration.traces.otlpExporter)
+                    let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(configuration: configuration.traces.batchSpanProcessor))
+                    let tracer = OTelTracer(
+                        idGenerator: OTelRandomIDGenerator(),
+                        sampler: OTelConstantSampler(isOn: true),
+                        propagator: OTelW3CPropagator(),
+                        processor: processor,
+                        environment: .detected(),
+                        resource: resource
+                    )
+                    return (tracer, TracerWrapper(wrapped: tracer))
+                #else
+                    fatalError("Using the OTLP/HTTP + Protobuf exporter requires the `OTLPHTTP` trait enabled.")
+                #endif
+            }
+        case .console, .jaeger, .zipkin:
+            fatalError("not implementated")
+        }
     }
 }

--- a/Tests/OTelTests/OTelPublicAPITests.swift
+++ b/Tests/OTelTests/OTelPublicAPITests.swift
@@ -36,10 +36,7 @@ import Testing
         #expect((error as? CustomStringConvertible)?.description == "Not implemented")
     }
 
-    @Test func testMakeTracingBackend() {
-        let error = #expect(throws: (any Error).self) {
-            try OTel.makeTracingBackend()
-        }
-        #expect((error as? CustomStringConvertible)?.description == "Not implemented")
+    @Test func testMakeTracingBackend() throws {
+        _ = try OTel.makeTracingBackend()
     }
 }


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we're providing APIs to make backends for the Swift observability APIs (#205). These were stubbed out in #210. This PR implements the `OTel.makeTracingBackend(configuration:)` API.

## Modifications

- Implement `OTel.makeTracingBackend`
- Update the bootstrap test to no longer expect this to fail

## Result

The metrics backend can now be used via `OTel.makeTracingBackend` or by `OTel.bootstrap`.

## Notes

- Related to #219.
- The PR to add API docs to this function will follow (since they will likely have more bike-shedding).
- There's an upcoming PR that will add end-to-end tests once this one and the metrics one land.
