### PR TITLE
Update .spi.yml targets and Swift version

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,4 +1,5 @@
 version: 1
 builder:
   configs:
-    - documentation_targets: [OTel, OTLPGRPC]
+    - documentation_targets: [OTel]
+      swift_version: 6.1


### PR DESCRIPTION
## Motivation

This package publishes its docs to Swift Package Index (SPI). The config needs updating to remove the modules that are no longer products, and to reflect the minimum required Swift version for the package.

## Modifications

- Update `.spi.yml` targets and Swift version

## Result

SPI should be able to ingest and publish docs for the `OTel` module.

## Notes

There's an upcoming PR to actually rework the DocC bundle, which is currently in the wrong place.