### PR TITLE
Use aggressive traces export timeout log correlation test

### DIFF
--- a/Tests/OTelTests/EndToEndTests.swift
+++ b/Tests/OTelTests/EndToEndTests.swift
@@ -425,7 +425,7 @@ import Tracing
                     var config = OTel.Configuration.default
                     config.metrics.enabled = false
                     config.logs.level = .debug
-                    // We use a tiny trace export timeout, otherwise the test will wait the export timeout is reached.
+                    // We use a tiny trace export timeout, otherwise the test will wait until the export timeout is reached.
                     config.traces.otlpExporter.timeout = .nanoseconds(1)
                     config.logs.otlpExporter.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                     config.logs.otlpExporter.protocol = .httpJSON

--- a/Tests/OTelTests/EndToEndTests.swift
+++ b/Tests/OTelTests/EndToEndTests.swift
@@ -425,6 +425,8 @@ import Tracing
                     var config = OTel.Configuration.default
                     config.metrics.enabled = false
                     config.logs.level = .debug
+                    // We use a tiny trace export timeout, otherwise the test will wait the export timeout is reached.
+                    config.traces.otlpExporter.timeout = .nanoseconds(1)
                     config.logs.otlpExporter.endpoint = "http://127.0.0.1:\(testServer.serverPort)/some/path"
                     config.logs.otlpExporter.protocol = .httpJSON
                     config.serviceName = "innie"


### PR DESCRIPTION
## Motivation

In #256 we added an end-to-end test that checked that the OTLP log records contained span and trace IDs when the tracing backend was also bootstrapped. This test was passing but I hadn't noticed it was taking 10 seconds to do so. The reason was that the test has no HTTP server was responding to the traces export so the test waited either for the traces export timeout or the service lifecycle graceful shutdown timeout, whichever was soonest. 

As an aside, this is great—it means that the logging backend is being shutdown _after_ the traces backend and waiting for it, which is the behaviour we want.

Just that, in this test, we simply don't care about the traces export at all.

## Modifications

Set an aggressive timeout in for the trace export in the log correlation test, since no server is listening.

## Result

A test that was passing, but taking 10 seconds, now passes almost immediately.