### PR TITLE
Add API docs to OTel.bootstrap

### DIFF
--- a/Sources/OTel/OTel+Bootstrap.swift
+++ b/Sources/OTel/OTel+Bootstrap.swift
@@ -33,7 +33,7 @@ extension OTel {
     /// - Returns: A service that manages the background work for the bootstrapped observability backends.
     ///
     ///   The returned service manages the complete lifecycle of all observability backends. It handles startup,
-    ///   background processing, and graceful shutdown of exporters and processors.  The service performs these
+    ///   background processing, and graceful shutdown of exporters and processors. The service performs these
     ///   operations.
     ///
     ///   > Important: You must run this service in a `ServiceGroup` alongside your application services for
@@ -76,8 +76,8 @@ extension OTel {
     /// To configure the behavior of the observability backends, first start with the default configuration and override
     /// the properties as required.
     ///
-    /// - Note: some of the values in this example are the default, but are explicitly set for illustrative purposes.
-    /// - Note: additional configuration will be applied from the environment variables defined in the OTel spec.
+    /// - Note: Some of the values in this example are the default, but are explicitly set for illustrative purposes.
+    /// - Note: Additional configuration will be applied from the environment variables defined in the OTel spec.
     ///
     /// ```swift
     /// // Start with defaults.


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we're providing a simplified bootstrap API (#205). This was implemented in #219 but the docs were deliberately deferred so we could take our time to get them polished, since this is the primary entry point for the library. This PR adds the API documentation to `OTel.bootstrap(configuration:)`.

## Modifications

- Add API docs to `OTel.bootstrap(configuration:)`

## Result

Good documentation available to adopters for the primary API of the library.