### PR TITLE
Correctly thread through the BLRP configuration

### DIFF
--- a/Sources/OTel/OTel+Backends.swift
+++ b/Sources/OTel/OTel+Backends.swift
@@ -115,7 +115,7 @@ extension OTel {
         let exporter = try WrappedLogRecordExporter(configuration: configuration, logger: logger)
         let processor: OTelBatchLogRecordProcessor = .init(
             exporter: exporter,
-            configuration: OTelBatchLogRecordProcessorConfiguration(environment: .detected()), // TODO: shim,
+            configuration: OTelBatchLogRecordProcessorConfiguration(configuration: configuration.logs.batchLogRecordProcessor),
             logger: logger
         )
         let handler = OTelLogHandler(


### PR DESCRIPTION
## Motivation

In `OTel.makeLoggingBackend` we construct the chain of objects used for the OTLP logging backend. At the time, we didn't have the `BatchLogRecordProcessorConfiguration` shim for the new configuration datamodel so we just used the default config, always. Now that the configuration API supports configuring the BLRP, we should be using that.

## Modifications

- Correctly thread through the BLRP configuration

## Result

Batch log record processor configuration is actually used during bootstrap.
