### PR TITLE
Apply per-signal path suffix to OTLP/HTTP endpoints unless manually set

### DIFF
--- a/Sources/OTLPHTTP/OTLPHTTPLogRecordExporter.swift
+++ b/Sources/OTLPHTTP/OTLPHTTPLogRecordExporter.swift
@@ -23,6 +23,8 @@ package final class OTLPHTTPLogRecordExporter: OTelLogRecordExporter {
 
     package init(configuration: OTel.Configuration.OTLPExporterConfiguration, logger: Logger) throws {
         self.logger = logger
+        var configuration = configuration
+        configuration.endpoint = configuration.logsHTTPEndpoint
         exporter = try OTLPHTTPExporter(configuration: configuration)
     }
 

--- a/Sources/OTLPHTTP/OTLPHTTPMetricExporter.swift
+++ b/Sources/OTLPHTTP/OTLPHTTPMetricExporter.swift
@@ -23,6 +23,8 @@ package final class OTLPHTTPMetricExporter: OTelMetricExporter {
 
     package init(configuration: OTel.Configuration.OTLPExporterConfiguration, logger: Logger) throws {
         self.logger = logger
+        var configuration = configuration
+        configuration.endpoint = configuration.metricsHTTPEndpoint
         exporter = try OTLPHTTPExporter(configuration: configuration)
     }
 

--- a/Sources/OTLPHTTP/OTLPHTTPSpanExporter.swift
+++ b/Sources/OTLPHTTP/OTLPHTTPSpanExporter.swift
@@ -23,6 +23,8 @@ package final class OTLPHTTPSpanExporter: OTelSpanExporter {
 
     package init(configuration: OTel.Configuration.OTLPExporterConfiguration, logger: Logger) throws {
         self.logger = logger
+        var configuration = configuration
+        configuration.endpoint = configuration.tracesHTTPEndpoint
         exporter = try OTLPHTTPExporter(configuration: configuration)
     }
 


### PR DESCRIPTION
## Motivation

Right now the way we handle OTLP/HTTP endpoint config needs some work and has some tests marked with `withKnownIssue`.

For OTLP/HTTP, how the endpoint is derived depends on whether the shared and/or specific keys are set.

> Based on the environment variables above, the OTLP/HTTP exporter MUST construct URLs for each
> signal as follow:
>
> 1. For the per-signal variables (`OTEL_EXPORTER_OTLP_<signal>_ENDPOINT`), the URL MUST be usedas-is
>    without any modification. The only exception is that if an URL contains no path part, the root
>    path `/` MUST be used (see Example 2).
> 2. If signals are sent that have no per-signal configuration from the previous point,
>    `OTEL_EXPORTER_OTLP_ENDPOINT` is used as a base URL and the signals are sent to these paths
>    relative to that:
>    - Traces: `v1/traces`
>    - Metrics: `v1/metrics`
>    - Logs: `v1/logs`
>    Non-normatively, this could be implemented by ensuring that the base URL ends with a slash and
>    then appending the relative URLs as strings.
>
> An SDK MUST NOT modify the URL in ways other than specified above. That also means, if the port is
> empty or not given, TCP port 80 is the default for the http scheme and TCP port 443 is the default
> for the https scheme, as per the usual rules for these schemes (RFC 7230).
> — source: https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp

As per the spec, we should defer this responsibility to the OTLP/HTTP exporters.

However, to make a clearer configuration for our API users, we already have per-signal OTLP exporter configuration, and to allow the exporters the ability to follow this policy, the exporter must be able to tell if the value is default, or explicitly set, either in-code or by an environment override.

## Modifications

Apply per-signal path suffix to OTLP/HTTP endpoints unless manually set

## Result

- When using OTLP/gRPC, the endpoint configuration is used as-is.
- When using OTLP/HTTP, the endpoint configuration is supplemented with a signal-appropriate path, but only if it has not been manually set.
