### PR TITLE
Add support for OTEL_SDK_DISABLED environment override

### DIFF
--- a/Sources/OTelCore/OTel+Configuration+Environment.swift
+++ b/Sources/OTelCore/OTel+Configuration+Environment.swift
@@ -36,6 +36,7 @@ extension OTel.Configuration {
 }
 
 extension OTel.Configuration.Key.GeneralKey {
+    static let sdkDisabled = Self(key: "OTEL_SDK_DISABLED")
     static let resourceAttributes = Self(key: "OTEL_RESOURCE_ATTRIBUTES")
     static let serviceName = Self(key: "OTEL_SERVICE_NAME")
     static let logLevel = Self(key: "OTEL_LOG_LEVEL")

--- a/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
+++ b/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
@@ -13,6 +13,11 @@
 
 extension OTel.Configuration {
     package mutating func applyEnvironmentOverrides(environment: [String: String]) {
+        if let sdkDisabled = environment.getBoolValue(.sdkDisabled), sdkDisabled {
+            logs.enabled = false
+            metrics.enabled = false
+            traces.enabled = false
+        }
         if let resourceAttributes = environment.getHeadersValue(.resourceAttributes) {
             // https://opentelemetry.io/docs/specs/otel/resource/sdk/#specifying-resource-information-via-an-environment-variable
             let incomingAttributes = Dictionary(resourceAttributes, uniquingKeysWith: { _, second in second })

--- a/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
+++ b/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
@@ -17,7 +17,19 @@ import Testing
 @Suite struct ConfigurationTests {
     // OTEL_SDK_DISABLED
     // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
-    @Test(.disabled("Not currently implemented")) func testSDKDisabled() {}
+    @Test func testSDKDisabled() {
+        #expect(OTel.Configuration.default.logs.enabled == true)
+        #expect(OTel.Configuration.default.metrics.enabled == true)
+        #expect(OTel.Configuration.default.traces.enabled == true)
+
+        OTel.Configuration.default.withEnvironmentOverrides(environment: [
+            "OTEL_SDK_DISABLED": "true",
+        ]) { config in
+            #expect(config.logs.enabled == false)
+            #expect(config.metrics.enabled == false)
+            #expect(config.traces.enabled == false)
+        }
+    }
 
     // OTEL_LOG_LEVEL
     // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/


### PR DESCRIPTION
## Motivation

As part of the drive toward 1.0 we've been expanding support for the environment variable overrides defined in the OTel spec. One such that we don't currently support is `OTEL_SDK_DISABLED`, which should disable all three signals.

## Modifications

Add support for `OTEL_SDK_DISABLED` environment override

## Result

Calling the `bootstrap(configuration:)` API with `OTEL_SDK_DISABLED` will disable the backends.