### PR TITLE
Update SwiftFormat rules to not indent conditional compilation blocks

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -9,6 +9,7 @@
 
 --extensionacl on-declarations
 --indent 4
+--ifdef no-indent
 --patternlet inline
 --stripunusedargs closure-only
 --wraparguments before-first

--- a/Sources/OTel/OTel+Backends.swift
+++ b/Sources/OTel/OTel+Backends.swift
@@ -17,10 +17,10 @@ import OTelCore
 import ServiceLifecycle
 import Tracing
 #if OTLPGRPC
-    import OTLPGRPC
+import OTLPGRPC
 #endif
 #if OTLPHTTP
-    import OTLPHTTP
+import OTLPHTTP
 #endif
 
 extension OTel {
@@ -41,15 +41,15 @@ extension OTel {
             switch configuration.metrics.otlpExporter.protocol.backing {
             case .grpc:
                 #if OTLPGRPC
-                    metricsExporter = try OTLPGRPCMetricExporter(configuration: configuration.metrics.otlpExporter)
+                metricsExporter = try OTLPGRPCMetricExporter(configuration: configuration.metrics.otlpExporter)
                 #else // OTLPGRPC
-                    fatalError("Using the OTLP/GRPC exporter requires the `OTLPGRPC` trait enabled.")
+                fatalError("Using the OTLP/GRPC exporter requires the `OTLPGRPC` trait enabled.")
                 #endif
             case .httpProtobuf, .httpJSON:
                 #if OTLPHTTP
-                    metricsExporter = try OTLPHTTPMetricExporter(configuration: configuration.metrics.otlpExporter)
+                metricsExporter = try OTLPHTTPMetricExporter(configuration: configuration.metrics.otlpExporter)
                 #else
-                    fatalError("Using the OTLP/HTTP + Protobuf exporter requires the `OTLPHTTP` trait enabled.")
+                fatalError("Using the OTLP/HTTP + Protobuf exporter requires the `OTLPHTTP` trait enabled.")
                 #endif
             }
         case .console:
@@ -86,35 +86,35 @@ extension OTel {
             switch configuration.traces.otlpExporter.protocol.backing {
             case .grpc:
                 #if OTLPGRPC
-                    let exporter = try OTLPGRPCSpanExporter(configuration: configuration.traces.otlpExporter)
-                    let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(configuration: configuration.traces.batchSpanProcessor))
-                    let tracer = OTelTracer(
-                        idGenerator: OTelRandomIDGenerator(),
-                        sampler: OTelConstantSampler(isOn: true),
-                        propagator: OTelW3CPropagator(),
-                        processor: processor,
-                        environment: .detected(),
-                        resource: resource
-                    )
-                    return (tracer, TracerWrapper(wrapped: tracer))
+                let exporter = try OTLPGRPCSpanExporter(configuration: configuration.traces.otlpExporter)
+                let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(configuration: configuration.traces.batchSpanProcessor))
+                let tracer = OTelTracer(
+                    idGenerator: OTelRandomIDGenerator(),
+                    sampler: OTelConstantSampler(isOn: true),
+                    propagator: OTelW3CPropagator(),
+                    processor: processor,
+                    environment: .detected(),
+                    resource: resource
+                )
+                return (tracer, TracerWrapper(wrapped: tracer))
                 #else // OTLPGRPC
-                    fatalError("Using the OTLP/GRPC exporter requires the `OTLPGRPC` trait enabled.")
+                fatalError("Using the OTLP/GRPC exporter requires the `OTLPGRPC` trait enabled.")
                 #endif
             case .httpProtobuf, .httpJSON:
                 #if OTLPHTTP
-                    let exporter = try OTLPHTTPSpanExporter(configuration: configuration.traces.otlpExporter)
-                    let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(configuration: configuration.traces.batchSpanProcessor))
-                    let tracer = OTelTracer(
-                        idGenerator: OTelRandomIDGenerator(),
-                        sampler: OTelConstantSampler(isOn: true),
-                        propagator: OTelW3CPropagator(),
-                        processor: processor,
-                        environment: .detected(),
-                        resource: resource
-                    )
-                    return (tracer, TracerWrapper(wrapped: tracer))
+                let exporter = try OTLPHTTPSpanExporter(configuration: configuration.traces.otlpExporter)
+                let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(configuration: configuration.traces.batchSpanProcessor))
+                let tracer = OTelTracer(
+                    idGenerator: OTelRandomIDGenerator(),
+                    sampler: OTelConstantSampler(isOn: true),
+                    propagator: OTelW3CPropagator(),
+                    processor: processor,
+                    environment: .detected(),
+                    resource: resource
+                )
+                return (tracer, TracerWrapper(wrapped: tracer))
                 #else
-                    fatalError("Using the OTLP/HTTP + Protobuf exporter requires the `OTLPHTTP` trait enabled.")
+                fatalError("Using the OTLP/HTTP + Protobuf exporter requires the `OTLPHTTP` trait enabled.")
                 #endif
             }
         case .console, .jaeger, .zipkin:

--- a/Sources/OTelCore/Configuration/OTelEnvironment.swift
+++ b/Sources/OTelCore/Configuration/OTelEnvironment.swift
@@ -12,11 +12,11 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Glibc)
-    import Glibc
+import Glibc
 #elseif canImport(Musl)
-    import Musl
+import Musl
 #else
-    import Darwin.C
+import Darwin.C
 #endif
 
 import Foundation

--- a/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
+++ b/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
@@ -145,27 +145,27 @@ extension OTel.Configuration.OTLPExporterConfiguration {
             switch `protocol` {
             case "http/json":
                 #if OTLPHTTP
-                    self.protocol = .httpJSON
+                self.protocol = .httpJSON
                 #else // OTLPHTTP
-                    fatalError("Using the OTLP/HTTP + JSON exporter requires the `OTLPHTTP` trait enabled.")
+                fatalError("Using the OTLP/HTTP + JSON exporter requires the `OTLPHTTP` trait enabled.")
                 #endif
             case "grpc":
                 #if OTLPGRPC
-                    self.protocol = .grpc
+                self.protocol = .grpc
                 #else // OTLPGRPC
-                    fatalError("Using the OTLP/GRPC exporter requires the `OTLPGRPC` trait enabled.")
+                fatalError("Using the OTLP/GRPC exporter requires the `OTLPGRPC` trait enabled.")
                 #endif
             case "http/protobuf":
                 #if OTLPHTTP
-                    self.protocol = .httpProtobuf
+                self.protocol = .httpProtobuf
                 #else // OTLPHTTP
-                    fatalError("Using the OTLP/HTTP + Protobuf exporter requires the `OTLPHTTP` trait enabled.")
+                fatalError("Using the OTLP/HTTP + Protobuf exporter requires the `OTLPHTTP` trait enabled.")
                 #endif
             default:
                 #if OTLPHTTP
-                    self.protocol = .httpProtobuf
+                self.protocol = .httpProtobuf
                 #else // OTLPHTTP
-                    fatalError("Using the OTLP/HTTP + Protobuf exporter requires the `OTLPHTTP` trait enabled.")
+                fatalError("Using the OTLP/HTTP + Protobuf exporter requires the `OTLPHTTP` trait enabled.")
                 #endif
             }
         }

--- a/Sources/OTelCore/OTel+Configuration.swift
+++ b/Sources/OTelCore/OTel+Configuration.swift
@@ -669,27 +669,21 @@ extension OTel.Configuration.OTLPExporterConfiguration {
         package var backing: Backing
 
         /// gRPC transport protocol for OTLP.
-        // swiftformat:disable indent
         #if !OTLPGRPC
         @available(*, unavailable, message: "Using the OTLP/gRPC exporter requires the `OTLPGRPC` trait enabled.")
         #endif
-        // swiftformat:enable indent
         public static let grpc: Self = .init(backing: .grpc)
 
         /// HTTP transport with Protocol Buffers encoding for OTLP.
-        // swiftformat:disable indent
         #if !OTLPHTTP
         @available(*, unavailable, message: "Using the OTLP/HTTP exporter requires the `OTLPHTTP` trait enabled.")
         #endif
-        // swiftformat:enable indent
         public static let httpProtobuf: Self = .init(backing: .httpProtobuf)
 
         /// HTTP transport with JSON encoding for OTLP.
-        // swiftformat:disable indent
         #if !OTLPHTTP
         @available(*, unavailable, message: "Using the OTLP/HTTP exporter requires the `OTLPHTTP` trait enabled.")
         #endif
-        // swiftformat:enable indent
         public static let httpJSON: Self = .init(backing: .httpJSON)
     }
 }

--- a/Sources/OTelCore/Resource/OTelProcessResourceDetector.swift
+++ b/Sources/OTelCore/Resource/OTelProcessResourceDetector.swift
@@ -36,9 +36,9 @@ package struct OTelProcessResourceDetector: OTelResourceDetector, CustomStringCo
             commandLine: { ProcessInfo.processInfo.arguments.joined(separator: " ") },
             owner: {
                 #if os(macOS) || os(Linux)
-                    return ProcessInfo.processInfo.userName
+                return ProcessInfo.processInfo.userName
                 #else
-                    return nil
+                return nil
                 #endif
             }
         )

--- a/Sources/OTelTesting/Metrics+TestHelpers.swift
+++ b/Sources/OTelTesting/Metrics+TestHelpers.swift
@@ -12,104 +12,104 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(XCTest)
-    @testable import OTelCore
-    import XCTest
+@testable import OTelCore
+import XCTest
 
-    extension Counter {
-        package var atomicValue: Int64 { atomic.load(ordering: .relaxed) }
+extension Counter {
+    package var atomicValue: Int64 { atomic.load(ordering: .relaxed) }
+}
+
+extension FloatingPointCounter {
+    package var atomicValue: Double { Double(bitPattern: atomic.load(ordering: .relaxed)) }
+}
+
+extension Gauge {
+    package var atomicValue: Double { Double(bitPattern: atomic.load(ordering: .relaxed)) }
+}
+
+extension Histogram {
+    private struct EquatableBucket: Equatable {
+        var bound: Value
+        var count: Int
     }
 
-    extension FloatingPointCounter {
-        package var atomicValue: Double { Double(bitPattern: atomic.load(ordering: .relaxed)) }
+    package func assertStateEquals(
+        count: Int,
+        sum: Value,
+        buckets: [(bound: Value, count: Int)],
+        countAboveUpperBound: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let state = box.withLockedValue { $0 }
+        XCTAssertEqual(state.count, count, "Unexpected count", file: file, line: line)
+        XCTAssertEqual(state.sum, sum, "Unexpected sum", file: file, line: line)
+        XCTAssertEqual(
+            state.buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
+            buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
+            "Unexpected buckets",
+            file: file, line: line
+        )
+        XCTAssertEqual(state.countAboveUpperBound, countAboveUpperBound, "Unexpected countAboveUpperBound", file: file, line: line)
+    }
+}
+
+extension OTelMetricPoint.OTelMetricData {
+    package var asSum: OTelSum? {
+        guard case .sum(let sum) = self.data else { return nil }
+        return sum
     }
 
-    extension Gauge {
-        package var atomicValue: Double { Double(bitPattern: atomic.load(ordering: .relaxed)) }
+    package var asGauge: OTelGauge? {
+        guard case .gauge(let gauge) = self.data else { return nil }
+        return gauge
     }
 
-    extension Histogram {
-        private struct EquatableBucket: Equatable {
-            var bound: Value
-            var count: Int
-        }
-
-        package func assertStateEquals(
-            count: Int,
-            sum: Value,
-            buckets: [(bound: Value, count: Int)],
-            countAboveUpperBound: Int,
-            file: StaticString = #filePath,
-            line: UInt = #line
-        ) {
-            let state = box.withLockedValue { $0 }
-            XCTAssertEqual(state.count, count, "Unexpected count", file: file, line: line)
-            XCTAssertEqual(state.sum, sum, "Unexpected sum", file: file, line: line)
-            XCTAssertEqual(
-                state.buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
-                buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
-                "Unexpected buckets",
-                file: file, line: line
-            )
-            XCTAssertEqual(state.countAboveUpperBound, countAboveUpperBound, "Unexpected countAboveUpperBound", file: file, line: line)
-        }
+    package var asHistogram: OTelHistogram? {
+        guard case .histogram(let histogram) = self.data else { return nil }
+        return histogram
     }
 
-    extension OTelMetricPoint.OTelMetricData {
-        package var asSum: OTelSum? {
-            guard case .sum(let sum) = self.data else { return nil }
-            return sum
+    package func assertIsCumulativeSumWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #filePath, line: UInt = #line) {
+        guard
+            case .sum(let sum) = data,
+            sum.monotonic,
+            sum.aggregationTemporality == .cumulative,
+            sum.points.count == 1,
+            let point = sum.points.first
+        else {
+            XCTFail("Not cumulative sum with one point: \(self)", file: file, line: line)
+            return
         }
-
-        package var asGauge: OTelGauge? {
-            guard case .gauge(let gauge) = self.data else { return nil }
-            return gauge
-        }
-
-        package var asHistogram: OTelHistogram? {
-            guard case .histogram(let histogram) = self.data else { return nil }
-            return histogram
-        }
-
-        package func assertIsCumulativeSumWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #filePath, line: UInt = #line) {
-            guard
-                case .sum(let sum) = data,
-                sum.monotonic,
-                sum.aggregationTemporality == .cumulative,
-                sum.points.count == 1,
-                let point = sum.points.first
-            else {
-                XCTFail("Not cumulative sum with one point: \(self)", file: file, line: line)
-                return
-            }
-            XCTAssertEqual(point.value, value, file: file, line: line)
-        }
-
-        package func assertIsGaugeWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #filePath, line: UInt = #line) {
-            guard
-                case .gauge(let gauge) = data,
-                gauge.points.count == 1,
-                let point = gauge.points.first
-            else {
-                XCTFail("Not gauge with one point: \(self)", file: file, line: line)
-                return
-            }
-            XCTAssertEqual(point.value, value, file: file, line: line)
-        }
-
-        package func assertIsCumulativeHistogramWith(count: Int, sum: Double, buckets: [OTelHistogramDataPoint.Bucket], file: StaticString = #filePath, line: UInt = #line) {
-            guard
-                case .histogram(let histogram) = data,
-                histogram.aggregationTemporality == .cumulative,
-                histogram.points.count == 1,
-                let point = histogram.points.first
-            else {
-                XCTFail("Not cumulative histogram with one point: \(self)", file: file, line: line)
-                return
-            }
-
-            XCTAssertEqual(point.count, UInt64(count), file: file, line: line)
-            XCTAssertEqual(point.sum, sum, file: file, line: line)
-            XCTAssertEqual(point.buckets, buckets, file: file, line: line)
-        }
+        XCTAssertEqual(point.value, value, file: file, line: line)
     }
+
+    package func assertIsGaugeWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #filePath, line: UInt = #line) {
+        guard
+            case .gauge(let gauge) = data,
+            gauge.points.count == 1,
+            let point = gauge.points.first
+        else {
+            XCTFail("Not gauge with one point: \(self)", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(point.value, value, file: file, line: line)
+    }
+
+    package func assertIsCumulativeHistogramWith(count: Int, sum: Double, buckets: [OTelHistogramDataPoint.Bucket], file: StaticString = #filePath, line: UInt = #line) {
+        guard
+            case .histogram(let histogram) = data,
+            histogram.aggregationTemporality == .cumulative,
+            histogram.points.count == 1,
+            let point = histogram.points.first
+        else {
+            XCTFail("Not cumulative histogram with one point: \(self)", file: file, line: line)
+            return
+        }
+
+        XCTAssertEqual(point.count, UInt64(count), file: file, line: line)
+        XCTAssertEqual(point.sum, sum, file: file, line: line)
+        XCTAssertEqual(point.buckets, buckets, file: file, line: line)
+    }
+}
 #endif

--- a/Sources/OTelTesting/RecordingMetricExporter.swift
+++ b/Sources/OTelTesting/RecordingMetricExporter.swift
@@ -12,48 +12,48 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(XCTest)
-    import NIOConcurrencyHelpers
-    import OTelCore
-    import XCTest
+import NIOConcurrencyHelpers
+import OTelCore
+import XCTest
 
-    package struct RecordingMetricExporter: OTelMetricExporter {
-        package typealias ExportCall = Collection<OTelResourceMetrics> & Sendable
+package struct RecordingMetricExporter: OTelMetricExporter {
+    package typealias ExportCall = Collection<OTelResourceMetrics> & Sendable
 
-        package struct RecordedCalls {
-            var exportCalls = [any ExportCall]()
-            var forceFlushCallCount = 0
-            var shutdownCallCount = 0
-        }
-
-        package let recordedCalls = NIOLockedValueBox(RecordedCalls())
-
-        package init() {}
-
-        package func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) {
-            recordedCalls.withLockedValue { $0.exportCalls.append(batch) }
-        }
-
-        package func forceFlush() {
-            recordedCalls.withLockedValue { $0.forceFlushCallCount += 1 }
-        }
-
-        package func shutdown() {
-            recordedCalls.withLockedValue { $0.shutdownCallCount += 1 }
-        }
+    package struct RecordedCalls {
+        var exportCalls = [any ExportCall]()
+        var forceFlushCallCount = 0
+        var shutdownCallCount = 0
     }
 
-    extension RecordingMetricExporter {
-        package func assert(
-            exportCallCount: Int,
-            forceFlushCallCount: Int,
-            shutdownCallCount: Int,
-            file: StaticString = #filePath,
-            line: UInt = #line
-        ) {
-            let recordedCalls = recordedCalls.withLockedValue { $0 }
-            XCTAssertEqual(recordedCalls.exportCalls.count, exportCallCount, "Unexpected export call count", file: file, line: line)
-            XCTAssertEqual(recordedCalls.forceFlushCallCount, forceFlushCallCount, "Unexpected forceFlush call count", file: file, line: line)
-            XCTAssertEqual(recordedCalls.shutdownCallCount, shutdownCallCount, "Unexpected shutdown call count", file: file, line: line)
-        }
+    package let recordedCalls = NIOLockedValueBox(RecordedCalls())
+
+    package init() {}
+
+    package func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) {
+        recordedCalls.withLockedValue { $0.exportCalls.append(batch) }
     }
+
+    package func forceFlush() {
+        recordedCalls.withLockedValue { $0.forceFlushCallCount += 1 }
+    }
+
+    package func shutdown() {
+        recordedCalls.withLockedValue { $0.shutdownCallCount += 1 }
+    }
+}
+
+extension RecordingMetricExporter {
+    package func assert(
+        exportCallCount: Int,
+        forceFlushCallCount: Int,
+        shutdownCallCount: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let recordedCalls = recordedCalls.withLockedValue { $0 }
+        XCTAssertEqual(recordedCalls.exportCalls.count, exportCallCount, "Unexpected export call count", file: file, line: line)
+        XCTAssertEqual(recordedCalls.forceFlushCallCount, forceFlushCallCount, "Unexpected forceFlush call count", file: file, line: line)
+        XCTAssertEqual(recordedCalls.shutdownCallCount, shutdownCallCount, "Unexpected shutdown call count", file: file, line: line)
+    }
+}
 #endif

--- a/Sources/OTelTesting/XCTAssertThrowsEquatableError.swift
+++ b/Sources/OTelTesting/XCTAssertThrowsEquatableError.swift
@@ -12,18 +12,18 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(XCTest)
-    import XCTest
+import XCTest
 
-    package func XCTAssertThrowsError<E: Error & Equatable>(_ expression: @autoclosure () throws -> some Any, _ error: E) {
-        do {
-            let value = try expression()
-            XCTFail("Expected error but received value: \(value)")
-        } catch let actualError {
-            guard let e = actualError as? E else {
-                XCTFail("Expected \(type(of: E.self)), but received \(type(of: actualError))")
-                return
-            }
-            XCTAssertEqual(e, error)
+package func XCTAssertThrowsError<E: Error & Equatable>(_ expression: @autoclosure () throws -> some Any, _ error: E) {
+    do {
+        let value = try expression()
+        XCTFail("Expected error but received value: \(value)")
+    } catch let actualError {
+        guard let e = actualError as? E else {
+            XCTFail("Expected \(type(of: E.self)), but received \(type(of: actualError))")
+            return
         }
+        XCTAssertEqual(e, error)
     }
+}
 #endif

--- a/Sources/OTelTesting/XCTestCase+Linux.swift
+++ b/Sources/OTelTesting/XCTestCase+Linux.swift
@@ -15,41 +15,41 @@
 // https://github.com/apple/swift-corelibs-xctest/issues/436#issuecomment-1703589930
 
 #if os(Linux) && swift(<5.10)
-    import XCTest
+import XCTest
 
-    extension XCTestCase {
-        /// Waits on a group of expectations for up to the specified timeout,
-        /// optionally enforcing their order of fulfillment.
-        ///
-        /// - Parameters:
-        ///     - expectations: An array of expectations that must be fulfilled.
-        ///     - seconds: The number of seconds within which all expectations must
-        ///         be fulfilled. The default timeout allows the test to run until
-        ///         it reaches its execution time allowance.
-        ///     - enforceOrderOfFulfillment: If `true`, the expectations specified
-        ///         by the `expectations` parameter must be satisfied in the order
-        ///         they appear in the array.
-        ///
-        /// Expectations can only appear in the list once. This function may return
-        /// early based on fulfillment of the provided expectations.
-        ///
-        /// - Note: If you do not specify a timeout when calling this function, it
-        ///     is recommended that you enable test timeouts to prevent a runaway
-        ///     expectation from hanging the test.
-        package func fulfillment(
-            of expectations: [XCTestExpectation],
-            timeout: TimeInterval,
-            enforceOrder: Bool = false
-        ) async {
-            await withCheckedContinuation { continuation in
-                // This function operates by blocking a background thread instead of one owned by libdispatch or by the
-                // Swift runtime (as used by Swift concurrency.) To ensure we use a thread owned by neither subsystem,
-                // use Foundation's Thread.detachNewThread(_:).
-                Thread.detachNewThread { [self] in
-                    wait(for: expectations, timeout: timeout, enforceOrder: enforceOrder)
-                    continuation.resume()
-                }
+extension XCTestCase {
+    /// Waits on a group of expectations for up to the specified timeout,
+    /// optionally enforcing their order of fulfillment.
+    ///
+    /// - Parameters:
+    ///     - expectations: An array of expectations that must be fulfilled.
+    ///     - seconds: The number of seconds within which all expectations must
+    ///         be fulfilled. The default timeout allows the test to run until
+    ///         it reaches its execution time allowance.
+    ///     - enforceOrderOfFulfillment: If `true`, the expectations specified
+    ///         by the `expectations` parameter must be satisfied in the order
+    ///         they appear in the array.
+    ///
+    /// Expectations can only appear in the list once. This function may return
+    /// early based on fulfillment of the provided expectations.
+    ///
+    /// - Note: If you do not specify a timeout when calling this function, it
+    ///     is recommended that you enable test timeouts to prevent a runaway
+    ///     expectation from hanging the test.
+    package func fulfillment(
+        of expectations: [XCTestExpectation],
+        timeout: TimeInterval,
+        enforceOrder: Bool = false
+    ) async {
+        await withCheckedContinuation { continuation in
+            // This function operates by blocking a background thread instead of one owned by libdispatch or by the
+            // Swift runtime (as used by Swift concurrency.) To ensure we use a thread owned by neither subsystem,
+            // use Foundation's Thread.detachNewThread(_:).
+            Thread.detachNewThread { [self] in
+                wait(for: expectations, timeout: timeout, enforceOrder: enforceOrder)
+                continuation.resume()
             }
         }
     }
+}
 #endif


### PR DESCRIPTION
## Motivation

We have more code that requires conditional compilation blocks with both the use of traits, and the use of Swift 6.1 features when available. The current SwiftFormat rules indent the conditional compilation blocks which is a bit annoying when it's the whole file. Additionally it creates future diff churn when then they are changed because all the code within them will need outdenting.

## Modifications

- Update swiftformat rules to not indent conditional compilation blocks.
- Reformat with the new rules.
- Remove the special comments where this was being disabled on an ad-hoc basis.

## Result

Easier to edit and read with conditional compilation.