### PR TITLE
Populate service.name resource attribute on export

### DIFF
--- a/Sources/OTelCore/OTelCore+ConfigurationShims.swift
+++ b/Sources/OTelCore/OTelCore+ConfigurationShims.swift
@@ -16,7 +16,17 @@ import Tracing
 
 extension OTelResource {
     package init(configuration: OTel.Configuration) {
-        let attributes = configuration.resourceAttributes.mapValues { $0.toSpanAttribute() }
+        var attributes = configuration.resourceAttributes.mapValues { $0.toSpanAttribute() }
+
+        // If service.name is also provided in OTEL_RESOURCE_ATTRIBUTES, then OTEL_SERVICE_NAME takes precedence.
+        // https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_service_name
+        // https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_resource_attributes
+        if let serviceName = attributes["service.name"], configuration.serviceName == OTel.Configuration.default.serviceName {
+            attributes["service.name"] = serviceName
+        } else {
+            attributes["service.name"] = .string(configuration.serviceName)
+        }
+
         self.init(attributes: SpanAttributes(attributes))
     }
 }

--- a/Tests/OTelTests/EndToEndTests.swift
+++ b/Tests/OTelTests/EndToEndTests.swift
@@ -41,6 +41,8 @@ import Tracing
                     config.metrics.enabled = false
                     config.traces.otlpExporter.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                     config.traces.otlpExporter.protocol = .httpProtobuf
+                    config.serviceName = "innie"
+                    config.resourceAttributes = ["deployment.environment": "prod"]
                     let observability = try OTel.bootstrap(configuration: config)
                     let serviceGroup = ServiceGroup(services: [observability], logger: .init(label: "service group"))
 
@@ -72,6 +74,9 @@ import Tracing
                     #expect(message.resourceSpans.count == 1)
                     #expect(message.resourceSpans.first?.scopeSpans.count == 1)
                     #expect(message.resourceSpans.first?.scopeSpans.first?.spans.count == 5)
+                    #expect(message.resourceSpans.first?.resource.attributes.count == 2)
+                    #expect(message.resourceSpans.first?.resource.attributes.first { $0.key == "service.name" }?.value.stringValue == "innie")
+                    #expect(message.resourceSpans.first?.resource.attributes.first { $0.key == "deployment.environment" }?.value.stringValue == "prod")
                 }
                 try testServer.receiveEndAndVerify { trailers in
                     #expect(trailers == nil)
@@ -101,6 +106,8 @@ import Tracing
                     config.metrics.enabled = false
                     config.traces.otlpExporter.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                     config.traces.otlpExporter.protocol = .httpJSON
+                    config.serviceName = "innie"
+                    config.resourceAttributes = ["deployment.environment": "prod"]
                     let observability = try OTel.bootstrap(configuration: config)
                     let serviceGroup = ServiceGroup(services: [observability], logger: .init(label: "service group"))
 
@@ -132,6 +139,9 @@ import Tracing
                     #expect(message.resourceSpans.count == 1)
                     #expect(message.resourceSpans.first?.scopeSpans.count == 1)
                     #expect(message.resourceSpans.first?.scopeSpans.first?.spans.count == 5)
+                    #expect(message.resourceSpans.first?.resource.attributes.count == 2)
+                    #expect(message.resourceSpans.first?.resource.attributes.first { $0.key == "service.name" }?.value.stringValue == "innie")
+                    #expect(message.resourceSpans.first?.resource.attributes.first { $0.key == "deployment.environment" }?.value.stringValue == "prod")
                 }
                 try testServer.receiveEndAndVerify { trailers in
                     #expect(trailers == nil)
@@ -161,6 +171,8 @@ import Tracing
                     config.traces.enabled = false
                     config.metrics.otlpExporter.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                     config.metrics.otlpExporter.protocol = .httpProtobuf
+                    config.serviceName = "innie"
+                    config.resourceAttributes = ["deployment.environment": "prod"]
                     let observability = try OTel.bootstrap(configuration: config)
                     let serviceGroup = ServiceGroup(services: [observability], logger: .init(label: "service group"))
 
@@ -188,6 +200,9 @@ import Tracing
                     #expect(message.resourceMetrics.count == 1)
                     #expect(message.resourceMetrics.first?.scopeMetrics.count == 1)
                     #expect(message.resourceMetrics.first?.scopeMetrics.first?.metrics.count == 3)
+                    #expect(message.resourceMetrics.first?.resource.attributes.count == 2)
+                    #expect(message.resourceMetrics.first?.resource.attributes.first { $0.key == "service.name" }?.value.stringValue == "innie")
+                    #expect(message.resourceMetrics.first?.resource.attributes.first { $0.key == "deployment.environment" }?.value.stringValue == "prod")
                 }
                 try testServer.receiveEndAndVerify { trailers in
                     #expect(trailers == nil)
@@ -217,6 +232,8 @@ import Tracing
                     config.traces.enabled = false
                     config.metrics.otlpExporter.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                     config.metrics.otlpExporter.protocol = .httpJSON
+                    config.serviceName = "innie"
+                    config.resourceAttributes = ["deployment.environment": "prod"]
                     let observability = try OTel.bootstrap(configuration: config)
                     let serviceGroup = ServiceGroup(services: [observability], logger: .init(label: "service group"))
 
@@ -244,6 +261,9 @@ import Tracing
                     #expect(message.resourceMetrics.count == 1)
                     #expect(message.resourceMetrics.first?.scopeMetrics.count == 1)
                     #expect(message.resourceMetrics.first?.scopeMetrics.first?.metrics.count == 3)
+                    #expect(message.resourceMetrics.first?.resource.attributes.count == 2)
+                    #expect(message.resourceMetrics.first?.resource.attributes.first { $0.key == "service.name" }?.value.stringValue == "innie")
+                    #expect(message.resourceMetrics.first?.resource.attributes.first { $0.key == "deployment.environment" }?.value.stringValue == "prod")
                 }
                 try testServer.receiveEndAndVerify { trailers in
                     #expect(trailers == nil)
@@ -274,6 +294,8 @@ import Tracing
                     config.logs.level = .debug
                     config.logs.otlpExporter.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                     config.logs.otlpExporter.protocol = .httpProtobuf
+                    config.serviceName = "innie"
+                    config.resourceAttributes = ["deployment.environment": "prod"]
                     let observability = try OTel.bootstrap(configuration: config)
                     // In this test we intentionally disable logging from Service Lifecycle to isolate the user logging.
                     let serviceGroup = ServiceGroup(services: [observability], logger: ._otelDisabled)
@@ -306,6 +328,9 @@ import Tracing
                     #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.count == 1)
                     #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.body == .init("Waffle party privileges have been revoked due to insufficient team spirit"))
                     #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.attributes.first { $0.key == "person" }?.value == .init("milchick"))
+                    #expect(message.resourceLogs.first?.resource.attributes.count == 2)
+                    #expect(message.resourceLogs.first?.resource.attributes.first { $0.key == "service.name" }?.value.stringValue == "innie")
+                    #expect(message.resourceLogs.first?.resource.attributes.first { $0.key == "deployment.environment" }?.value.stringValue == "prod")
                 }
                 try testServer.receiveEndAndVerify { trailers in
                     #expect(trailers == nil)
@@ -336,6 +361,8 @@ import Tracing
                     config.logs.level = .debug
                     config.logs.otlpExporter.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                     config.logs.otlpExporter.protocol = .httpJSON
+                    config.serviceName = "innie"
+                    config.resourceAttributes = ["deployment.environment": "prod"]
                     let observability = try OTel.bootstrap(configuration: config)
                     // In this test we intentionally disable logging from Service Lifecycle to isolate the user logging.
                     let serviceGroup = ServiceGroup(services: [observability], logger: ._otelDisabled)
@@ -368,6 +395,9 @@ import Tracing
                     #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.count == 1)
                     #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.body == .init("Waffle party privileges have been revoked due to insufficient team spirit"))
                     #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.attributes.first { $0.key == "person" }?.value == .init("milchick"))
+                    #expect(message.resourceLogs.first?.resource.attributes.count == 2)
+                    #expect(message.resourceLogs.first?.resource.attributes.first { $0.key == "service.name" }?.value.stringValue == "innie")
+                    #expect(message.resourceLogs.first?.resource.attributes.first { $0.key == "deployment.environment" }?.value.stringValue == "prod")
                 }
                 try testServer.receiveEndAndVerify { trailers in
                     #expect(trailers == nil)


### PR DESCRIPTION
## Motivation

During export, the resource attribute `service.name` is expected to be populated. It's value should be taken from the explicit service name configuration value, if set, falling back to the `service.name` resource attribute, if set, falling back to `unknown_service`.

> If service.name is also provided in OTEL_RESOURCE_ATTRIBUTES, then OTEL_SERVICE_NAME takes precedence.
> — source: https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_service_name


The logic to handle the `OTEL_SERVICE_NAME` and `OTEL_RESOURCE_ATTRIBUTES` is already correct, but `service.name` was not appearing in the resource attributes when `OTel.Configuration.serviceName` was set.

This was because `OTelResource.init(configuration:)`, which is then passed to the exporters, was only taking the values in the resource attributes.

## Modifications

- Populate service.name resource attribute on export

## Result

The `service.name` attribute is now set on exports and honors the `serviceName` configuration value and `OTEL_SERVICE_NAME` environment variable.
