### PR TITLE
Implement the OTLP/HTTP log exporter

### DIFF
--- a/Sources/OTLPCore/Logging/OTelLogRecord+Proto.swift
+++ b/Sources/OTLPCore/Logging/OTelLogRecord+Proto.swift
@@ -1,0 +1,109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2024 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import OTelCore
+
+extension Opentelemetry_Proto_Logs_V1_LogRecord {
+    package init(_ logRecord: OTelLogRecord) {
+        timeUnixNano = logRecord.timeNanosecondsSinceEpoch
+        observedTimeUnixNano = logRecord.timeNanosecondsSinceEpoch
+
+        severityNumber = .init(logRecord.level)
+        severityText = String(describing: logRecord.level)
+
+        body = .init(logRecord.body.description)
+
+        attributes = .init(logRecord.metadata)
+        droppedAttributesCount = 0 // TODO: do we need this?
+
+        flags = 0 // TODO: do we need this?
+
+        if let spanContext = logRecord.spanContext {
+            traceID = spanContext.traceID.data
+            spanID = spanContext.spanID.data
+        }
+    }
+}
+
+extension Opentelemetry_Proto_Logs_V1_SeverityNumber {
+    init(_ level: Logger.Level) {
+        // https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber
+        switch level {
+        case .trace: self = .trace
+        case .debug: self = .debug
+        case .info: self = .info
+        case .notice: self = .info2
+        case .warning: self = .warn
+        case .error: self = .error
+        case .critical: self = .error2
+        }
+    }
+}
+
+extension [Opentelemetry_Proto_Common_V1_KeyValue] {
+    init(_ metadata: Logger.Metadata) {
+        self.init()
+        reserveCapacity(metadata.count)
+        for (key, value) in metadata {
+            let attribute = Opentelemetry_Proto_Common_V1_KeyValue.with {
+                $0.key = key
+                $0.value = .init(value)
+            }
+            append(attribute)
+        }
+    }
+}
+
+extension Opentelemetry_Proto_Common_V1_KeyValueList {
+    init(_ metadata: Logger.Metadata) {
+        values = [Opentelemetry_Proto_Common_V1_KeyValue](metadata)
+    }
+}
+
+extension Opentelemetry_Proto_Common_V1_AnyValue {
+    init(_ metadataValue: Logger.MetadataValue) {
+        switch metadataValue {
+        case .string(let string):
+            stringValue = string
+        case .stringConvertible(let stringConvertible):
+            stringValue = stringConvertible.description
+        case .dictionary(let metadata):
+            kvlistValue = Opentelemetry_Proto_Common_V1_KeyValueList(metadata)
+        case .array(let array):
+            arrayValue = .with {
+                $0.values = array.map { metadataValue in Opentelemetry_Proto_Common_V1_AnyValue(metadataValue) }
+            }
+        }
+    }
+}
+
+extension Opentelemetry_Proto_Logs_V1_ResourceLogs {
+    package init(_ logRecords: some Collection<OTelLogRecord>) {
+        if let resource = logRecords.first?.resource {
+            self.resource = .init(resource)
+        }
+
+        scopeLogs = [Opentelemetry_Proto_Logs_V1_ScopeLogs.with {
+            $0.scope = .swiftOTelScope
+            $0.logRecords = logRecords.map(Opentelemetry_Proto_Logs_V1_LogRecord.init)
+        }]
+    }
+}
+
+extension Opentelemetry_Proto_Common_V1_InstrumentationScope {
+    fileprivate static let swiftOTelScope = Opentelemetry_Proto_Common_V1_InstrumentationScope.with {
+        $0.name = "swift-otel"
+        $0.version = OTelLibrary.version
+    }
+}

--- a/Sources/OTLPHTTP/OTLPHTTPLogRecordExporter.swift
+++ b/Sources/OTLPHTTP/OTLPHTTPLogRecordExporter.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import OTelCore
+import OTLPCore
+
+package final class OTLPHTTPLogRecordExporter: OTelLogRecordExporter {
+    typealias Request = Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest
+    typealias Response = Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse
+    let exporter: OTLPHTTPExporter<Request, Response>
+    private let logger = Logger(label: String(describing: OTLPHTTPLogRecordExporter.self))
+
+    package init(configuration: OTel.Configuration.OTLPExporterConfiguration) throws {
+        exporter = try OTLPHTTPExporter(configuration: configuration)
+    }
+
+    package func export(_ batch: some Collection<OTelLogRecord> & Sendable) async throws {
+        let proto = Request.with { request in
+            request.resourceLogs = [Opentelemetry_Proto_Logs_V1_ResourceLogs(batch)]
+        }
+        let response = try await exporter.send(proto)
+        if response.hasPartialSuccess {
+            // https://opentelemetry.io/docs/specs/otlp/#partial-success-1
+            logger.warning("Partial success", metadata: ["message": .string(response.partialSuccess.errorMessage)])
+        }
+    }
+
+    package func forceFlush() async throws {
+        try await exporter.forceFlush()
+    }
+
+    package func shutdown() async {
+        await exporter.shutdown()
+    }
+}

--- a/Tests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
+++ b/Tests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
@@ -169,4 +169,88 @@ import Tracing
             try await group.waitForAll()
         }
     }
+
+    @Test func testOTLPHTTPLogRecordExporterProtobuf() async throws {
+        try await withThrowingTaskGroup { group in
+            let testServer = NIOHTTP1TestServer(group: .singletonMultiThreadedEventLoopGroup)
+            defer { #expect(throws: Never.self) { try testServer.stop() } }
+
+            // Client
+            group.addTask {
+                var config = OTel.Configuration.OTLPExporterConfiguration.default
+                config.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
+                config.protocol = .httpProtobuf
+                let exporter = try OTLPHTTPLogRecordExporter(configuration: config)
+                try await exporter.export([OTelLogRecord(body: "Hello", level: .trace, metadata: ["foo": "bar"], timeNanosecondsSinceEpoch: 1234, resource: OTelResource(), spanContext: nil)])
+                await exporter.shutdown()
+            }
+
+            try testServer.receiveHeadAndVerify { head in
+                #expect(head.method == .POST)
+                #expect(head.uri == "/some/path")
+                #expect(head.headers["Content-Type"] == ["application/x-protobuf"])
+            }
+            try testServer.receiveBodyAndVerify { body in
+                let message = try Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest(serializedBytes: Data(buffer: body))
+                #expect(message.resourceLogs.count == 1)
+                #expect(message.resourceLogs.first?.scopeLogs.count == 1)
+                #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.count == 1)
+                #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.body == .init("Hello"))
+                #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.attributes.first { $0.key == "foo" }?.value == .init("bar"))
+                #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.timeUnixNano == 1234)
+            }
+            try testServer.receiveEndAndVerify { trailers in
+                #expect(trailers == nil)
+            }
+
+            try testServer.writeOutbound(.head(.init(version: .http1_1, status: .ok, headers: ["Content-Type": "application/x-protobuf"])))
+            let response = Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse()
+            try testServer.writeOutbound(.body(.byteBuffer(.init(data: response.serializedData()))))
+            try testServer.writeOutbound(.end(nil))
+
+            try await group.waitForAll()
+        }
+    }
+
+    @Test func testOTLPHTTPLogRecordExporterJSON() async throws {
+        try await withThrowingTaskGroup { group in
+            let testServer = NIOHTTP1TestServer(group: .singletonMultiThreadedEventLoopGroup)
+            defer { #expect(throws: Never.self) { try testServer.stop() } }
+
+            // Client
+            group.addTask {
+                var config = OTel.Configuration.OTLPExporterConfiguration.default
+                config.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
+                config.protocol = .httpJSON
+                let exporter = try OTLPHTTPLogRecordExporter(configuration: config)
+                try await exporter.export([OTelLogRecord(body: "Hello", level: .trace, metadata: ["foo": "bar"], timeNanosecondsSinceEpoch: 1234, resource: OTelResource(), spanContext: nil)])
+                await exporter.shutdown()
+            }
+
+            try testServer.receiveHeadAndVerify { head in
+                #expect(head.method == .POST)
+                #expect(head.uri == "/some/path")
+                #expect(head.headers["Content-Type"] == ["application/json"])
+            }
+            try testServer.receiveBodyAndVerify { body in
+                let message = try Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest(jsonUTF8Bytes: Data(buffer: body))
+                #expect(message.resourceLogs.count == 1)
+                #expect(message.resourceLogs.first?.scopeLogs.count == 1)
+                #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.count == 1)
+                #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.body == .init("Hello"))
+                #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.attributes.first { $0.key == "foo" }?.value == .init("bar"))
+                #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.timeUnixNano == 1234)
+            }
+            try testServer.receiveEndAndVerify { trailers in
+                #expect(trailers == nil)
+            }
+
+            try testServer.writeOutbound(.head(.init(version: .http1_1, status: .ok, headers: ["Content-Type": "application/json"])))
+            let response = Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse()
+            try testServer.writeOutbound(.body(.byteBuffer(.init(data: response.jsonUTF8Data()))))
+            try testServer.writeOutbound(.end(nil))
+
+            try await group.waitForAll()
+        }
+    }
 }


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we're adding support for a logging backend. The `OTelBatchLogRecordProcessor` was already implemented some time back, but we held off adding the exporter, pending the expected work for the 1.0 overhaul.

This PR adds the OTLP/HTTP logging exporter.

## Modifications

- Implement the OTLP/HTTP log exporter
 
## Result

OTLP/HTTP exporter exists for logging backend.