### PR TITLE
Rename diagnostic logging configuration API for clarity

### DIFF
--- a/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
+++ b/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
@@ -21,8 +21,8 @@ extension OTel.Configuration {
         if let serviceName = environment.getStringValue(.serviceName) {
             self.serviceName = serviceName
         }
-        if let logLevel = environment.getEnumValue(of: OTel.Configuration.LogLevel.Backing.self, .logLevel) {
-            self.logLevel = .init(backing: logLevel)
+        if let diagnosticLogLevel = environment.getEnumValue(of: OTel.Configuration.LogLevel.Backing.self, .logLevel) {
+            self.diagnosticLogLevel = .init(backing: diagnosticLogLevel)
         }
         if let propagators = environment.getStringValue(.propagators) {
             self.propagators.removeAll()

--- a/Sources/OTelCore/OTel+Configuration.swift
+++ b/Sources/OTelCore/OTel+Configuration.swift
@@ -83,7 +83,7 @@ extension OTel {
         /// does not affect application logging or log signal collection.
         ///
         /// - Default value: `.console`.
-        public var logger: LoggerSelection
+        public var diagnosticLogger: DiagnosticLoggerSelection
 
         /// The minimum log level for internal diagnostic messages.
         ///
@@ -92,7 +92,7 @@ extension OTel {
         ///
         /// - Environment variable(s): `OTEL_LOG_LEVEL`.
         /// - Default value: `.info`.
-        public var logLevel: LogLevel
+        public var diagnosticLogLevel: LogLevel
 
         /// The list of propagators used for context propagation across service boundaries.
         ///
@@ -135,8 +135,8 @@ extension OTel {
         public static let `default`: Self = .init(
             serviceName: "unknown_service",
             resourceAttributes: [:],
-            logger: .console,
-            logLevel: .info,
+            diagnosticLogger: .console,
+            diagnosticLogLevel: .info,
             propagators: [.traceContext, .baggage],
             traces: .default,
             metrics: .default,
@@ -147,7 +147,7 @@ extension OTel {
 
 extension OTel.Configuration {
     /// Logger to use for internal diagnostics.
-    public struct LoggerSelection: Sendable {
+    public struct DiagnosticLoggerSelection: Sendable {
         package enum Backing: Sendable {
             case console
             case custom(Logger)


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we're overhauling the public API and want to make it as obvious as possible to use. One source of confusion is the configuration for the internal diagnostic logger, which is currently configured using `OTel.Configuration.logger` and `OTel.Configuration.logLevel`. These influence the diagnostic logging of Swift OTel itself, and _not_ the logging backend provided by Swift OTel for use with Swift Log.

This PR updates the API to rename the configuration for the diagnostic logger to avoid this confusion.

## Modifications

- Rename diagnostic logging configuration API for clarity 

## Result

The following APIs have been renamed:

- `OTel.Configuration.logLevel` -> `OTel.Configuration.diagnosticLogLevel`
- `OTel.Configuration.logger` -> `OTel.Configuration.diagnosticLogger`
- `OTel.Configuration.LoggerSelection` -> `OTel.Configuration.DiagnosticLoggerSelection`
