### PR TITLE
Add missing shared swift settings to OTelTests target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,8 @@ let package = Package(
             dependencies: [
                 .target(name: "OTel"),
                 .product(name: "NIOTestUtils", package: "swift-nio"),
-            ]
+            ],
+            swiftSettings: sharedSwiftSettings
         ),
 
         .target(


### PR DESCRIPTION
## Motivation

When doing a quick audit of the package manifest, I noticed that the `OTelTests` test target is not using the `sharedSwiftSettings` used by all other targets. This means it won't be able to use the `@available(gRPCSwift, *)` macro and any other compile time settings we wish to enforce across the whole package.

## Modifications

- Add missing shared swift settings to OTelTests target

## Result

The `OTelTests` target is compiled with the same settings as all other targets.
