### PR TITLE
When OTLP/HTTP export partially succeeds, include rejected count in diagnostic

### DIFF
--- a/Sources/OTLPHTTP/OTLPHTTPLogRecordExporter.swift
+++ b/Sources/OTLPHTTP/OTLPHTTPLogRecordExporter.swift
@@ -37,7 +37,10 @@ package final class OTLPHTTPLogRecordExporter: OTelLogRecordExporter {
         let response = try await exporter.send(proto)
         if response.hasPartialSuccess {
             // https://opentelemetry.io/docs/specs/otlp/#partial-success-1
-            logger.warning("Partial success", metadata: ["message": .string(response.partialSuccess.errorMessage)])
+            logger.warning("Partial success", metadata: [
+                "message": "\(response.partialSuccess.errorMessage)",
+                "rejected_log_records": "\(response.partialSuccess.rejectedLogRecords)",
+            ])
         }
     }
 

--- a/Sources/OTLPHTTP/OTLPHTTPMetricExporter.swift
+++ b/Sources/OTLPHTTP/OTLPHTTPMetricExporter.swift
@@ -37,7 +37,10 @@ package final class OTLPHTTPMetricExporter: OTelMetricExporter {
         let response = try await exporter.send(proto)
         if response.hasPartialSuccess {
             // https://opentelemetry.io/docs/specs/otlp/#partial-success-1
-            logger.warning("Partial success", metadata: ["message": .string(response.partialSuccess.errorMessage)])
+            logger.warning("Partial success", metadata: [
+                "message": "\(response.partialSuccess.errorMessage)",
+                "rejected_data_points": "\(response.partialSuccess.rejectedDataPoints)",
+            ])
         }
     }
 

--- a/Sources/OTLPHTTP/OTLPHTTPSpanExporter.swift
+++ b/Sources/OTLPHTTP/OTLPHTTPSpanExporter.swift
@@ -37,7 +37,10 @@ package final class OTLPHTTPSpanExporter: OTelSpanExporter {
         let response = try await exporter.send(proto)
         if response.hasPartialSuccess {
             // https://opentelemetry.io/docs/specs/otlp/#partial-success-1
-            logger.warning("Partial success", metadata: ["message": .string(response.partialSuccess.errorMessage)])
+            logger.warning("Partial success", metadata: [
+                "message": "\(response.partialSuccess.errorMessage)",
+                "rejected_spans": "\(response.partialSuccess.rejectedSpans)",
+            ])
         }
     }
 


### PR DESCRIPTION
## Motivation

The OTel spec defines how a server should respond to an OTLP/HTTP request that is partially successful. It SHOULD populate the `error_message` field of the response—which we already log—but it MUST also populate a field indicating the number of rejected elements: `rejected_log_records`, `rejected_data_points`, or `rejected_spans`.

## Modification

- When OTLP/HTTP export partially succeeds, include rejected count in diagnostic log message metadata

## Result

Diagnostic log messages for OTLP/HTTP partial success contain information on the number of messages rejected.