### PR TITLE
Call the exporter run method in a child task in BLRP and PEMR

### DIFF
--- a/Sources/OTelCore/Logging/Processing/Batch/OTelBatchLogRecordProcessor.swift
+++ b/Sources/OTelCore/Logging/Processing/Batch/OTelBatchLogRecordProcessor.swift
@@ -68,6 +68,9 @@ package actor OTelBatchLogRecordProcessor<Exporter: OTelLogRecordExporter, Clock
         await withTaskCancellationOrGracefulShutdownHandler {
             await withThrowingTaskGroup(of: Void.self) { taskGroup in
                 taskGroup.addTask {
+                    try await self.exporter.run()
+                }
+                taskGroup.addTask {
                     for await log in self.logStream {
                         await self._onLog(log)
                     }


### PR DESCRIPTION
## Motivation

As part of moving to gRPC Swift v2, we added a run method to the various exporter protocols, which is needed because we need to run the client connection pool. However, we didn't actually update the `BatchLogRecordProcessor` or `PeriodicExportingMetricsReader` to call the exporter run method as part of their own run method.

## Modifications

- Call the exporter run method in a child task in BLRP and PEMR

## Notes

We didn't catch this in tests because the OTLP/gRPC tests explicitly ran the exporter. What we'd need is something equivalent to the recent end-to-end tests that were created for the OTLP/HTTP exporters, which run a mock server and test functionality using _only the bootstrap API_. However, for that, we'll need to extract the gRPC mock collector out of `OTLPGRPCTests` to its own target so it can be used by `OTelTests`.