### PR TITLE
Support only Swift 6 language mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -162,5 +162,5 @@ let package = Package(
         ),
 
     ],
-    swiftLanguageModes: [.version("6"), .v5]
+    swiftLanguageModes: [.v6]
 )


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we'll only be supporting Swift 6.1 or newer. As a consequence, we can drop support for the Swift 5 language mode.

## Modifications

- Update package manifest to remove Swift 5 language mode
 
## Result

Package supports only Swift 6 language mode.