### PR TITLE
Remove (now moot) StrictConcurrency=complete package setting

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,6 @@
 import PackageDescription
 
 let sharedSwiftSettings: [SwiftSetting] = [
-    .enableExperimentalFeature("StrictConcurrency=complete"),
     .enableUpcomingFeature("InternalImportsByDefault"),
 ]
 


### PR DESCRIPTION
## Motivation

As part of the roadmap for 1.0 (see #206), we dropped support for Swift 5 language mode in #237. That makes the `StrictConcurrency=complete` feature used in the Package.swift redundant.

## Modifications

- Remove (now moot) `StrictConcurrency=complete` package setting
 
## Result

Package manifest no longer contains moot `StrictConcurrency=complete` setting.