### PR TITLE
Gracefully handle unsupported configuration

### DIFF
--- a/Sources/OTel/OTel+Backends.swift
+++ b/Sources/OTel/OTel+Backends.swift
@@ -312,12 +312,13 @@ extension OTel {
         let logger = configuration.makeDiagnosticLogger()
         let resource = OTelResource(configuration: configuration)
         let sampler = WrappedSampler(configuration: configuration)
+        let propagator = OTelMultiplexPropagator(configuration: configuration)
         let exporter = try WrappedSpanExporter(configuration: configuration, logger: logger)
         let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(configuration: configuration.traces.batchSpanProcessor), logger: logger)
         let tracer = OTelTracer(
             idGenerator: OTelRandomIDGenerator(),
             sampler: sampler,
-            propagator: OTelW3CPropagator(),
+            propagator: propagator,
             processor: processor,
             environment: .detected(),
             resource: resource,

--- a/Sources/OTel/OTel+Bootstrap.swift
+++ b/Sources/OTel/OTel+Bootstrap.swift
@@ -119,7 +119,7 @@ extension OTel {
     internal static func bootstrap(configuration: Configuration = .default, environment: [String: String]) throws -> some Service {
         let logger = configuration.makeDiagnosticLogger()
         var configuration = configuration
-        configuration.applyEnvironmentOverrides(environment: environment)
+        configuration.applyEnvironmentOverrides(environment: environment, logger: logger)
 
         var services: [Service] = []
 

--- a/Sources/OTel/OTelCore+GenericWrappers.swift
+++ b/Sources/OTel/OTelCore+GenericWrappers.swift
@@ -103,6 +103,7 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
             }
         case .console:
             throw NotImplementedError()
+        case .none: preconditionFailure()
         }
     }
 }
@@ -160,6 +161,7 @@ internal enum WrappedMetricExporter: OTelMetricExporter {
             }
         case .prometheus, .console:
             throw NotImplementedError()
+        case .none: preconditionFailure()
         }
     }
 }
@@ -217,6 +219,7 @@ internal enum WrappedSpanExporter: OTelSpanExporter {
             }
         case .console, .jaeger, .zipkin:
             throw NotImplementedError()
+        case .none: preconditionFailure()
         }
     }
 }
@@ -264,5 +267,26 @@ internal enum WrappedSampler: OTelSampler {
         case .jaegerRemote: fatalError("Swift OTel does not support the Jaeger sampler")
         case .xray: fatalError("Swift OTel does not support the X-Ray sampler")
         }
+    }
+}
+
+extension OTelMultiplexPropagator {
+    init(configuration: OTel.Configuration) {
+        var propagators: [OTelPropagator] = []
+        loop: for propagatorConfigValue in configuration.propagators {
+            switch propagatorConfigValue.backing {
+            case .none:
+                propagators.removeAll()
+                break loop // If none is in the config, we'll assume that was deliberate and short-circuit here.
+            case .traceContext: propagators.append(OTelW3CPropagator())
+            case .baggage: fatalError("Swift OTel does not support the W3C Baggage propagator")
+            case .b3: fatalError("Swift OTel does not support the B3 Single propagator")
+            case .b3Multi: fatalError("Swift OTel does not support the B3 Multi propagator")
+            case .jaeger: fatalError("Swift OTel does not support the Jaeger propagator")
+            case .xray: fatalError("Swift OTel does not support the AWS X-Ray propagator")
+            case .otTrace: fatalError("Swift OTel does not support the OT Trace propagator")
+            }
+        }
+        self.init(propagators)
     }
 }

--- a/Sources/OTelCore/OTel+Configuration+EnvironmentVariableRepresentable.swift
+++ b/Sources/OTelCore/OTel+Configuration+EnvironmentVariableRepresentable.swift
@@ -1,0 +1,356 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+
+protocol OTelEnvironmentVariableRepresentable {
+    init?(environmentVariableValue: String)
+    var environmentVariableValue: String { get }
+    static var hint: String? { get }
+}
+
+extension OTelEnvironmentVariableRepresentable {
+    static var hint: String? { nil }
+}
+
+extension OTelEnvironmentVariableRepresentable {
+    fileprivate mutating func override(using key: OTel.Configuration.Key, from environment: [String: String], logger: Logger? = nil) {
+        guard let proposedValue = environment.getStringValue(key) else { return }
+
+        let result: OTelEnvironmentOverrideResult
+        let previousValue = self
+
+        if let newValue = Self(environmentVariableValue: proposedValue) {
+            self = newValue
+            result = .success
+        } else {
+            result = .failure(hint: Self.hint)
+        }
+
+        logger?.logOverride(
+            environmentKey: key.environmentVariableName,
+            environmentValue: proposedValue,
+            previousValue: previousValue.environmentVariableValue,
+            newValue: environmentVariableValue,
+            result: result
+        )
+    }
+
+    internal mutating func override(using key: OTel.Configuration.Key.GeneralKey, from environment: [String: String], logger: Logger? = nil) {
+        override(using: .single(key), from: environment, logger: logger)
+    }
+
+    internal mutating func override(using key: OTel.Configuration.Key.SignalSpecificKey, for signal: OTel.Configuration.Key.Signal, from environment: [String: String], logger: Logger? = nil) {
+        override(using: .signalSpecific(key, signal), from: environment, logger: logger)
+    }
+}
+
+private enum OTelEnvironmentOverrideResult {
+    case success
+    case failure(hint: String?)
+}
+
+extension Logger {
+    fileprivate func logOverride(
+        environmentKey: String,
+        environmentValue: String,
+        previousValue: String,
+        newValue: String,
+        result: OTelEnvironmentOverrideResult
+    ) {
+        var logger = self
+
+        logger[metadataKey: "environment_key"] = "\(environmentKey)"
+        logger[metadataKey: "environment_value"] = "\(environmentValue)"
+        logger[metadataKey: "previous_value"] = "\(previousValue)"
+        logger[metadataKey: "new_value"] = "\(newValue)"
+
+        switch result {
+        case .success:
+            logger.info("Configuration updated from environment")
+        case .failure(let hint):
+            if let hint { logger[metadataKey: "hint"] = "\(hint)" }
+            logger.warning("Failed to update configuration from environment")
+        }
+    }
+}
+
+extension Bool: OTelEnvironmentVariableRepresentable {
+    init?(environmentVariableValue: String) {
+        // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#boolean
+        switch environmentVariableValue.lowercased() {
+        case "true": self = true
+        case "false", "": self = false
+        default: return nil
+        }
+    }
+
+    var environmentVariableValue: String { self ? "true" : "false" }
+
+    static var hint: String? { "Value must be case-insensitive string `true`, `false`, or empty" }
+}
+
+extension Int: OTelEnvironmentVariableRepresentable {
+    init?(environmentVariableValue: String) {
+        // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#integer
+        guard let value = Int(environmentVariableValue), value >= 0 else { return nil }
+        self = value
+    }
+
+    var environmentVariableValue: String { "\(self)" }
+
+    static var hint: String? { "Value must be a non-negative integer" }
+}
+
+extension Duration: OTelEnvironmentVariableRepresentable {
+    init?(environmentVariableValue: String) {
+        // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#duration
+        guard let value = Int(environmentVariableValue), value >= 0 else { return nil }
+        self = .milliseconds(value)
+    }
+
+    var environmentVariableValue: String {
+        String(components.seconds * 1000 + components.attoseconds / 1_000_000_000_000_000)
+    }
+
+    static var hint: String? { "Value must be a non-negative integer number of milliseconds" }
+}
+
+extension String: OTelEnvironmentVariableRepresentable {
+    init?(environmentVariableValue: String) { self = environmentVariableValue }
+    var environmentVariableValue: String { self }
+}
+
+extension RawRepresentable where RawValue == String {
+    init?(environmentVariableValue: String) { self.init(rawValue: environmentVariableValue) }
+    var environmentVariableValue: String { rawValue }
+}
+
+extension CaseIterable where AllCases.Element: RawRepresentable, AllCases.Element.RawValue == String {
+    static var supportedEnvironmentVariableValues: [String] { Self.allCases.map(\.rawValue) }
+}
+
+protocol OTelEnum<Backing>: OTelEnvironmentVariableRepresentable where Backing: RawRepresentable<String> & CaseIterable {
+    associatedtype Backing
+    var backing: Backing { get }
+    init(backing: Backing)
+}
+
+extension OTelEnum {
+    init?(environmentVariableValue: String) {
+        guard let backing = Backing(environmentVariableValue: environmentVariableValue) else { return nil }
+        self.init(backing: backing)
+    }
+
+    var environmentVariableValue: String { backing.environmentVariableValue }
+    static var supportedEnvironmentVariableValues: [String] { Backing.supportedEnvironmentVariableValues }
+    static var hint: String? { "Value must be one of: \(Backing.supportedEnvironmentVariableValues)" }
+}
+
+extension Array: OTelEnvironmentVariableRepresentable where Element: OTelEnvironmentVariableRepresentable {
+    init?(environmentVariableValue: String) {
+        /// The OTel spec is pretty clear about how to handle unsupported values: the SDK should log and fallback to the
+        /// default.
+        ///
+        /// However, it's not clear on how an SDK should behave when only some of the values in a comma-separated list
+        /// are unsupported.
+        ///
+        /// There are a few options:
+        /// 1. Just use the valid values, and warn and skip the invalid ones.
+        /// 2. If any are invalid, warn and abort the override. override.
+        ///
+        /// This implementation goes for (2) since if an adopter has chosen a list, we cannot decide that a partial
+        /// override is acceptable for them. And, in the cases where they provide only invalid values, allowing this
+        /// to proceed with an empty list may be very harmful. For example, a typo in the sampler configuration should
+        /// not result in no sampling, since the adopter presumably wants sampling, and it's possible that disabling
+        /// sampling altogether wll have a negative performance implication.
+        var newValues: [Element] = []
+        for proposedValue in environmentVariableValue.split(separator: ",") {
+            guard let value = Element(environmentVariableValue: String(proposedValue)) else { return nil }
+            newValues.append(value)
+        }
+        self = newValues
+    }
+
+    var environmentVariableValue: String {
+        map(\.environmentVariableValue).joined(separator: ",")
+    }
+
+    static var hint: String? {
+        guard let elementHint = Element.hint else { return nil }
+        return "Value must be a comma-separated list of values where, for each value: \(elementHint)"
+    }
+}
+
+extension Optional: OTelEnvironmentVariableRepresentable where Wrapped: OTelEnvironmentVariableRepresentable {
+    init?(environmentVariableValue: String) {
+        guard let value = Wrapped(environmentVariableValue: environmentVariableValue) else { return nil }
+        self = .some(value)
+    }
+
+    var environmentVariableValue: String {
+        switch self {
+        case .some(let value): value.environmentVariableValue
+        case .none: "none"
+        }
+    }
+}
+
+extension OTel.Configuration.Propagator: OTelEnum {}
+extension OTel.Configuration.LogLevel: OTelEnum {}
+extension OTel.Configuration.LogsConfiguration.ExporterSelection: OTelEnum {}
+extension OTel.Configuration.MetricsConfiguration.ExporterSelection: OTelEnum {}
+extension OTel.Configuration.TracesConfiguration.ExporterSelection: OTelEnum {}
+extension OTel.Configuration.OTLPExporterConfiguration.Compression: OTelEnum {}
+// swiftformat:disable:next redundantBackticks
+extension OTel.Configuration.OTLPExporterConfiguration.`Protocol`: OTelEnum {}
+extension OTel.Configuration.TracesConfiguration.SamplerConfiguration.Backing: OTelEnvironmentVariableRepresentable {}
+
+extension OTel.Configuration.TracesConfiguration.SamplerConfiguration.ArgumentBacking? {
+    internal mutating func override(for sampler: OTel.Configuration.TracesConfiguration.SamplerConfiguration.Backing, using key: OTel.Configuration.Key.GeneralKey, from environment: [String: String], logger: Logger? = nil) {
+        if let proposedValue = environment.getStringValue(key) {
+            let result: OTelEnvironmentOverrideResult
+            let previousValue = self
+
+            switch sampler {
+            case .traceIDRatio, .parentBasedTraceIDRatio:
+                guard let value = Double(proposedValue), value >= 0.0, value <= 1.0 else {
+                    result = .failure(hint: "Value must be a sampling probability: a number in the [0..1] range, e.g. `0.25`")
+                    break
+                }
+                self = .traceIDRatio(samplingProbability: value)
+                result = .success
+            case .jaegerRemote, .parentBasedJaegerRemote:
+                // Example: endpoint=http://localhost:14250,pollingIntervalMs=5000,initialSamplingRate=0.25
+                let parameters = proposedValue.split(separator: ",", maxSplits: 3).map { $0.split(separator: "=", maxSplits: 2) }
+                guard
+                    parameters.count == 3, parameters.allSatisfy({ $0.count == 2 }),
+                    parameters[0][0] == "endpoint",
+                    let endpoint = String(parameters[0][1]) as String?,
+                    parameters[1][0] == "pollingIntervalMs",
+                    let pollingIntervalMilliseconds = Int(parameters[1][1]),
+                    parameters[2][0] == "initialSamplingRate",
+                    let initialSamplingRate = Double(parameters[2][1])
+                else {
+                    result = .failure(hint: "Value must be an comma-separated list of key-value pairs in a specific order. Example: `endpoint=http://localhost:14250,pollingIntervalMs=5000,initialSamplingRate=0.25`")
+                    break
+                }
+                self = .jaegerRemote(
+                    endpoint: endpoint,
+                    pollingInterval: .milliseconds(pollingIntervalMilliseconds),
+                    initialSamplingRate: initialSamplingRate
+                )
+                result = .success
+            default:
+                result = .failure(hint: "Argument is not supported for \(sampler) sampler")
+            }
+
+            logger?.logOverride(
+                environmentKey: key.key,
+                environmentValue: proposedValue,
+                previousValue: previousValue.environmentVariableValue,
+                newValue: environmentVariableValue,
+                result: result
+            )
+        }
+    }
+
+    var environmentVariableValue: String {
+        switch self {
+        case .traceIDRatio(let samplingProbability):
+            "\(samplingProbability)"
+        case .jaegerRemote(let endpoint, let pollingInterval, let initialSamplingRate):
+            "endpoint=\(endpoint),pollingIntervalMs=\(pollingInterval),initialSamplingRate=\(initialSamplingRate)"
+        case .none: "none"
+        }
+    }
+}
+
+struct OTelHeaders {
+    var backing: [(String, String)]
+}
+
+extension OTelHeaders: OTelEnvironmentVariableRepresentable {
+    init?(environmentVariableValue: String) {
+        // https://opentelemetry.io/docs/specs/otel/protocol/exporter/#specifying-headers-via-environment-variables
+        var backing: [(String, String)] = []
+        for header in environmentVariableValue.utf8.split(separator: .init(ascii: ",")) {
+            let pair = header.split(separator: .init(ascii: "="), maxSplits: 1, omittingEmptySubsequences: true)
+            guard let key = pair.first, let value = pair.dropFirst().first else { return nil }
+            backing.append((
+                String(decoding: key, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines),
+                String(decoding: value, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+            ))
+        }
+        self.backing = backing
+    }
+
+    var environmentVariableValue: String {
+        backing.map { key, value in "\(key)=\(value)" }.joined(separator: ",")
+    }
+}
+
+struct OTelResourceAttributes {
+    var backing: [String: String]
+}
+
+extension OTelResourceAttributes: OTelEnvironmentVariableRepresentable {
+    init?(environmentVariableValue: String) {
+        // https://opentelemetry.io/docs/specs/otel/resource/sdk/#specifying-resource-information-via-an-environment-variable
+        guard let resourceAttributes = OTelHeaders(environmentVariableValue: environmentVariableValue) else {
+            return nil
+        }
+        backing = Dictionary(resourceAttributes.backing, uniquingKeysWith: { _, second in second })
+    }
+
+    var environmentVariableValue: String {
+        backing.map { key, value in "\(key)=\(value)" }.joined(separator: ",")
+    }
+
+    internal mutating func merge(using key: OTel.Configuration.Key.GeneralKey, from environment: [String: String], logger: Logger? = nil) {
+        guard let proposedValue = environment[key.key] else { return }
+        let previousValue = self
+        let result: OTelEnvironmentOverrideResult
+        if let resourceAttributes = OTelHeaders(environmentVariableValue: proposedValue) {
+            let incomingAttributes = Dictionary(resourceAttributes.backing, uniquingKeysWith: { _, second in second })
+            backing.merge(incomingAttributes, uniquingKeysWith: { current, _ in current })
+            result = .success
+        } else {
+            result = .failure(hint: "Value must be comma-separated key=value pairs")
+        }
+
+        logger?.logOverride(
+            environmentKey: key.key,
+            environmentValue: proposedValue,
+            previousValue: previousValue.environmentVariableValue,
+            newValue: environmentVariableValue,
+            result: result
+        )
+    }
+}
+
+extension [(String, String)] {
+    internal mutating func override(using key: OTel.Configuration.Key.SignalSpecificKey, for signal: OTel.Configuration.Key.Signal, from environment: [String: String], logger: Logger? = nil) {
+        var headers = OTelHeaders(backing: self)
+        headers.override(using: .otlpExporterHeaders, for: signal, from: environment, logger: logger)
+        self = headers.backing
+    }
+}
+
+extension [String: String] {
+    internal mutating func merge(using key: OTel.Configuration.Key.GeneralKey, from environment: [String: String], logger: Logger? = nil) {
+        var resourceAttributes = OTelResourceAttributes(backing: self)
+        resourceAttributes.merge(using: key, from: environment, logger: logger)
+        self = resourceAttributes.backing
+    }
+}

--- a/Sources/OTelCore/OTel+Configuration+EnvironmentVariableRepresentable.swift
+++ b/Sources/OTelCore/OTel+Configuration+EnvironmentVariableRepresentable.swift
@@ -167,13 +167,13 @@ extension Array: OTelEnvironmentVariableRepresentable where Element: OTelEnviron
         ///
         /// There are a few options:
         /// 1. Just use the valid values, and warn and skip the invalid ones.
-        /// 2. If any are invalid, warn and abort the override. override.
+        /// 2. If any are invalid, warn and abort the override.
         ///
         /// This implementation goes for (2) since if an adopter has chosen a list, we cannot decide that a partial
         /// override is acceptable for them. And, in the cases where they provide only invalid values, allowing this
         /// to proceed with an empty list may be very harmful. For example, a typo in the sampler configuration should
         /// not result in no sampling, since the adopter presumably wants sampling, and it's possible that disabling
-        /// sampling altogether wll have a negative performance implication.
+        /// sampling altogether will have a negative performance implication.
         var newValues: [Element] = []
         for proposedValue in environmentVariableValue.split(separator: ",") {
             guard let value = Element(environmentVariableValue: String(proposedValue)) else { return nil }
@@ -242,7 +242,7 @@ extension OTel.Configuration.TracesConfiguration.SamplerConfiguration.ArgumentBa
                     parameters[2][0] == "initialSamplingRate",
                     let initialSamplingRate = Double(parameters[2][1])
                 else {
-                    result = .failure(hint: "Value must be an comma-separated list of key-value pairs in a specific order. Example: `endpoint=http://localhost:14250,pollingIntervalMs=5000,initialSamplingRate=0.25`")
+                    result = .failure(hint: "Value must be a comma-separated list of key-value pairs in a specific order. Example: `endpoint=http://localhost:14250,pollingIntervalMs=5000,initialSamplingRate=0.25`")
                     break
                 }
                 self = .jaegerRemote(

--- a/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
+++ b/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
@@ -39,6 +39,10 @@ import Testing
         #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
             "OTEL_LOG_LEVEL": "trace",
         ]).diagnosticLogLevel.backing == .trace)
+
+        #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_LOG_LEVEL": "invalid",
+        ]).diagnosticLogLevel.backing == .info)
     }
 
     // OTEL_SERVICE_NAME
@@ -88,15 +92,19 @@ import Testing
     // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
     // https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_propagators
     @Test func testPropagators() {
-        #expect(OTel.Configuration.default.propagators.map(\.backing) == [.traceContext, .baggage])
+        #expect(OTel.Configuration.default.propagators.map(\.backing) == [.traceContext])
 
         #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
             "OTEL_PROPAGATORS": "b3,xray",
         ]).propagators.map(\.backing) == [.b3, .xray])
 
         #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_PROPAGATORS": "b3,xray,invalid",
+        ]).propagators.map(\.backing) == OTel.Configuration.default.propagators.map(\.backing))
+
+        #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
             "OTEL_PROPAGATORS": "none",
-        ]).propagators.map(\.backing) == [])
+        ]).propagators.map(\.backing) == [.none])
     }
 
     // OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG
@@ -126,6 +134,23 @@ import Testing
         ]) { config in
             #expect(config.traces.sampler.backing == .traceIDRatio)
             #expect(config.traces.sampler.argument == .traceIDRatio(samplingProbability: 0.25))
+        }
+
+        // TODO: this test needs some work (out of range probablilty)
+        OTel.Configuration.default.withEnvironmentOverrides(environment: [
+            "OTEL_TRACES_SAMPLER": "traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "1.25",
+        ]) { config in
+            #expect(config.traces.sampler.backing == .traceIDRatio)
+            #expect(config.traces.sampler.argument == nil)
+        }
+
+        OTel.Configuration.default.withEnvironmentOverrides(environment: [
+            "OTEL_TRACES_SAMPLER": "traceidratio",
+            "OTEL_TRACES_SAMPLER_ARG": "-0.25",
+        ]) { config in
+            #expect(config.traces.sampler.backing == .traceIDRatio)
+            #expect(config.traces.sampler.argument == nil)
         }
 
         #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
@@ -162,6 +187,18 @@ import Testing
         #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
             "OTEL_TRACES_SAMPLER": "xray",
         ]).traces.sampler.backing == .xray)
+
+        OTel.Configuration.default.with { _ in
+            typealias Sampler = OTel.Configuration.TracesConfiguration.SamplerConfiguration
+            #expect(Sampler.traceIDRatio.argument == .traceIDRatio(samplingProbability: 1.0))
+            #expect(Sampler.traceIDRatio(ratio: 0.25)?.argument == .traceIDRatio(samplingProbability: 0.25))
+            #expect(Sampler.traceIDRatio(ratio: 1.1) == nil)
+            #expect(Sampler.traceIDRatio(ratio: -0.25) == nil)
+            #expect(Sampler.parentBasedTraceIDRatio.argument == .traceIDRatio(samplingProbability: 1.0))
+            #expect(Sampler.parentBasedTraceIDRatio(ratio: 0.25)?.argument == .traceIDRatio(samplingProbability: 0.25))
+            #expect(Sampler.parentBasedTraceIDRatio(ratio: 1.1) == nil)
+            #expect(Sampler.parentBasedTraceIDRatio(ratio: -0.25) == nil)
+        }
     }
 
     // OTEL_BSP_SCHEDULE_DELAY
@@ -496,6 +533,16 @@ import Testing
         // OTLP/HTTP environment overrides.
         OTel.Configuration.default.with { config in
             config.traces.otlpExporter.protocol = .httpProtobuf
+
+            // Doesn't mess up the endpoint computation if no environment is set.
+            config.withEnvironmentOverrides(environment: [:]) { config in
+                #expect(config.logs.otlpExporter.endpoint == OTel.Configuration.default.metrics.otlpExporter.endpoint)
+                #expect(config.logs.otlpExporter.logsHTTPEndpoint == OTel.Configuration.default.metrics.otlpExporter.logsHTTPEndpoint)
+                #expect(config.metrics.otlpExporter.endpoint == OTel.Configuration.default.metrics.otlpExporter.endpoint)
+                #expect(config.metrics.otlpExporter.metricsHTTPEndpoint == OTel.Configuration.default.metrics.otlpExporter.metricsHTTPEndpoint)
+                #expect(config.traces.otlpExporter.endpoint == OTel.Configuration.default.metrics.otlpExporter.endpoint)
+                #expect(config.traces.otlpExporter.tracesHTTPEndpoint == OTel.Configuration.default.metrics.otlpExporter.tracesHTTPEndpoint)
+            }
 
             // Applies signal-specific suffix.
             config.withEnvironmentOverrides(environment: [
@@ -836,7 +883,7 @@ import Testing
 extension OTel.Configuration {
     fileprivate func applyingEnvironmentOverrides(environment: [String: String]) -> Self {
         var result = self
-        result.applyEnvironmentOverrides(environment: environment)
+        result.applyEnvironmentOverrides(environment: environment, logger: ._otelDisabled)
         return result
     }
 

--- a/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
+++ b/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
@@ -136,7 +136,6 @@ import Testing
             #expect(config.traces.sampler.argument == .traceIDRatio(samplingProbability: 0.25))
         }
 
-        // TODO: this test needs some work (out of range probablilty)
         OTel.Configuration.default.withEnvironmentOverrides(environment: [
             "OTEL_TRACES_SAMPLER": "traceidratio",
             "OTEL_TRACES_SAMPLER_ARG": "1.25",


### PR DESCRIPTION
## Motivation

As part of the 1.0 roadmap (#206), we've providing config-driven APIs, and ones that support environment overrides. This has been in place for a while, but there's some specific behaviour we want for unsupported configuration, which is driven by the OTel spec. Specifically:

- When we detect unrecognised configuration in the environment variables, we should warn, using the diagnostic logger, and not override.
- When we detect recognised, but unsupported configuration in the environment variables (i.e. in the OTel spec, but not supported by Swift OTel), we'd like to have this fail differently.
- Unrecognised in-code configuration is vacuously unreachable, but for recognised, but unsupported configuration can be marked as unilaterally unavailable.

## Modifications

This PR is a bit on the chunky side, because configuration is naturally a wide-spread thing, but much of it is moving existing functionality from one place to another.

- Create an internal `protocol OTelEnvironmentRepresentable`, for types that we want to be able to override from environment variables.
- Provide a centralised `override(...)` function that operates on types that conform to `OTelEnvironmentRepresentable` which allows for a consistent user experience for how successful and unsuccessful overrides are handled and logged, including with a hint of supported values.
- Move the logic that parses types (boolean, integer, durations, timeouts, enums, etc.) from environment variables according to the OTel spec from `OTel+Configuration+EnvironmentOverrides.swift` to be alongside `OTel+Configuration+EnvironmentVaraibleRepresentable.swift`.
- Add a `case none` to internal backing enums, which allows them to use the centralised override logic with the `"none"` environment variable, as the OTel spec requires for enum types.
- Support setting the propagators, which was hard-coded until now (including disabling them).
- Validation for the sampling probability parameter passed to `.traceIDRatio` (resulting in an API change).
- Extend tests to cover more invalid scenarios.

## Result

- Attempting to use configuration from the spec that is not supported from Swift OTel will be a compile time error:

```swift
var config = OTel.Configuration.default
config.propagators = [.jaeger]  // error: 'jaeger' is unavailable: This option is not supported by Swift OTel
```

- Every successful configuration override from environment variable is logged at info level to the diagnostic logger, with the environment variable name, previous value, and new value—for example:
- Every failed configuration override from environment variable is logged at warning level to the diagnostic logger, with the environment variable name, previous value, and new value, and a hint explaining why the value was not supported.

Here are some examples, generated by running the tests with a diagnostic logger:

```
􀟈 Test testBatchLogRecordProcessorExportTimeout() started.
2025-07-21T12:18:51+0100 info  : environment_key=OTEL_BLRP_EXPORT_TIMEOUT environment_value=15000 new_value=15000 previous_value=30000 [OTelCore] Configuration updated from environment
2025-07-21T12:18:51+0100 info  : environment_key=OTEL_BLRP_EXPORT_TIMEOUT environment_value=0 new_value=0 previous_value=30000 [OTelCore] Configuration updated from environment
2025-07-21T12:18:51+0100 warning  : environment_key=OTEL_BLRP_EXPORT_TIMEOUT environment_value=-5000 hint=Value must be a non-negative integer number of milliseconds new_value=30000 previous_value=30000 [OTelCore] Failed to update configuration from environment
2025-07-21T12:18:51+0100 warning  : environment_key=OTEL_BLRP_EXPORT_TIMEOUT environment_value=invalid hint=Value must be a non-negative integer number of milliseconds new_value=30000 previous_value=30000 [OTelCore] Failed to update configuration from environment
􁁛 Test testBatchLogRecordProcessorExportTimeout() passed after 0.001 seconds.

...

􀟈 Test testPropagators() started.
2025-07-21T12:20:17+0100 info  : environment_key=OTEL_PROPAGATORS environment_value=b3,xray new_value=b3,xray previous_value=tracecontext [OTelCore] Configuration updated from environment
2025-07-21T12:20:17+0100 warning  : environment_key=OTEL_PROPAGATORS environment_value=b3,xray,invalid hint=Value must be a comma-separated list of values where, for each value: Value must be one of: ["tracecontext", "baggage", "b3", "b3multi", "jaeger", "xray", "otTrace", "none"] new_value=tracecontext previous_value=tracecontext [OTelCore] Failed to update configuration from environment
2025-07-21T12:20:17+0100 info  : environment_key=OTEL_PROPAGATORS environment_value=none new_value=none previous_value=tracecontext [OTelCore] Configuration updated from environment
􁁛 Test testPropagators() passed after 0.001 seconds.
```
