### PR TITLE
Use matrix workflow to CI all example packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,55 @@ jobs:
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
 
+
+  construct-examples-matrix:
+    name: Example Package (Construct Matrix)
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.find-examples.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - name: Find examples
+        id: find-examples
+        run: |
+          find Examples/ -maxdepth 2 -name Package.swift -type f -print0 \
+          | xargs -0 dirname \
+          | jq -Rrs 'split("\n") | map(select(length > 0)) | {example: .}| @json | "matrix=\(.)"' \
+          | tee -a $GITHUB_OUTPUT
+
+  test-examples:
+    name: Example Package
+    runs-on: ubuntu-latest
+    needs: construct-examples-matrix
+    strategy:
+      matrix: ${{ fromJSON(needs.construct-examples-matrix.outputs.matrix) }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.example }}
+    steps:
+      - name: Install Swift
+        uses: vapor/swiftly-action@v0.2.0
+        with:
+          toolchain: latest
+        env:
+          SWIFTLY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4.2.2
+      - name: Override example package dependency on root package
+        run: swift package edit swift-otel --path ${{ github.workspace }}
+      - name: Resolve example package dependencies
+        run: swift package resolve
+      - name: Build example package
+        run: swift build
+      - name: Check if example package has tests
+        id: check-for-tests
+        run: |
+          if test -d Tests/; then
+            echo "example_has_tests=true" | tee -a $GITHUB_OUTPUT
+          fi
+      - name: Run example package tests
+        run: swift test
+        if: steps.check-for-tests.outputs.example_has_tests == 'true'
+
   compile-counter-example:
     name: Compile Counter Example
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,23 +111,3 @@ jobs:
       - name: Run example package tests
         run: swift test
         if: steps.check-for-tests.outputs.example_has_tests == 'true'
-
-  compile-counter-example:
-    name: Compile Counter Example
-    runs-on: ubuntu-24.04
-    defaults:
-      run:
-        working-directory: ./Examples/Counter
-    steps:
-      - name: Install Swift
-        uses: vapor/swiftly-action@v0.2.0
-        with:
-          toolchain: latest
-        env:
-          SWIFTLY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Checkout
-        uses: actions/checkout@v4.2.2
-      - name: Resolve Swift dependencies
-        run: swift package resolve
-      - name: Build
-        run: swift build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
     needs: construct-examples-matrix
     strategy:
       matrix: ${{ fromJSON(needs.construct-examples-matrix.outputs.matrix) }}
+      fail-fast: false
     defaults:
       run:
         working-directory: ${{ matrix.example }}

--- a/Examples/Counter/Package.swift
+++ b/Examples/Counter/Package.swift
@@ -8,7 +8,8 @@ let package = Package(
         .executable(name: "counter", targets: ["Example"]),
     ],
     dependencies: [
-        .package(name: "swift-otel", path: "../.."),
+        // TODO: update this to `from: 1.0.0` when we release 1.0.
+        .package(url: "https://github.com/swift-otel/swift-otel.git", branch: "main"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.4.1"),
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.0.0"),

--- a/Examples/Server/Package.swift
+++ b/Examples/Server/Package.swift
@@ -1,29 +1,21 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
 
 import PackageDescription
 
 let package = Package(
     name: "swift-otel-server-example",
-    platforms: [
-        .macOS(.v14),
-    ],
+    platforms: [.macOS(.v14)],
     dependencies: [
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
         .package(url: "https://github.com/swift-otel/swift-otel.git", branch: "main"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
-        .package(url: "https://github.com/apple/swift-metrics.git", from: "2.4.1"),
-        .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(
             name: "ServerExample",
             dependencies: [
-                .product(name: "OTel", package: "swift-otel"),
                 .product(name: "Hummingbird", package: "hummingbird"),
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "Metrics", package: "swift-metrics"),
-                .product(name: "Tracing", package: "swift-distributed-tracing"),
+                .product(name: "OTel", package: "swift-otel"),
             ]
         ),
     ]

--- a/Examples/Server/Package.swift
+++ b/Examples/Server/Package.swift
@@ -8,7 +8,8 @@ let package = Package(
         .macOS(.v14),
     ],
     dependencies: [
-        .package(name: "swift-otel", path: "../.."),
+        // TODO: update this to `from: 1.0.0` when we release 1.0.
+        .package(url: "https://github.com/swift-otel/swift-otel.git", branch: "main"),
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.4.1"),

--- a/Examples/Server/Sources/ServerExample/ServerExample.swift
+++ b/Examples/Server/Sources/ServerExample/ServerExample.swift
@@ -12,18 +12,13 @@
 //===----------------------------------------------------------------------===//
 
 import Hummingbird
-import Logging
-import Metrics
 import OTel
-import Tracing
 
 @main
 enum ServerMiddlewareExample {
     static func main() async throws {
         // Bootstrap the observability backends with default configuration.
-        // TODO: Uncomment this line when the 1.0 API is ready.
-        // let observability = try OTel.bootstrap()
-        let observability: ServiceGroup! = nil
+        let observability = try OTel.bootstrap()
 
         // Create an HTTP server with instrumentation middlewares added.
         let router = Router()


### PR DESCRIPTION
## Motivation

We currently have two example Swift packages in the repo and plan to rework them and add more. There are current draw backs with the testing strategy:

1. Only one of the example projects is built in CI.
2. The example projects depend on this package using `.package(name:path:)` using a local dependency which makes them unsuitable for lifting out of this repo.

## Modifications

- ci: Create matrix workflow for examples
- examples: Use upstream URL in example projects
- ci: Remove now vestigial, non-matrix job for counter example
- examples: Get HTTP server example passing CI


## Result

- CI now uses a matrix job to auto-discover, build, and test all example packages in `Examples/`.
- Example packages now depend on Swift OTel by URL so they're suitable for using by others.

## Notes

This PR contains the bare minimum to get the server example building in CI. We do want to iterate on it (and probably add more examples) but we should decouple that from this PR to get the CI in place.