### PR TITLE
Ensure HTTP client is shutdown in OTLPHTTPExporter.deinit

### DIFF
--- a/Sources/OTLPHTTP/OTLPHTTPExporter.swift
+++ b/Sources/OTLPHTTP/OTLPHTTPExporter.swift
@@ -110,10 +110,6 @@ final class OTLPHTTPExporter<Request: Message, Response: Message>: Sendable {
     func shutdown() async {
         try? await self.httpClient.shutdown()
     }
-
-    func syncShutdown() throws {
-        try self.httpClient.syncShutdown()
-    }
 }
 
 enum OTLPHTTPExporterError: Swift.Error {

--- a/Tests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
+++ b/Tests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
@@ -35,7 +35,6 @@ import Tracing
                 config.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                 config.protocol = .httpProtobuf
                 let exporter = try OTLPHTTPSpanExporter(configuration: config)
-                defer { try? exporter.exporter.syncShutdown() }
                 let span = OTelFinishedSpan.stub()
                 await #expect(throws: Never.self) { try await exporter.export([span]) }
             }
@@ -73,7 +72,6 @@ import Tracing
                 config.protocol = .httpJSON
                 config.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                 let exporter = try OTLPHTTPSpanExporter(configuration: config)
-                defer { try? exporter.exporter.syncShutdown() }
                 let span = OTelFinishedSpan.stub()
                 await #expect(throws: Never.self) { try await exporter.export([span]) }
             }
@@ -111,7 +109,6 @@ import Tracing
                 config.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                 config.protocol = .httpProtobuf
                 let exporter = try OTLPHTTPMetricExporter(configuration: config)
-                defer { try? exporter.exporter.syncShutdown() }
                 await #expect(throws: Never.self) { try await exporter.export([OTelResourceMetrics(scopeMetrics: [])]) }
             }
 
@@ -148,7 +145,6 @@ import Tracing
                 config.protocol = .httpJSON
                 config.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                 let exporter = try OTLPHTTPMetricExporter(configuration: config)
-                defer { try? exporter.exporter.syncShutdown() }
                 await #expect(throws: Never.self) { try await exporter.export([OTelResourceMetrics(scopeMetrics: [])]) }
             }
 


### PR DESCRIPTION
## Motivation

In #218 we added the implementation for the OTLP/HTTP exporters. As part of the review we discussed the options for shutting down the HTTP client and opted to not use `deinit` and to provide a sync shutdown method that folks were expected to call in a defer block when creating an exporter. This turns out to not be adequate for all scenarios.

The usual flow for the OTLP/HTTP exporter is that its shutdown is handled by the object that holds the exporter. In some narrow scenarios, this type will have been created but the holding type not successfully created or started, e.g. when there is a misconfiguraiton. In these scenarios, the user should be presented with a clear error that they can debug. Having the application crash because HTTP client inside the exporter was not shutdown will worsen the experience.

## Modifications

- Shutdown the HTTP client in `OTLPHTTPExporter.deinit`.

## Results

More robust.