### PR TITLE
Add missing trait compiler guards to fix macOS adopters

### DIFF
--- a/Sources/OTel/OTelCore+GenericWrappers.swift
+++ b/Sources/OTel/OTelCore+GenericWrappers.swift
@@ -49,36 +49,63 @@ import W3CTraceContext
 /// have performance implications.
 ///
 /// (2) is a better choice for a closed set of types since it introduces minimal overhead.
+///
+/// Note that, in order to abstract over platform availability and provide the package on older platforms that are not
+/// supported by gRPC Swift v2, some of the below wrapper enums _do_ hold an existential in one of their cases. In this
+/// case, they still add value because they:
+///
+/// (a) Allow us to remove the existential from the API surface.
+/// (b) Allow us to remove the existential completely for the OTLP/HTTP exporter.
 
 internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
-    case grpc(OTLPGRPCLogRecordExporter)
+    #if OTLPGRPC
+    case grpc(any OTelLogRecordExporter)
+    #endif
+    #if OTLPHTTP
     case http(OTLPHTTPLogRecordExporter)
+    #endif
 
     func run() async throws {
         switch self {
+        #if OTLPGRPC
         case .grpc(let exporter): try await exporter.run()
+        #endif
+        #if OTLPHTTP
         case .http(let exporter): try await exporter.run()
+        #endif
         }
     }
 
     func export(_ batch: some Collection<OTelLogRecord> & Sendable) async throws {
         switch self {
+        #if OTLPGRPC
         case .grpc(let exporter): try await exporter.export(batch)
+        #endif
+        #if OTLPHTTP
         case .http(let exporter): try await exporter.export(batch)
+        #endif
         }
     }
 
     func forceFlush() async throws {
         switch self {
+        #if OTLPGRPC
         case .grpc(let exporter): try await exporter.forceFlush()
+        #endif
+        #if OTLPHTTP
         case .http(let exporter): try await exporter.forceFlush()
+        #endif
         }
     }
 
     func shutdown() async {
         switch self {
+        #if OTLPGRPC
         case .grpc(let exporter): await exporter.shutdown()
+        #endif
+        #if OTLPHTTP
         case .http(let exporter): await exporter.shutdown()
+        #endif
         }
     }
 
@@ -113,34 +140,54 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
 }
 
 internal enum WrappedMetricExporter: OTelMetricExporter {
-    case grpc(OTLPGRPCMetricExporter)
+    #if OTLPGRPC
+    case grpc(any OTelMetricExporter)
+    #endif
+    #if OTLPHTTP
     case http(OTLPHTTPMetricExporter)
+    #endif
 
     func run() async throws {
         switch self {
+        #if OTLPGRPC
         case .grpc(let exporter): try await exporter.run()
+        #endif
+        #if OTLPHTTP
         case .http(let exporter): try await exporter.run()
+        #endif
         }
     }
 
     func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {
         switch self {
+        #if OTLPGRPC
         case .grpc(let exporter): try await exporter.export(batch)
+        #endif
+        #if OTLPHTTP
         case .http(let exporter): try await exporter.export(batch)
+        #endif
         }
     }
 
     func forceFlush() async throws {
         switch self {
+        #if OTLPGRPC
         case .grpc(let exporter): try await exporter.forceFlush()
+        #endif
+        #if OTLPHTTP
         case .http(let exporter): try await exporter.forceFlush()
+        #endif
         }
     }
 
     func shutdown() async {
         switch self {
+        #if OTLPGRPC
         case .grpc(let exporter): await exporter.shutdown()
+        #endif
+        #if OTLPHTTP
         case .http(let exporter): await exporter.shutdown()
+        #endif
         }
     }
 
@@ -175,34 +222,54 @@ internal enum WrappedMetricExporter: OTelMetricExporter {
 }
 
 internal enum WrappedSpanExporter: OTelSpanExporter {
-    case grpc(OTLPGRPCSpanExporter)
+    #if OTLPGRPC
+    case grpc(any OTelSpanExporter)
+    #endif
+    #if OTLPHTTP
     case http(OTLPHTTPSpanExporter)
+    #endif
 
     func run() async throws {
         switch self {
+        #if OTLPGRPC
         case .grpc(let exporter): try await exporter.run()
+        #endif
+        #if OTLPHTTP
         case .http(let exporter): try await exporter.run()
+        #endif
         }
     }
 
     func export(_ batch: some Collection<OTelFinishedSpan> & Sendable) async throws {
         switch self {
+        #if OTLPGRPC
         case .grpc(let exporter): try await exporter.export(batch)
+        #endif
+        #if OTLPHTTP
         case .http(let exporter): try await exporter.export(batch)
+        #endif
         }
     }
 
     func forceFlush() async throws {
         switch self {
+        #if OTLPGRPC
         case .grpc(let exporter): try await exporter.forceFlush()
+        #endif
+        #if OTLPHTTP
         case .http(let exporter): try await exporter.forceFlush()
+        #endif
         }
     }
 
     func shutdown() async {
         switch self {
+        #if OTLPGRPC
         case .grpc(let exporter): await exporter.shutdown()
+        #endif
+        #if OTLPHTTP
         case .http(let exporter): await exporter.shutdown()
+        #endif
         }
     }
 

--- a/Sources/OTelCore/OTel+Configuration.swift
+++ b/Sources/OTelCore/OTel+Configuration.swift
@@ -861,7 +861,7 @@ extension OTel.Configuration {
             headers: [],
             compression: .none,
             timeout: .seconds(10),
-            protocol: .httpProtobuf
+            protocol: .init(backing: .httpProtobuf)
         )
     }
 }


### PR DESCRIPTION
## Motivation

When developing the examples, for which there's an upcoming PR, I found there were some missing trait guards, meaning that you couldn't compile the project with lower platform. This is because it was unilaterally trying to use the gRPC symbols in the bootstraps. The only way we can resolve this is to introduce an existential at this layer. This is no worse than the behaviour we had until very recently, and still a significant improvement on having existential everywhere. Here they only exist for the exporter (not on the hot path for adopter code), and only when using gRPC (the price we'll have to pay to lower the minimum platform requirements for the package). 

## Modifications

- Add missing trait compiler guards

## Result

Downstream packages can compile without raising their minimum platform.

## Notes

Upcoming PRs will flesh out the examples, which will help us catch some of this. But the real reason this wasn't caught was because there's no macOS CI, since availability annotations are only relevant on Apple platforms.