### PR TITLE
Remove placeholder tests that now have actual tests

### DIFF
--- a/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
+++ b/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
@@ -90,16 +90,6 @@ import Testing
         }
     }
 
-    // OTEL_TRACES_SAMPLER
-    // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
-    // https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler
-    @Test(.disabled("Not currently implemented")) func testTracesSampler() {}
-
-    // OTEL_TRACES_SAMPLER_ARG
-    // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
-    // https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_traces_sampler_arg
-    @Test(.disabled("Not currently implemented")) func testTracesSamplerArg() {}
-
     // OTEL_PROPAGATORS
     // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
     // https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_propagators


### PR DESCRIPTION
## Motivation

Back in #248 we added tests for the configuration overrides and put in some `.disabled` placeholders for things that weren't implemented yet. An example of this is placeholders for `OTEL_TRACES_SAMPLER` and `OTEL_TRACES_SAMPLER_ARG`. 

We added support for configuring the traces sampler in #251, along with tests, but left these disabled placeholder tests there by accident, which are now completely redundant.

## Modifications

Remove placeholder tests that now have actual tests.

## Result

Cleaned up testing code (no user impact).
