### PR TITLE
[CI] Add 6.2-snapshot to unit tests matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["latest"]
+        swift: ["latest", "6.2-snapshot"]
 
     steps:
       - name: Install Swift


### PR DESCRIPTION
We started adding Swift Testing exit tests to the project to test global bootstrapping of the observability backends. However, these tests can only run on Swift 6.2+. We decided to conditionally compile them for now and add Swift 6.2 to the unit test matrix to already start exercising them on the CI.