### PR TITLE
Update Swift version option for Swift Format

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,6 @@
 # file options
 
---swiftversion 5.9
+--swiftversion 6.1
 --exclude .build
 --exclude **/*.pb.swift
 --exclude **/*.grpc.swift


### PR DESCRIPTION
## Motivation

This package only supports Swift 6.1+ now but we are still using `swiftformat --swift-version 5.9` as a linter.

## Modifications

Update Swift version option for Swift Format

## Result

Linting rules match minimum required Swift version.