### PR TITLE
Relax package requirements to macOS 13, iOS 16, tvOS 16, watchOS 9, visionOS 1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,13 @@ import PackageDescription
 
 let sharedSwiftSettings: [SwiftSetting] = [
     .enableUpcomingFeature("InternalImportsByDefault"),
+    PlatformRequirements.clockAPI.availabilityMacro,
+    PlatformRequirements.gRPCSwift.availabilityMacro,
 ]
 
 let package = Package(
     name: "swift-otel",
-    platforms: [.macOS(.v15), .iOS(.v18), .tvOS(.v18), .watchOS(.v11), .visionOS(.v2)],
+    platforms: PlatformRequirements.clockAPI.supportedPlatforms,
     products: [
         .library(name: "OTel", targets: ["OTel"]),
     ],

--- a/Sources/OTLPGRPC/Logging/OTLPGRPCLogRecordExporter.swift
+++ b/Sources/OTLPGRPC/Logging/OTLPGRPCLogRecordExporter.swift
@@ -16,6 +16,7 @@ package import OTelCore
 import OTLPCore
 package import Logging
 
+@available(gRPCSwift, *)
 package final class OTLPGRPCLogRecordExporter: OTelLogRecordExporter {
     typealias Client = Opentelemetry_Proto_Collector_Logs_V1_LogsService.Client<HTTP2ClientTransport.Posix>
     private let client: OTLPGRPCExporter<Client>

--- a/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporter.swift
+++ b/Sources/OTLPGRPC/Metrics/OTLPGRPCMetricExporter.swift
@@ -17,6 +17,7 @@ import OTLPCore
 package import Logging
 
 /// A metrics exporter emitting metric batches to an OTel collector via gRPC.
+@available(gRPCSwift, *)
 package final class OTLPGRPCMetricExporter: OTelMetricExporter {
     typealias Client = Opentelemetry_Proto_Collector_Metrics_V1_MetricsService.Client<HTTP2ClientTransport.Posix>
     private let client: OTLPGRPCExporter<Client>

--- a/Sources/OTLPGRPC/OTLPGRPCExporter.swift
+++ b/Sources/OTLPGRPC/OTLPGRPCExporter.swift
@@ -18,6 +18,7 @@ import Logging
 import OTelCore
 
 /// Unifying protocol for shared OTLP/gRPC exporter across signals.
+@available(gRPCSwift, *)
 protocol OTLPGRPCClient<Transport, Request, Response> where Response: Sendable, Transport: ClientTransport {
     associatedtype Transport
     associatedtype Request
@@ -33,10 +34,14 @@ protocol OTLPGRPCClient<Transport, Request, Response> where Response: Sendable, 
     ) async throws -> Result where Result: Sendable
 }
 
+@available(gRPCSwift, *)
 extension Opentelemetry_Proto_Collector_Logs_V1_LogsService.Client: OTLPGRPCClient {}
+@available(gRPCSwift, *)
 extension Opentelemetry_Proto_Collector_Metrics_V1_MetricsService.Client: OTLPGRPCClient {}
+@available(gRPCSwift, *)
 extension Opentelemetry_Proto_Collector_Trace_V1_TraceService.Client: OTLPGRPCClient {}
 
+@available(gRPCSwift, *)
 final class OTLPGRPCExporter<Client: OTLPGRPCClient>: Sendable where Client: Sendable, Client.Transport == HTTP2ClientTransport.Posix {
     private let logger: Logger
     private let underlyingClient: GRPCClient<Client.Transport>
@@ -80,6 +85,7 @@ final class OTLPGRPCExporter<Client: OTLPGRPCClient>: Sendable where Client: Sen
     }
 }
 
+@available(gRPCSwift, *)
 enum OTLPGRPCExporterError: Swift.Error {
     case invalidEndpoint(String)
     case partialMTLSdConfiguration
@@ -87,6 +93,7 @@ enum OTLPGRPCExporterError: Swift.Error {
     case invalidProtocol
 }
 
+@available(gRPCSwift, *)
 extension HTTP2ClientTransport.Posix.Config {
     init(_ configuration: OTel.Configuration.OTLPExporterConfiguration) {
         self = .defaults
@@ -97,6 +104,7 @@ extension HTTP2ClientTransport.Posix.Config {
     }
 }
 
+@available(gRPCSwift, *)
 extension CallOptions {
     init(_ configuration: OTel.Configuration.OTLPExporterConfiguration) {
         self = .defaults
@@ -110,6 +118,7 @@ extension CallOptions {
     }
 }
 
+@available(gRPCSwift, *)
 extension HTTP2ClientTransport.Posix {
     init(_ configuration: OTel.Configuration.OTLPExporterConfiguration) throws {
         guard
@@ -161,6 +170,7 @@ extension HTTP2ClientTransport.Posix {
     }
 }
 
+@available(gRPCSwift, *)
 extension Metadata {
     init(_ configuration: OTel.Configuration.OTLPExporterConfiguration) {
         self.init()

--- a/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporter.swift
+++ b/Sources/OTLPGRPC/Tracing/OTLPGRPCSpanExporter.swift
@@ -17,6 +17,7 @@ import OTLPCore
 package import Logging
 
 /// A span exporter emitting span batches to an OTel collector via gRPC.
+@available(gRPCSwift, *)
 package final class OTLPGRPCSpanExporter: OTelSpanExporter {
     typealias Client = Opentelemetry_Proto_Collector_Trace_V1_TraceService.Client<HTTP2ClientTransport.Posix>
     private let client: OTLPGRPCExporter<Client>

--- a/Sources/OTel/OTelCore+GenericWrappers.swift
+++ b/Sources/OTel/OTelCore+GenericWrappers.swift
@@ -88,8 +88,12 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
             switch configuration.logs.otlpExporter.protocol.backing {
             case .grpc:
                 #if OTLPGRPC
-                let exporter = try OTLPGRPCLogRecordExporter(configuration: configuration.logs.otlpExporter, logger: logger)
-                self = .grpc(exporter)
+                if #available(gRPCSwift, *) {
+                    let exporter = try OTLPGRPCLogRecordExporter(configuration: configuration.logs.otlpExporter, logger: logger)
+                    self = .grpc(exporter)
+                } else {
+                    fatalError("Using the OTLP/gRPC exporter is not supported on this platform.")
+                }
                 #else // OTLPGRPC
                 fatalError("Using the OTLP/gRPC exporter requires the `OTLPGRPC` trait enabled.")
                 #endif
@@ -145,8 +149,12 @@ internal enum WrappedMetricExporter: OTelMetricExporter {
             switch configuration.metrics.otlpExporter.protocol.backing {
             case .grpc:
                 #if OTLPGRPC
-                let exporter = try OTLPGRPCMetricExporter(configuration: configuration.metrics.otlpExporter, logger: logger)
-                self = .grpc(exporter)
+                if #available(gRPCSwift, *) {
+                    let exporter = try OTLPGRPCMetricExporter(configuration: configuration.metrics.otlpExporter, logger: logger)
+                    self = .grpc(exporter)
+                } else {
+                    fatalError("Using the OTLP/gRPC exporter is not supported on this platform.")
+                }
                 #else // OTLPGRPC
                 fatalError("Using the OTLP/gRPC exporter requires the `OTLPGRPC` trait enabled.")
                 #endif
@@ -202,8 +210,12 @@ internal enum WrappedSpanExporter: OTelSpanExporter {
             switch configuration.traces.otlpExporter.protocol.backing {
             case .grpc:
                 #if OTLPGRPC
-                let exporter = try OTLPGRPCSpanExporter(configuration: configuration.traces.otlpExporter, logger: logger)
-                self = .grpc(exporter)
+                if #available(gRPCSwift, *) {
+                    let exporter = try OTLPGRPCSpanExporter(configuration: configuration.traces.otlpExporter, logger: logger)
+                    self = .grpc(exporter)
+                } else {
+                    fatalError("Using the OTLP/gRPC exporter is not supported on this platform.")
+                }
                 #else // OTLPGRPC
                 fatalError("Using the OTLP/gRPC exporter requires the `OTLPGRPC` trait enabled.")
                 #endif

--- a/Sources/OTelCore/OTel+Configuration.swift
+++ b/Sources/OTelCore/OTel+Configuration.swift
@@ -855,6 +855,7 @@ extension OTel.Configuration.OTLPExporterConfiguration {
         #if !OTLPGRPC
         @available(*, unavailable, message: "Using the OTLP/gRPC exporter requires the `OTLPGRPC` trait enabled.")
         #endif
+        @available(gRPCSwift, *)
         public static let grpc: Self = .init(backing: .grpc)
 
         /// HTTP transport with Protocol Buffers encoding for OTLP.

--- a/Tests/OTLPGRPCTests/Metrics/OTLPGRPCMetricExporterTests.swift
+++ b/Tests/OTLPGRPCTests/Metrics/OTLPGRPCMetricExporterTests.swift
@@ -18,6 +18,7 @@ import OTLPCore
 @testable import OTLPGRPC
 import XCTest
 
+@available(gRPCSwift, *)
 final class OTLPGRPCMetricExporterTests: XCTestCase {
     private var requestLogger: Logger!
     private var backgroundActivityLogger: Logger!
@@ -184,6 +185,7 @@ final class OTLPGRPCMetricExporterTests: XCTestCase {
     }
 }
 
+@available(gRPCSwift, *)
 extension OTLPGRPCMetricExporter {
     // Overload with logging disabled.
     convenience init(configuration: OTel.Configuration.OTLPExporterConfiguration) throws {

--- a/Tests/OTLPGRPCTests/OTLPGRPCMockCollector.swift
+++ b/Tests/OTLPGRPCTests/OTLPGRPCMockCollector.swift
@@ -18,6 +18,7 @@ import OTLPGRPC
 import SwiftProtobuf
 import XCTest
 
+@available(gRPCSwift, *)
 final class OTLPGRPCMockCollector: Sendable {
     let recordingMetricsService = RecordingMetricsService()
     let recordingTraceService = RecordingTraceService()
@@ -76,6 +77,7 @@ final class OTLPGRPCMockCollector: Sendable {
     }
 }
 
+@available(gRPCSwift, *)
 final class RecordingService<Request, Response>: Sendable where Request: Message, Response: Message {
     struct RecordedRequest {
         var message: Request
@@ -95,6 +97,7 @@ final class RecordingService<Request, Response>: Sendable where Request: Message
     }
 }
 
+@available(gRPCSwift, *)
 final class RecordingTraceService: Opentelemetry_Proto_Collector_Trace_V1_TraceService.ServiceProtocol {
     typealias Request = Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest
     typealias Response = Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse
@@ -104,6 +107,7 @@ final class RecordingTraceService: Opentelemetry_Proto_Collector_Trace_V1_TraceS
     }
 }
 
+@available(gRPCSwift, *)
 final class RecordingMetricsService: Opentelemetry_Proto_Collector_Metrics_V1_MetricsService.ServiceProtocol {
     typealias Request = Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest
     typealias Response = Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceResponse

--- a/Tests/OTLPGRPCTests/Tracing/OTLPGRPCSpanExporterTests.swift
+++ b/Tests/OTLPGRPCTests/Tracing/OTLPGRPCSpanExporterTests.swift
@@ -19,6 +19,7 @@ import OTelTesting
 import Tracing
 import XCTest
 
+@available(gRPCSwift, *)
 final class OTLPGRPCSpanExporterTests: XCTestCase {
     private var requestLogger: Logger!
     private var backgroundActivityLogger: Logger!
@@ -149,6 +150,7 @@ final class OTLPGRPCSpanExporterTests: XCTestCase {
     }
 }
 
+@available(gRPCSwift, *)
 extension OTLPGRPCSpanExporter {
     // Overload with logging disabled.
     convenience init(configuration: OTel.Configuration.OTLPExporterConfiguration) throws {

--- a/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
+++ b/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
@@ -458,11 +458,11 @@ import Testing
         ]).logs.enabled == false)
     }
 
-    // OTEL_EXPORTER_OTLP_ENDPOINT
+    // OTEL_EXPORTER_OTLP_ENDPOINT (OTLP/HTTP edition).
     // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
     // https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options
     // https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
-    @Test func testOTLPExporterEndpoint() {
+    @Test func testOTLPExporterEndpointHTTP() {
         #expect(OTel.Configuration.OTLPExporterConfiguration.default.protocol == .httpProtobuf)
         #expect(OTel.Configuration.OTLPExporterConfiguration.default.endpoint == "http://localhost:4318")
         #expect(OTel.Configuration.OTLPExporterConfiguration.default.logsHTTPEndpoint == "http://localhost:4318/v1/logs")
@@ -528,7 +528,14 @@ import Testing
                 #expect(config.traces.otlpExporter.tracesHTTPEndpoint == "https://otel-collector.example.com:4318/v1/traces")
             }
         }
+    }
 
+    // OTEL_EXPORTER_OTLP_ENDPOINT (OTLP/gRPC edition).
+    // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+    // https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options
+    // https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
+    @available(gRPCSwift, *)
+    @Test func testOTLPExporterEndpointGRPC() {
         // OTLP/gRPC endpoint in-code overrides.
         OTel.Configuration.default.with { config in
             config.logs.otlpExporter.protocol = .grpc
@@ -648,6 +655,7 @@ import Testing
     // OTEL_EXPORTER_OTLP_PROTOCOL
     // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
     // https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options
+    @available(gRPCSwift, *)
     @Test func testOTLPExporterProtocol() {
         #expect(OTel.Configuration.OTLPExporterConfiguration.default.protocol == .httpProtobuf)
 

--- a/Tests/OTelTests/EndToEndTests.swift
+++ b/Tests/OTelTests/EndToEndTests.swift
@@ -492,7 +492,7 @@ import Tracing
             logger.info("outside")
             withSpan("span") { _ in logger.info("inside") }
         }
-        let lines = try #require(String(validating: result.standardErrorContent, as: UTF8.self)).split(separator: "\n")
+        let lines = try #require(String(bytes: result.standardErrorContent, encoding: .utf8)).split(separator: "\n")
         let outside = try #require(lines.first { $0.contains("outside") })
         let inside = try #require(lines.first { $0.contains("inside") })
         for metadataKey in ["span_id", "trace_id", "trace_flags"] {
@@ -519,7 +519,7 @@ import Tracing
             logger.info("outside")
             withSpan("span") { _ in logger.info("inside") }
         }
-        let lines = try #require(String(validating: result.standardErrorContent, as: UTF8.self)).split(separator: "\n")
+        let lines = try #require(String(bytes: result.standardErrorContent, encoding: .utf8)).split(separator: "\n")
         let outside = try #require(lines.first { $0.contains("outside") })
         let inside = try #require(lines.first { $0.contains("inside") })
         for metadataKey in ["🔧", "🫆", "🏴‍☠️"] {


### PR DESCRIPTION
## Motivation

When we updated the OTLP/gRPC exporters to gRPC Swift v2, we temporarily raised the minimum platform requirements for Swift OTel to match the requirements of gRPC Swift v2. These are pretty new (iOS 18 aligned), but the rest of the package only depends on iOS 16 aligned APIs (e.g. `Clock`, `Duration`, etc.).

Prior to this they were set to macOS 13 (incompletely: only macOS was specified).

There's a continuum of options here, including removing the package platform requirements entirely and using availability annotations on the entire API surface. Since the majority of the API depends on `Clock`, `Duration`, and friends, we have a practical minimum of macOS 13, iOS 16, etc., and the package would likely offer an empty API surface on platforms older than these.

This approach would be necessary if a _library_ package wanted to take a _new_ dependency on Swift OTel, that currently has more relaxed platform requirements (including no stated requirements), without resulting in a SemVer major for that package.

However, Swift OTel is intended for leaf/application packages as its principal offering is APIs for bootstrapping the Swift observability backends.

During API review on the forums, we did have a concrete request to not _raise_ the platform requirements from what they were in the 0.x releases. This was justified by app developers who need to support a few years of OS releases back, which seemed reasonable.

At this point, an important note is that it's always possible to relax the requirements of this package without a SemVer major, but increasing them is a breaking change.

The decision at the contributors meetup was to proceed with a pragmatic middle-ground: to lower the package platform requirements to macOS 13, iOS 16, etc., but defer removing them entirely for now.

## Modifications

- Define PlatformRequirements helper struct in Package.swift
- Drop package platform requirements and use `@available(gRPCSwift, *)` where needed

## Result

- Package requirements now macOS 13, iOS 16, tvOS 16, watchOS 9, visionOS 1
- OTLP/gRPC APIs marked as only available on macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2