### PR TITLE
Add Logging metadata provider API with end-to-end tests

### DIFF
--- a/Sources/OTel/OTel+LoggingMetadataProvider.swift
+++ b/Sources/OTel/OTel+LoggingMetadataProvider.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public import Logging
+import OTelCore
+
+extension OTel {
+    /// Create a logging metadata provider, which includes metadata about the current span.
+    ///
+    /// - Parameter configuration: Configuration for the logging metadata provider.
+    ///
+    /// - Returns: A metadata provider ready to use with Logging.
+    ///
+    /// This API is for users who wish to bootstrap the logging system with a backend that is not provided by this
+    /// package, but wish to correlate their logging events with the current instrumentation trace, if it exists.
+    ///
+    /// - Note: When using the OTLP logging backend, this metadata is already included in the log record.
+    public static func makeLoggingMetadataProvider(
+        configuration: OTel.Configuration.LoggingMetadataProviderConfiguration = .default
+    ) -> Logger.MetadataProvider {
+        .otel(
+            traceIDKey: configuration.traceIDKey,
+            spanIDKey: configuration.spanIDKey,
+            traceFlagsKey: configuration.traceFlagsKey
+        )
+    }
+}

--- a/Sources/OTelCore/OTel+Configuration.swift
+++ b/Sources/OTelCore/OTel+Configuration.swift
@@ -870,3 +870,18 @@ extension OTel.Configuration.OTLPExporterConfiguration {
         public static let httpJSON: Self = .init(backing: .httpJSON)
     }
 }
+
+extension OTel.Configuration {
+    /// Configuration for the batch logging metadata provider.
+    public struct LoggingMetadataProviderConfiguration: Sendable {
+        public var traceIDKey: String
+        public var spanIDKey: String
+        public var traceFlagsKey: String
+
+        public static let `default`: Self = .init(
+            traceIDKey: "trace_id",
+            spanIDKey: "span_id",
+            traceFlagsKey: "trace_flags"
+        )
+    }
+}

--- a/Tests/OTelTests/EndToEndTests.swift
+++ b/Tests/OTelTests/EndToEndTests.swift
@@ -458,8 +458,10 @@ import Tracing
                 }
                 try testServer.receiveBodyAndVerify { body in
                     let message = try Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest(jsonUTF8Data: Data(buffer: body))
-                    #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.spanID.count == 8)
-                    #expect(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.traceID.count == 16)
+                    let spanID = try #require(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.spanID)
+                    #expect(spanID.count == 8 && !spanID.allSatisfy { $0 == 0 })
+                    let traceID = try #require(message.resourceLogs.first?.scopeLogs.first?.logRecords.first?.traceID)
+                    #expect(traceID.count == 16 && !spanID.allSatisfy { $0 == 0 })
                 }
                 try testServer.receiveEndAndVerify { trailers in
                     #expect(trailers == nil)


### PR DESCRIPTION
## Motivation

As part of the 1.0 release, we wanted to include a `Logger.MetadataProvider` for users who are not using the OTLP logging backend, but wish to have their logs correlated with the spans produced by the tracing backend.

There was also some discussion about whether we should be adding this logging metadata provider to the OTLP backend itself. This turns out to be unnecessary, since the OTLP log records already contain the span and trace IDs.

## Modifications

- Add configuration datamodel for logging metadata provider
- Add `OTel.makeLoggingMetadataProvider` API
- Add end-to-end test to check span and trace IDs in OTLP log records
- Add end-to-end test using OTel metadata provider with StreamLogHandler

## Result

New API `OTel.makeLoggingMetadataProvider`