### PR TITLE
Add configuration API for the batch log record processor

### DIFF
--- a/Sources/OTelCore/OTel+Configuration+Environment.swift
+++ b/Sources/OTelCore/OTel+Configuration+Environment.swift
@@ -49,6 +49,10 @@ extension OTel.Configuration.Key.GeneralKey {
     static let batchSpanProcessorExportTimeout = Self(key: "OTEL_BSP_EXPORT_TIMEOUT")
     static let batchSpanProcessorMaxQueueSize = Self(key: "OTEL_BSP_MAX_QUEUE_SIZE")
     static let batchSpanProcessorExportBatchSize = Self(key: "OTEL_BSP_EXPORT_BATCH_SIZE")
+    static let batchLogRecordProcessorScheduleDelay = Self(key: "OTEL_BRLP_SCHEDULE_DELAY")
+    static let batchLogRecordProcessorExportTimeout = Self(key: "OTEL_BRLP_EXPORT_TIMEOUT")
+    static let batchLogRecordProcessorMaxQueueSize = Self(key: "OTEL_BRLP_MAX_QUEUE_SIZE")
+    static let batchLogRecordProcessorExportBatchSize = Self(key: "OTEL_BRLP_EXPORT_BATCH_SIZE")
 }
 
 extension OTel.Configuration.Key.SignalSpecificKey {

--- a/Sources/OTelCore/OTel+Configuration+Environment.swift
+++ b/Sources/OTelCore/OTel+Configuration+Environment.swift
@@ -49,10 +49,10 @@ extension OTel.Configuration.Key.GeneralKey {
     static let batchSpanProcessorExportTimeout = Self(key: "OTEL_BSP_EXPORT_TIMEOUT")
     static let batchSpanProcessorMaxQueueSize = Self(key: "OTEL_BSP_MAX_QUEUE_SIZE")
     static let batchSpanProcessorExportBatchSize = Self(key: "OTEL_BSP_EXPORT_BATCH_SIZE")
-    static let batchLogRecordProcessorScheduleDelay = Self(key: "OTEL_BRLP_SCHEDULE_DELAY")
-    static let batchLogRecordProcessorExportTimeout = Self(key: "OTEL_BRLP_EXPORT_TIMEOUT")
-    static let batchLogRecordProcessorMaxQueueSize = Self(key: "OTEL_BRLP_MAX_QUEUE_SIZE")
-    static let batchLogRecordProcessorExportBatchSize = Self(key: "OTEL_BRLP_EXPORT_BATCH_SIZE")
+    static let batchLogRecordProcessorScheduleDelay = Self(key: "OTEL_BLRP_SCHEDULE_DELAY")
+    static let batchLogRecordProcessorExportTimeout = Self(key: "OTEL_BLRP_EXPORT_TIMEOUT")
+    static let batchLogRecordProcessorMaxQueueSize = Self(key: "OTEL_BLRP_MAX_QUEUE_SIZE")
+    static let batchLogRecordProcessorExportBatchSize = Self(key: "OTEL_BLRP_EXPORT_BATCH_SIZE")
 }
 
 extension OTel.Configuration.Key.SignalSpecificKey {

--- a/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
+++ b/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
@@ -106,6 +106,7 @@ extension OTel.Configuration.MetricsConfiguration {
 
 extension OTel.Configuration.LogsConfiguration {
     internal mutating func applyEnvironmentOverrides(environment: [String: String]) {
+        batchLogRecordProcessor.applyEnvironmentOverrides(environment: environment)
         if let logsExporter = environment.getStringValue(.logsExporter) {
             switch logsExporter {
             case "none":
@@ -134,6 +135,23 @@ extension OTel.Configuration.TracesConfiguration.BatchSpanProcessorConfiguration
             self.maxQueueSize = maxQueueSize
         }
         if let exportBatchSize = environment.getIntegerValue(.batchSpanProcessorExportBatchSize) {
+            maxExportBatchSize = exportBatchSize
+        }
+    }
+}
+
+extension OTel.Configuration.LogsConfiguration.BatchLogRecordProcessorConfiguration {
+    internal mutating func applyEnvironmentOverrides(environment: [String: String]) {
+        if let scheduleDelay = environment.getDurationValue(.batchLogRecordProcessorScheduleDelay) {
+            self.scheduleDelay = scheduleDelay
+        }
+        if let exportTimeout = environment.getTimeoutValue(.batchLogRecordProcessorExportTimeout) {
+            self.exportTimeout = exportTimeout
+        }
+        if let maxQueueSize = environment.getIntegerValue(.batchLogRecordProcessorMaxQueueSize) {
+            self.maxQueueSize = maxQueueSize
+        }
+        if let exportBatchSize = environment.getIntegerValue(.batchLogRecordProcessorExportBatchSize) {
             maxExportBatchSize = exportBatchSize
         }
     }

--- a/Sources/OTelCore/OTel+Configuration.swift
+++ b/Sources/OTelCore/OTel+Configuration.swift
@@ -337,6 +337,11 @@ extension OTel.Configuration {
         /// - Default value: `true`.
         public var enabled: Bool
 
+        /// Configuration for the batch log record processor.
+        ///
+        /// - Default value: `.default`.
+        public var batchLogRecordProcessor: BatchLogRecordProcessorConfiguration
+
         /// Selection of logs exporter implementation.
         ///
         /// - Environment variable(s): `OTEL_LOGS_EXPORTER`.
@@ -354,6 +359,7 @@ extension OTel.Configuration {
         /// where possible.
         public static let `default`: Self = .init(
             enabled: true,
+            batchLogRecordProcessor: .default,
             exporter: .otlp,
             otlpExporter: .default
         )
@@ -474,6 +480,51 @@ extension OTel.Configuration.LogsConfiguration {
 
         /// Console exporter for logs (development/debugging).
         public static let console: Self = .init(backing: .console)
+    }
+}
+
+extension OTel.Configuration.LogsConfiguration {
+    /// Configuration for the batch log record processor.
+    ///
+    /// The batch processor collects log records in memory and exports them in batches to improve
+    /// performance and reduce network overhead.
+    public struct BatchLogRecordProcessorConfiguration: Sendable {
+        /// Maximum time to wait before triggering an export.
+        ///
+        /// - Environment variable(s): `OTEL_BRLP_SCHEDULE_DELAY`.
+        /// - Default value: 1 seconds.
+        public var scheduleDelay: Duration
+
+        /// Maximum time to wait for each export operation.
+        ///
+        /// - Environment variable(s): `OTEL_BRLP_EXPORT_TIMEOUT`.
+        /// - Default value: 30 seconds.
+        public var exportTimeout: Duration
+
+        /// Maximum number of log records to keep in the queue.
+        ///
+        /// After the size is reached logs are dropped.
+        ///
+        /// - Environment variable(s): `OTEL_BRLP_MAX_QUEUE_SIZE`.
+        /// - Default value: 2048.
+        public var maxQueueSize: Int
+
+        /// Maximum number of log records to export in a single batch.
+        ///
+        /// - Environment variable(s): `OTEL_BRLP_MAX_EXPORT_BATCH_SIZE`.
+        /// - Default value: 512.
+        public var maxExportBatchSize: Int
+
+        /// Default batch span processor configuration.
+        ///
+        /// See individual property documentation for specific default values, which respect the OTel specification
+        /// where possible.
+        public static let `default`: Self = .init(
+            scheduleDelay: .seconds(1),
+            exportTimeout: .seconds(30),
+            maxQueueSize: 2048,
+            maxExportBatchSize: 512
+        )
     }
 }
 

--- a/Sources/OTelCore/OTel+Configuration.swift
+++ b/Sources/OTelCore/OTel+Configuration.swift
@@ -491,13 +491,13 @@ extension OTel.Configuration.LogsConfiguration {
     public struct BatchLogRecordProcessorConfiguration: Sendable {
         /// Maximum time to wait before triggering an export.
         ///
-        /// - Environment variable(s): `OTEL_BRLP_SCHEDULE_DELAY`.
-        /// - Default value: 1 seconds.
+        /// - Environment variable(s): `OTEL_BLRP_SCHEDULE_DELAY`.
+        /// - Default value: 1 second.
         public var scheduleDelay: Duration
 
         /// Maximum time to wait for each export operation.
         ///
-        /// - Environment variable(s): `OTEL_BRLP_EXPORT_TIMEOUT`.
+        /// - Environment variable(s): `OTEL_BLRP_EXPORT_TIMEOUT`.
         /// - Default value: 30 seconds.
         public var exportTimeout: Duration
 
@@ -505,13 +505,13 @@ extension OTel.Configuration.LogsConfiguration {
         ///
         /// After the size is reached logs are dropped.
         ///
-        /// - Environment variable(s): `OTEL_BRLP_MAX_QUEUE_SIZE`.
+        /// - Environment variable(s): `OTEL_BLRP_MAX_QUEUE_SIZE`.
         /// - Default value: 2048.
         public var maxQueueSize: Int
 
         /// Maximum number of log records to export in a single batch.
         ///
-        /// - Environment variable(s): `OTEL_BRLP_MAX_EXPORT_BATCH_SIZE`.
+        /// - Environment variable(s): `OTEL_BLRP_MAX_EXPORT_BATCH_SIZE`.
         /// - Default value: 512.
         public var maxExportBatchSize: Int
 

--- a/Sources/OTelCore/OTelCore+ConfigurationShims.swift
+++ b/Sources/OTelCore/OTelCore+ConfigurationShims.swift
@@ -20,6 +20,18 @@ extension OTelResource {
     }
 }
 
+extension OTelBatchLogRecordProcessorConfiguration {
+    package init(configuration: OTel.Configuration.LogsConfiguration.BatchLogRecordProcessorConfiguration) {
+        self.init(
+            environment: [:],
+            maximumQueueSize: UInt(configuration.maxQueueSize),
+            scheduleDelay: configuration.scheduleDelay,
+            maximumExportBatchSize: UInt(configuration.maxExportBatchSize),
+            exportTimeout: configuration.exportTimeout
+        )
+    }
+}
+
 extension OTelPeriodicExportingMetricsReaderConfiguration {
     package init(configuration: OTel.Configuration.MetricsConfiguration) {
         self.init(


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we're adding support for a logging backend. The `OTelBatchLogRecordProcessor` was already implemented some time back, but we held off adding the exporter, pending the expected work for the 1.0 overhaul.

This PR is the first that starts to consolidate the logging work and provide a functioning backend. It adds the additional configuration datamodel needed to configure the batch log record processor according to the OTel spec.

## Modifications

- Add configuration API for the batch log record processor
 
## Result

Configuration for the logging backend can now be expressed as part of the `OTel.Configuration` object.