### PR TITLE
Factor out common parts of OTLP/gRPC exporters

### DIFF
--- a/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporter.swift
+++ b/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporter.swift
@@ -17,7 +17,7 @@ import NIOSSL
 import OTelCore
 import OTLPCore
 
-/// A span exporter emitting span batches to an OTel collector via gRPC.
+/// A metrics exporter emitting metric batches to an OTel collector via gRPC.
 package final class OTLPGRPCMetricExporter: OTelMetricExporter {
     typealias Client = Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceAsyncClient
     typealias Configuration = OTLPGRPCMetricExporterConfiguration

--- a/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporter.swift
+++ b/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporter.swift
@@ -11,101 +11,46 @@
 //
 //===----------------------------------------------------------------------===//
 
-import GRPC
 import Logging
 import NIO
-import NIOHPACK
 import NIOSSL
 import OTelCore
 import OTLPCore
 
-/// Exports metrics to an OTel collector using OTLP/gRPC.
+/// A span exporter emitting span batches to an OTel collector via gRPC.
 package final class OTLPGRPCMetricExporter: OTelMetricExporter {
-    private let configuration: OTLPGRPCMetricExporterConfiguration
-    private let connection: ClientConnection
-    private let client: Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceAsyncClient
-    private let logger = Logger(label: String(describing: OTLPGRPCMetricExporter.self))
+    typealias Client = Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceAsyncClient
+    typealias Configuration = OTLPGRPCMetricExporterConfiguration
+    private let client: OTLPGRPCExporter<Client, Configuration>
 
-    package convenience init(
-        configuration: OTLPGRPCMetricExporterConfiguration,
+    init(
+        configuration: Configuration,
         group: any EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         requestLogger: Logger = ._otelDisabled,
-        backgroundActivityLogger: Logger = ._otelDisabled
+        backgroundActivityLogger: Logger = ._otelDisabled,
+        trustRoots: NIOSSLTrustRoots = .default
     ) {
-        self.init(
+        client = OTLPGRPCExporter(
             configuration: configuration,
             group: group,
             requestLogger: requestLogger,
             backgroundActivityLogger: backgroundActivityLogger,
-            trustRoots: .default
-        )
-    }
-
-    init(
-        configuration: OTLPGRPCMetricExporterConfiguration,
-        group: any EventLoopGroup,
-        requestLogger: Logger,
-        backgroundActivityLogger: Logger,
-        trustRoots: NIOSSLTrustRoots
-    ) {
-        self.configuration = configuration
-
-        if configuration.endpoint.isInsecure {
-            logger.debug("Using insecure connection.", metadata: [
-                "host": "\(configuration.endpoint.host)",
-                "port": "\(configuration.endpoint.port)",
-            ])
-            connection = ClientConnection.insecure(group: group)
-                .withBackgroundActivityLogger(backgroundActivityLogger)
-                .connect(host: configuration.endpoint.host, port: configuration.endpoint.port)
-        } else {
-            logger.debug("Using secure connection.", metadata: [
-                "host": "\(configuration.endpoint.host)",
-                "port": "\(configuration.endpoint.port)",
-            ])
-            connection = ClientConnection
-                .usingPlatformAppropriateTLS(for: group)
-                .withTLS(trustRoots: trustRoots)
-                .withBackgroundActivityLogger(backgroundActivityLogger)
-                // TODO: Support OTEL_EXPORTER_OTLP_CERTIFICATE
-                // TODO: Support OTEL_EXPORTER_OTLP_CLIENT_KEY
-                // TODO: Support OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE
-                .connect(host: configuration.endpoint.host, port: configuration.endpoint.port)
-        }
-
-        var headers = configuration.headers
-        if !headers.isEmpty {
-            logger.trace("Configured custom request headers.", metadata: [
-                "keys": .array(headers.map { "\($0.name)" }),
-            ])
-        }
-        headers.replaceOrAdd(name: "user-agent", value: "OTel-OTLP-Exporter-Swift/\(OTelLibrary.version)")
-
-        client = Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceAsyncClient(
-            channel: connection,
-            defaultCallOptions: .init(customMetadata: headers, logger: requestLogger)
+            trustRoots: trustRoots
         )
     }
 
     package func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {
-        if case .shutdown = connection.connectivity.state {
-            logger.error("Attempted to export batch while already being shut down.")
-            throw OTelMetricExporterAlreadyShutDownError()
-        }
         let request = Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest.with { request in
             request.resourceMetrics = batch.map(Opentelemetry_Proto_Metrics_V1_ResourceMetrics.init)
         }
-
         _ = try await client.export(request)
     }
 
     package func forceFlush() async throws {
-        // This exporter is a "push exporter" and so the OTel spec says that force flush should do nothing.
+        try await client.forceFlush()
     }
 
     package func shutdown() async {
-        let promise = connection.eventLoop.makePromise(of: Void.self)
-        connection.closeGracefully(deadline: .now() + .milliseconds(500), promise: promise)
-        try? await promise.futureResult.get()
+        await client.shutdown()
     }
 }

--- a/Sources/OTLPGRPC/OTLPGRPCExporter.swift
+++ b/Sources/OTLPGRPC/OTLPGRPCExporter.swift
@@ -1,0 +1,140 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import GRPC
+import Logging
+import NIO
+import NIOHPACK
+import NIOSSL
+import OTelCore
+
+/// Unifying protocol for shared OTLP/gRPC exporter across signals.
+///
+/// NOTE: This is a temporary measure and this type will be overhauled as we migrate to gRPC Swift v2.
+protocol OTLPGRPCClient<Request, Response, Interceptors>: GRPCClient {
+    associatedtype Request
+    associatedtype Response
+    associatedtype Interceptors
+    func export(_ request: Request, callOptions: CallOptions?) async throws -> Response
+
+    init(
+        channel: GRPCChannel,
+        defaultCallOptions: CallOptions,
+        interceptors: Interceptors?
+    )
+}
+
+extension Opentelemetry_Proto_Collector_Trace_V1_TraceServiceAsyncClient: OTLPGRPCClient {}
+extension Opentelemetry_Proto_Collector_Metrics_V1_MetricsServiceAsyncClient: OTLPGRPCClient {}
+
+/// Unifying protocol for shared OTLP/gRPC exporter across signals.
+///
+/// NOTE: This is a temporary measure and this type will be overhauled as we move to using `OTel.Configuration`.
+protocol OTLPGRPCExporterConfiguration {
+    var endpoint: OTLPGRPCEndpoint { get }
+    var headers: HPACKHeaders { get }
+}
+
+extension OTLPGRPCSpanExporterConfiguration: OTLPGRPCExporterConfiguration {}
+extension OTLPGRPCMetricExporterConfiguration: OTLPGRPCExporterConfiguration {}
+
+final class OTLPGRPCExporter<Client: OTLPGRPCClient, Configuration: OTLPGRPCExporterConfiguration>: Sendable where Client: Sendable, Configuration: Sendable {
+    private let configuration: Configuration
+    private let connection: ClientConnection
+    private let client: Client
+    private let logger = Logger(label: "OTLPGRPCExporter")
+
+    convenience init(
+        configuration: Configuration,
+        group: any EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
+        requestLogger: Logger = ._otelDisabled,
+        backgroundActivityLogger: Logger = ._otelDisabled
+    ) {
+        self.init(
+            configuration: configuration,
+            group: group,
+            requestLogger: requestLogger,
+            backgroundActivityLogger: backgroundActivityLogger,
+            trustRoots: .default
+        )
+    }
+
+    init(
+        configuration: Configuration,
+        group: any EventLoopGroup,
+        requestLogger: Logger,
+        backgroundActivityLogger: Logger,
+        trustRoots: NIOSSLTrustRoots
+    ) {
+        self.configuration = configuration
+
+        if configuration.endpoint.isInsecure {
+            logger.debug("Using insecure connection.", metadata: [
+                "host": "\(configuration.endpoint.host)",
+                "port": "\(configuration.endpoint.port)",
+            ])
+            connection = ClientConnection.insecure(group: group)
+                .withBackgroundActivityLogger(backgroundActivityLogger)
+                .connect(host: configuration.endpoint.host, port: configuration.endpoint.port)
+        } else {
+            logger.debug("Using secure connection.", metadata: [
+                "host": "\(configuration.endpoint.host)",
+                "port": "\(configuration.endpoint.port)",
+            ])
+            connection = ClientConnection
+                .usingPlatformAppropriateTLS(for: group)
+                .withTLS(trustRoots: trustRoots)
+                .withBackgroundActivityLogger(backgroundActivityLogger)
+                // TODO: Support OTEL_EXPORTER_OTLP_CERTIFICATE
+                // TODO: Support OTEL_EXPORTER_OTLP_CLIENT_KEY
+                // TODO: Support OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE
+                .connect(host: configuration.endpoint.host, port: configuration.endpoint.port)
+        }
+
+        var headers = configuration.headers
+        if !headers.isEmpty {
+            logger.trace("Configured custom request headers.", metadata: [
+                "keys": .array(headers.map { "\($0.name)" }),
+            ])
+        }
+        headers.replaceOrAdd(name: "user-agent", value: "OTel-OTLP-Exporter-Swift/\(OTelLibrary.version)")
+
+        client = Client(
+            channel: connection,
+            defaultCallOptions: .init(customMetadata: headers, logger: requestLogger),
+            interceptors: nil
+        )
+    }
+
+    func export(_ request: Client.Request) async throws -> Client.Response {
+        if case .shutdown = connection.connectivity.state {
+            logger.error("Attempted to export while already being shut down.")
+            throw OTLPGRPCExporterError.exporterAlreadyShutDown
+        }
+        return try await client.export(request, callOptions: nil)
+    }
+
+    func forceFlush() async throws {
+        // This exporter is a "push exporter" and so the OTel spec says that force flush should do nothing.
+    }
+
+    func shutdown() async {
+        let promise = connection.eventLoop.makePromise(of: Void.self)
+        connection.closeGracefully(deadline: .now() + .milliseconds(500), promise: promise)
+        try? await promise.futureResult.get()
+    }
+}
+
+enum OTLPGRPCExporterError: Swift.Error {
+    case exporterAlreadyShutDown
+}

--- a/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporter.swift
+++ b/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporter.swift
@@ -11,97 +11,35 @@
 //
 //===----------------------------------------------------------------------===//
 
-import struct Foundation.URL
-import GRPC
 import Logging
 import NIO
-import NIOHPACK
 import NIOSSL
 import OTelCore
 import OTLPCore
-import Tracing
 
 /// A span exporter emitting span batches to an OTel collector via gRPC.
 package final class OTLPGRPCSpanExporter: OTelSpanExporter {
-    private let configuration: OTLPGRPCSpanExporterConfiguration
-    private let connection: ClientConnection
-    private let client: Opentelemetry_Proto_Collector_Trace_V1_TraceServiceAsyncClient
-    private let logger = Logger(label: String(describing: OTLPGRPCSpanExporter.self))
+    typealias Client = Opentelemetry_Proto_Collector_Trace_V1_TraceServiceAsyncClient
+    typealias Configuration = OTLPGRPCSpanExporterConfiguration
+    private let client: OTLPGRPCExporter<Client, Configuration>
 
-    /// Create an OTLP gRPC span exporter.
-    ///
-    /// - Parameters:
-    ///   - configuration: The exporters configuration.
-    ///   - group: The NIO event loop group to run the exporter in.
-    ///   - requestLogger: Logs info about the underlying gRPC requests. Defaults to disabled, i.e. not emitting any logs.
-    ///   - backgroundActivityLogger: Logs info about the underlying gRPC connection. Defaults to disabled, i.e. not emitting any logs.
-    package convenience init(
-        configuration: OTLPGRPCSpanExporterConfiguration,
+    init(
+        configuration: Configuration,
         group: any EventLoopGroup = MultiThreadedEventLoopGroup.singleton,
         requestLogger: Logger = ._otelDisabled,
-        backgroundActivityLogger: Logger = ._otelDisabled
+        backgroundActivityLogger: Logger = ._otelDisabled,
+        trustRoots: NIOSSLTrustRoots = .default
     ) {
-        self.init(
+        client = OTLPGRPCExporter(
             configuration: configuration,
             group: group,
             requestLogger: requestLogger,
             backgroundActivityLogger: backgroundActivityLogger,
-            trustRoots: .default
-        )
-    }
-
-    init(
-        configuration: OTLPGRPCSpanExporterConfiguration,
-        group: any EventLoopGroup,
-        requestLogger: Logger,
-        backgroundActivityLogger: Logger,
-        trustRoots: NIOSSLTrustRoots
-    ) {
-        self.configuration = configuration
-
-        if configuration.endpoint.isInsecure {
-            logger.debug("Using insecure connection.", metadata: [
-                "host": "\(configuration.endpoint.host)",
-                "port": "\(configuration.endpoint.port)",
-            ])
-            connection = ClientConnection.insecure(group: group)
-                .withBackgroundActivityLogger(backgroundActivityLogger)
-                .connect(host: configuration.endpoint.host, port: configuration.endpoint.port)
-        } else {
-            logger.debug("Using secure connection.", metadata: [
-                "host": "\(configuration.endpoint.host)",
-                "port": "\(configuration.endpoint.port)",
-            ])
-            connection = ClientConnection
-                .usingPlatformAppropriateTLS(for: group)
-                .withTLS(trustRoots: trustRoots)
-                .withBackgroundActivityLogger(backgroundActivityLogger)
-                // TODO: Support OTEL_EXPORTER_OTLP_CERTIFICATE
-                // TODO: Support OTEL_EXPORTER_OTLP_CLIENT_KEY
-                // TODO: Support OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE
-                .connect(host: configuration.endpoint.host, port: configuration.endpoint.port)
-        }
-
-        var headers = configuration.headers
-        if !headers.isEmpty {
-            logger.trace("Configured custom request headers.", metadata: [
-                "keys": .array(headers.map { "\($0.name)" }),
-            ])
-        }
-        headers.replaceOrAdd(name: "user-agent", value: "OTel-OTLP-Exporter-Swift/\(OTelLibrary.version)")
-
-        client = Opentelemetry_Proto_Collector_Trace_V1_TraceServiceAsyncClient(
-            channel: connection,
-            defaultCallOptions: .init(customMetadata: headers, logger: requestLogger)
+            trustRoots: trustRoots
         )
     }
 
     package func export(_ batch: some Collection<OTelFinishedSpan>) async throws {
-        if case .shutdown = connection.connectivity.state {
-            logger.error("Attempted to export batch while already being shut down.")
-            throw OTelSpanExporterAlreadyShutDownError()
-        }
-
         let request = Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest.with { request in
             request.resourceSpans = [Opentelemetry_Proto_Trace_V1_ResourceSpans(batch)]
         }
@@ -109,14 +47,11 @@ package final class OTLPGRPCSpanExporter: OTelSpanExporter {
         _ = try await client.export(request)
     }
 
-    /// ``OTLPGRPCSpanExporter`` sends batches of spans as soon as they are received, so this method is a no-op.
-    package func forceFlush() async throws {}
+    package func forceFlush() async throws {
+        try await client.forceFlush()
+    }
 
     package func shutdown() async {
-        let promise = connection.eventLoop.makePromise(of: Void.self)
-
-        connection.closeGracefully(deadline: .now() + .milliseconds(500), promise: promise)
-
-        try? await promise.futureResult.get()
+        await client.shutdown()
     }
 }

--- a/Tests/OTLPGRPCTests/Metrics/OTLPGRPCMetricExporterTests.swift
+++ b/Tests/OTLPGRPCTests/Metrics/OTLPGRPCMetricExporterTests.swift
@@ -176,7 +176,7 @@ final class OTLPGRPCMetricExporterTests: XCTestCase {
 
                 XCTFail("Expected exporter to throw error, successfully exported instead.")
             }
-        } catch is OTelMetricExporterAlreadyShutDownError {
+        } catch OTLPGRPCExporterError.exporterAlreadyShutDown {
             errorCaught.fulfill()
         }
         await fulfillment(of: [errorCaught], timeout: 0.0)

--- a/Tests/OTLPGRPCTests/Tracing/OTLPGRPCSpanExporterTests.swift
+++ b/Tests/OTLPGRPCTests/Tracing/OTLPGRPCSpanExporterTests.swift
@@ -146,7 +146,7 @@ final class OTLPGRPCSpanExporterTests: XCTestCase {
 
                 XCTFail("Expected exporter to throw error, successfully exported instead.")
             }
-        } catch is OTelSpanExporterAlreadyShutDownError {}
+        } catch OTLPGRPCExporterError.exporterAlreadyShutDown {}
     }
 
     func test_forceFlush() async throws {


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we're reworking the OTLP/gRPC exporters in a number of ways, including supporting mTLS, updating to gRPC Swift v2, and adding a logging exporter. To support this effort, we'd first like to unify the underlying exporter logic used by the OTLP/gRPC metrics and tracing exporters, which is currently duplicative.

## Modifications

- Factor out common parts of OTLP/gRPC exporters

## Result

We now have a single, shared place for the OTLP/gRPC exporter core logic, which will make it simpler to iterate on and extend to support logging.

## Notes

- This does not attempt to make any improvements to the logic, simply to move it into a shared place as an incremental step.