### PR TITLE
Add X-Ray ID generator

### DIFF
--- a/Sources/OTel/OTel+Backends.swift
+++ b/Sources/OTel/OTel+Backends.swift
@@ -311,12 +311,13 @@ extension OTel {
     public static func makeTracingBackend(configuration: OTel.Configuration = .default) throws -> (factory: some Tracer, service: some Service) {
         let logger = configuration.makeDiagnosticLogger()
         let resource = OTelResource(configuration: configuration)
+        let idGenerator = WrappedIDGenerator(configuration: configuration)
         let sampler = WrappedSampler(configuration: configuration)
         let propagator = OTelMultiplexPropagator(configuration: configuration)
         let exporter = try WrappedSpanExporter(configuration: configuration, logger: logger)
         let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(configuration: configuration.traces.batchSpanProcessor), logger: logger)
         let tracer = OTelTracer(
-            idGenerator: OTelRandomIDGenerator(),
+            idGenerator: idGenerator,
             sampler: sampler,
             propagator: propagator,
             processor: processor,

--- a/Sources/OTel/OTelCore+GenericWrappers.swift
+++ b/Sources/OTel/OTelCore+GenericWrappers.swift
@@ -303,6 +303,38 @@ internal enum WrappedSpanExporter: OTelSpanExporter {
     }
 }
 
+internal enum WrappedIDGenerator: OTelIDGenerator {
+    case random(OTelRandomIDGenerator<SystemRandomNumberGenerator>)
+    case xray(OTelXRayIDGenerator<SystemRandomNumberGenerator>)
+
+    func nextTraceID() -> TraceID {
+        switch self {
+        case .random(let wrapped):
+            wrapped.nextTraceID()
+        case .xray(let wrapped):
+            wrapped.nextTraceID()
+        }
+    }
+
+    func nextSpanID() -> SpanID {
+        switch self {
+        case .random(let wrapped):
+            wrapped.nextSpanID()
+        case .xray(let wrapped):
+            wrapped.nextSpanID()
+        }
+    }
+
+    init(configuration: OTel.Configuration) {
+        switch configuration.traces.idGenerator.backing {
+        case .random:
+            self = .random(OTelRandomIDGenerator())
+        case .xray:
+            self = .xray(OTelXRayIDGenerator())
+        }
+    }
+}
+
 internal enum WrappedSampler: OTelSampler {
     case alwaysOn(OTelConstantSampler)
     case alwaysOff(OTelConstantSampler)

--- a/Sources/OTelCore/Context/OTelXRayIDGenerator.swift
+++ b/Sources/OTelCore/Context/OTelXRayIDGenerator.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import struct Dispatch.DispatchWallTime
+import NIOConcurrencyHelpers
+package import W3CTraceContext
+
+/// Generates trace and span ids using a `RandomNumberGenerator` in an X-Ray compatible format.
+///
+/// - SeeAlso: [AWS X-Ray: Tracing header](https://docs.aws.amazon.com/xray/latest/devguide/xray-concepts.html#xray-concepts-tracingheader)
+package struct OTelXRayIDGenerator<NumberGenerator: RandomNumberGenerator & Sendable>: OTelIDGenerator {
+    private let getCurrentSecondsSinceEpoch: @Sendable () -> UInt32
+    private let randomNumberGenerator: NIOLockedValueBox<NumberGenerator>
+
+    package init(
+        randomNumberGenerator: NumberGenerator,
+        getCurrentSecondsSinceEpoch: @escaping @Sendable () -> UInt32
+    ) {
+        self.randomNumberGenerator = .init(randomNumberGenerator)
+        self.getCurrentSecondsSinceEpoch = getCurrentSecondsSinceEpoch
+    }
+
+    package func nextTraceID() -> TraceID {
+        var traceIDBytes = TraceID.Bytes((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+        withUnsafeMutableBytes(of: &traceIDBytes) { ptr in
+            ptr.storeBytes(of: self.getCurrentSecondsSinceEpoch().bigEndian, as: UInt32.self)
+            ptr.storeBytes(
+                of: randomNumberGenerator.withLockedValue { $0.next(upperBound: UInt32.max) }.bigEndian,
+                toByteOffset: 4,
+                as: UInt32.self
+            )
+            ptr.storeBytes(
+                of: randomNumberGenerator.withLockedValue { $0.next(upperBound: UInt64.max) }.bigEndian,
+                toByteOffset: 8,
+                as: UInt64.self
+            )
+        }
+        return TraceID(bytes: traceIDBytes)
+    }
+
+    package func nextSpanID() -> SpanID {
+        var spanIDBytes = SpanID.Bytes((0, 0, 0, 0, 0, 0, 0, 0))
+        withUnsafeMutableBytes(of: &spanIDBytes) { ptr in
+            ptr.storeBytes(of: randomNumberGenerator.withLockedValue { $0.next() }.bigEndian, as: UInt64.self)
+        }
+        return SpanID(bytes: spanIDBytes)
+    }
+}
+
+extension DispatchWallTime {
+    fileprivate var secondsSinceEpoch: UInt32 {
+        let seconds = Int64(bitPattern: self.rawValue) / -1_000_000_000
+        return UInt32(seconds)
+    }
+}
+
+extension OTelXRayIDGenerator where NumberGenerator == SystemRandomNumberGenerator {
+    package init() {
+        self.init(
+            randomNumberGenerator: SystemRandomNumberGenerator(),
+            getCurrentSecondsSinceEpoch: {
+                DispatchWallTime.now().secondsSinceEpoch
+            }
+        )
+    }
+}

--- a/Sources/OTelCore/OTel+Configuration.swift
+++ b/Sources/OTelCore/OTel+Configuration.swift
@@ -269,6 +269,9 @@ extension OTel.Configuration {
             get { !enabled }
         }
 
+        /// AWS X-Ray ID generator for AWS environments.
+        public var idGenerator: IDGeneratorConfiguration
+
         /// Sampler to be used for traces.
         ///
         /// - Environment variable(s): `OTEL_TRACES_SAMPLER`, `OTEL_TRACES_SAMPLER_ARG`.
@@ -297,6 +300,7 @@ extension OTel.Configuration {
         /// where possible.
         public static let `default`: Self = .init(
             enabled: true,
+            idGenerator: .random,
             sampler: .parentBasedAlwaysOn,
             batchSpanProcessor: .default,
             exporter: .otlp,
@@ -407,6 +411,24 @@ extension OTel.Configuration {
             exporter: .otlp,
             otlpExporter: .default
         )
+    }
+}
+
+extension OTel.Configuration.TracesConfiguration {
+    /// Selection of ID generator.
+    public struct IDGeneratorConfiguration: Sendable {
+        package enum Backing: Sendable {
+            case random
+            case xray
+        }
+
+        package var backing: Backing
+
+        /// A random ID generator.
+        public static let random: Self = .init(backing: .random)
+
+        /// AWS X-Ray propagator for AWS environments.
+        public static let xray: Self = .init(backing: .xray)
     }
 }
 

--- a/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
+++ b/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
@@ -107,6 +107,10 @@ import Testing
         ]).propagators.map(\.backing) == [.none])
     }
 
+    @Test func testIDGeneratorSelection() {
+        #expect(OTel.Configuration.default.traces.idGenerator.backing == .random)
+    }
+
     // OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG
     // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
     @Test func testSamplerSelection() {

--- a/Tests/OTelCoreTests/Context/OTelXRayIDGeneratorTests.swift
+++ b/Tests/OTelCoreTests/Context/OTelXRayIDGeneratorTests.swift
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import OTelCore
+import Testing
+import W3CTraceContext
+
+@Suite
+struct OTelXRayIDGeneratorTests {
+    @Test func generatesRandomTraceID() async throws {
+        let idGenerator = OTelXRayIDGenerator(
+            randomNumberGenerator: ConstantNumberGenerator(value: .max),
+            getCurrentSecondsSinceEpoch: { 1_616_064_590 }
+        )
+
+        let generatedTraceID = idGenerator.nextTraceID()
+        let expectedTraceID = TraceID(
+            bytes: .init((96, 83, 48, 78, 255, 255, 255, 254, 255, 255, 255, 255, 255, 255, 255, 254))
+        )
+
+        #expect(generatedTraceID == expectedTraceID)
+    }
+
+    @Test func generatesRandomTraceID_withRandomNumberGenerator() {
+        let idGenerator = OTelXRayIDGenerator(
+            randomNumberGenerator: ConstantNumberGenerator(value: .random(in: 0 ..< .max)),
+            getCurrentSecondsSinceEpoch: { 1_616_064_590 }
+        )
+
+        let randomTraceID = idGenerator.nextTraceID()
+
+        #expect(
+            randomTraceID.description.starts(with: "6053304e"),
+            "X-Ray trace ids must start with the current timestamp."
+        )
+    }
+
+    @Test func generatesUniqueTraceIDs() {
+        let idGenerator = OTelXRayIDGenerator()
+        var traceIDs = Set<TraceID>()
+
+        for _ in 0 ..< 1000 {
+            traceIDs.insert(idGenerator.nextTraceID())
+        }
+
+        #expect(traceIDs.count == 1000, "Generating 1000 X-Ray trace ids should result in 1000 unique trace ids.")
+    }
+
+    @Test func generatesRandomSpanID() {
+        let idGenerator = OTelXRayIDGenerator(
+            randomNumberGenerator: ConstantNumberGenerator(value: .max),
+            getCurrentSecondsSinceEpoch: { 0 }
+        )
+
+        let generatedSpanID = idGenerator.nextSpanID()
+        let expectedSpanID = SpanID(bytes: .init((255, 255, 255, 255, 255, 255, 255, 255)))
+
+        #expect(generatedSpanID == expectedSpanID)
+    }
+
+    @Test func generatesRandomSpanID_withRandomNumberGenerator() {
+        let randomValue = UInt64.random(in: 0 ..< .max)
+        let randomHexString = String(randomValue, radix: 16, uppercase: false)
+        let hexString = randomHexString.count == 16 ? randomHexString : "0\(randomHexString)"
+        let idGenerator = OTelXRayIDGenerator(
+            randomNumberGenerator: ConstantNumberGenerator(value: randomValue),
+            getCurrentSecondsSinceEpoch: { 0 }
+        )
+
+        let randomSpanID = idGenerator.nextSpanID()
+
+        #expect(randomSpanID.description == hexString)
+    }
+
+    @Test func generatesUniqueSpanIDs() {
+        let idGenerator = OTelXRayIDGenerator()
+        var spanIDs = Set<SpanID>()
+
+        for _ in 0 ..< 1000 {
+            spanIDs.insert(idGenerator.nextSpanID())
+        }
+
+        #expect(spanIDs.count == 1000, "Generating 1000 X-Ray span ids should result in 1000 unique span ids.")
+    }
+}
+
+// MARK: - Helpers
+
+private struct ConstantNumberGenerator: RandomNumberGenerator {
+    let value: UInt64
+
+    func next() -> UInt64 {
+        value
+    }
+}


### PR DESCRIPTION
## Motivation

As part of the the 1.0 public API redesign, we hard-coded the generator for trace and span IDs to `OTelRandomIDGenerator`
and marked the `IDGenerator` protocol `internal`.

This renders the X-Ray based ID generator defined in slashmo/swift-otel-xray unusable.

We work around this by moving `OTelXRayIDGenerator` into swift-otel and adding a configuration option for the ID generator selection.

> [!NOTE]
> I checked the OTel spec and there's no environment variable defined for choosing the ID generator so I opted not to add one in Swift OTel.

## Modifications

- Move `OTelXRayIDGenerator` into swift-otel.
- Add configuration option for selecting the ID generator, one of `random` (default) or `xray`.

## Result

- We have a usable X-Ray based ID generator.
