### PR TITLE
Add API to configure the default logging level of the logging backend

### DIFF
--- a/Sources/OTel/OTel+Backends.swift
+++ b/Sources/OTel/OTel+Backends.swift
@@ -128,7 +128,7 @@ extension OTel {
                 let processor = OTelBatchLogRecordProcessor(exporter: exporter, configuration: .init(configuration: configuration.logs.batchLogRecordProcessor))
                 let handler = OTelLogHandler(
                     processor: processor,
-                    logLevel: .debug, // um.... wat?
+                    logLevel: Logger.Level(configuration.logs.level),
                     resource: resource
                 )
                 return ({ _ in handler }, Wrapper(wrapped: processor))
@@ -144,7 +144,7 @@ extension OTel {
                 )
                 let handler = OTelLogHandler(
                     processor: processor,
-                    logLevel: .debug, // um.... wat?
+                    logLevel: Logger.Level(configuration.logs.level),
                     resource: resource
                 )
                 return ({ _ in handler }, Wrapper(wrapped: processor))

--- a/Sources/OTelCore/OTel+Configuration.swift
+++ b/Sources/OTelCore/OTel+Configuration.swift
@@ -177,6 +177,7 @@ extension OTel.Configuration {
             case warning
             case info
             case debug
+            case trace
         }
 
         package var backing: Backing
@@ -192,6 +193,9 @@ extension OTel.Configuration {
 
         /// Debug log level - all messages including debug information are logged.
         public static let debug: Self = .init(backing: .debug)
+
+        /// Trace log level - all messages including fine-grained debug information are logged.
+        public static let trace: Self = .init(backing: .trace)
     }
 }
 
@@ -337,6 +341,11 @@ extension OTel.Configuration {
         /// - Default value: `true`.
         public var enabled: Bool
 
+        /// Default log level for loggers returned by the logging backend factory.
+        ///
+        /// - Default value: `.info`
+        public var level: LogLevel
+
         /// Configuration for the batch log record processor.
         ///
         /// - Default value: `.default`.
@@ -359,6 +368,7 @@ extension OTel.Configuration {
         /// where possible.
         public static let `default`: Self = .init(
             enabled: true,
+            level: .info,
             batchLogRecordProcessor: .default,
             exporter: .otlp,
             otlpExporter: .default

--- a/Sources/OTelCore/OTelCore+ConfigurationShims.swift
+++ b/Sources/OTelCore/OTelCore+ConfigurationShims.swift
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Logging
 import Tracing
 
 extension OTelResource {
@@ -51,5 +52,17 @@ extension OTelBatchSpanProcessorConfiguration {
             maximumExportBatchSize: UInt(configuration.maxExportBatchSize),
             exportTimeout: configuration.exportTimeout
         )
+    }
+}
+
+extension Logging.Logger.Level {
+    package init(_ level: OTel.Configuration.LogLevel) {
+        switch level.backing {
+        case .error: self = .error
+        case .warning: self = .warning
+        case .info: self = .info
+        case .debug: self = .debug
+        case .trace: self = .trace
+        }
     }
 }

--- a/Tests/OTelTests/EndToEndTests.swift
+++ b/Tests/OTelTests/EndToEndTests.swift
@@ -271,6 +271,7 @@ import Tracing
                     var config = OTel.Configuration.default
                     config.metrics.enabled = false
                     config.traces.enabled = false
+                    config.logs.level = .debug
                     config.logs.otlpExporter.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                     config.logs.otlpExporter.protocol = .httpProtobuf
                     let observability = try OTel.bootstrap(configuration: config)
@@ -333,6 +334,7 @@ import Tracing
                     var config = OTel.Configuration.default
                     config.metrics.enabled = false
                     config.traces.enabled = false
+                    config.logs.level = .debug
                     config.logs.otlpExporter.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                     config.logs.otlpExporter.protocol = .httpJSON
                     let observability = try OTel.bootstrap(configuration: config)


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we're adding support for a logging backend. The API to make and bootstrap the backend landed in #242 but we didn't have any way to configure the logging level of loggers returned by the factory by default.

This PR adds API for configuring that logging level.

## Modifications

- Add API to configure the default logging level of the logging backend
- Add `trace` to the configuration options
 
## Result

Configuration for the logging backend now includes the default log level applied to loggers returned from the factory.

## Notes

We are only supporting a subset of what can typically be expressed by Swift Log, since these are the only ones that overlap with the OTel spec[^1].

[^1]: https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber