### PR TITLE
Fix default endpoint when using OTLP/gRPC exporter

### DIFF
--- a/Sources/OTLPGRPC/OTLPGRPCExporter.swift
+++ b/Sources/OTLPGRPC/OTLPGRPCExporter.swift
@@ -122,11 +122,11 @@ extension CallOptions {
 extension HTTP2ClientTransport.Posix {
     init(_ configuration: OTel.Configuration.OTLPExporterConfiguration) throws {
         guard
-            let endpointComponents = URLComponents(string: configuration.endpoint),
+            let endpointComponents = URLComponents(string: configuration.grpcEndpoint),
             let host = endpointComponents.host,
             let port = endpointComponents.port
         else {
-            throw OTLPGRPCExporterError.invalidEndpoint(configuration.endpoint)
+            throw OTLPGRPCExporterError.invalidEndpoint(configuration.grpcEndpoint)
         }
 
         /// > A scheme of https indicates a secure connection and takes precedence over the insecure configuration

--- a/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
+++ b/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
@@ -92,10 +92,11 @@ extension OTel.Configuration.OTLPExporterConfiguration {
         case .metrics: key.metrics
         case .logs: key.logs
         }
-        switch (environment[key.shared], environment[signalSpecificKey]) {
-        case (.some, .none): endpointHasBeenExplicitlySet = false
-        case (_, .some): endpointHasBeenExplicitlySet = true
-        case (.none, .none): endpointHasBeenExplicitlySet = previousValue.endpointHasBeenExplicitlySet
+        switch (self.protocol.backing, environment[key.shared], environment[signalSpecificKey]) {
+        case (_, .none, .none): endpointHasBeenExplicitlySet = previousValue.endpointHasBeenExplicitlySet
+        case (.grpc, .some, _), (.grpc, _, .some): endpointHasBeenExplicitlySet = true
+        case (_, .some, .none): endpointHasBeenExplicitlySet = false
+        case (_, _, .some): endpointHasBeenExplicitlySet = true
         }
         insecure.override(using: .otlpExporterInsecure, for: signal, from: environment, logger: logger)
         certificateFilePath.override(using: .otlpExporterCertificate, for: signal, from: environment, logger: logger)

--- a/Sources/OTelCore/OTel+Configuration.swift
+++ b/Sources/OTelCore/OTel+Configuration.swift
@@ -735,6 +735,10 @@ extension OTel.Configuration {
             }
         }
 
+        package var grpcEndpoint: String {
+            endpointHasBeenExplicitlySet ? endpoint : "http://localhost:4317"
+        }
+
         /// Whether to enable client transport security for gRPC connections.
         ///
         /// Controls whether to use insecure (non-TLS) connections. Only applies to OTLP/gRPC

--- a/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
+++ b/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
@@ -582,52 +582,63 @@ import Testing
     // https://opentelemetry.io/docs/specs/otel/protocol/exporter/#endpoint-urls-for-otlphttp
     @available(gRPCSwift, *)
     @Test func testOTLPExporterEndpointGRPC() {
+        #expect(OTel.Configuration.default.logs.otlpExporter.grpcEndpoint == "http://localhost:4317")
+        #expect(OTel.Configuration.default.metrics.otlpExporter.grpcEndpoint == "http://localhost:4317")
+        #expect(OTel.Configuration.default.traces.otlpExporter.grpcEndpoint == "http://localhost:4317")
+
         // OTLP/gRPC endpoint in-code overrides.
         OTel.Configuration.default.with { config in
-            config.logs.otlpExporter.protocol = .grpc
-            config.metrics.otlpExporter.protocol = .grpc
-            config.traces.otlpExporter.protocol = .grpc
-
             config.logs.otlpExporter.endpoint = "https://other-otel-collector.example.com:3123/custom"
             #expect(config.logs.otlpExporter.endpoint == "https://other-otel-collector.example.com:3123/custom")
+            #expect(config.logs.otlpExporter.grpcEndpoint == "https://other-otel-collector.example.com:3123/custom")
             config.metrics.otlpExporter.endpoint = "https://other-otel-collector.example.com:3123/custom"
             #expect(config.metrics.otlpExporter.endpoint == "https://other-otel-collector.example.com:3123/custom")
+            #expect(config.metrics.otlpExporter.grpcEndpoint == "https://other-otel-collector.example.com:3123/custom")
             config.traces.otlpExporter.endpoint = "https://other-otel-collector.example.com:3123/custom"
             #expect(config.traces.otlpExporter.endpoint == "https://other-otel-collector.example.com:3123/custom")
+            #expect(config.metrics.otlpExporter.grpcEndpoint == "https://other-otel-collector.example.com:3123/custom")
         }
 
         // OTLP/gRPC environment overrides.
         OTel.Configuration.default.with { config in
-            config.logs.otlpExporter.protocol = .grpc
-            config.metrics.otlpExporter.protocol = .grpc
-            config.traces.otlpExporter.protocol = .grpc
-
             // Applies signal-specific suffix.
             config.withEnvironmentOverrides(environment: [
+                "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
                 "OTEL_EXPORTER_OTLP_ENDPOINT": "https://otel-collector.example.com:4317",
             ]) { config in
                 #expect(config.logs.otlpExporter.endpoint == "https://otel-collector.example.com:4317")
+                #expect(config.logs.otlpExporter.grpcEndpoint == "https://otel-collector.example.com:4317")
                 #expect(config.metrics.otlpExporter.endpoint == "https://otel-collector.example.com:4317")
+                #expect(config.metrics.otlpExporter.grpcEndpoint == "https://otel-collector.example.com:4317")
                 #expect(config.traces.otlpExporter.endpoint == "https://otel-collector.example.com:4317")
+                #expect(config.traces.otlpExporter.grpcEndpoint == "https://otel-collector.example.com:4317")
             }
 
             // Trailing slash is untouched for gRPC endpoints.
             config.withEnvironmentOverrides(environment: [
+                "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
                 "OTEL_EXPORTER_OTLP_ENDPOINT": "https://otel-collector.example.com:4317/",
             ]) { config in
                 #expect(config.logs.otlpExporter.endpoint == "https://otel-collector.example.com:4317/")
+                #expect(config.logs.otlpExporter.grpcEndpoint == "https://otel-collector.example.com:4317/")
                 #expect(config.metrics.otlpExporter.endpoint == "https://otel-collector.example.com:4317/")
+                #expect(config.metrics.otlpExporter.grpcEndpoint == "https://otel-collector.example.com:4317/")
                 #expect(config.traces.otlpExporter.endpoint == "https://otel-collector.example.com:4317/")
+                #expect(config.traces.otlpExporter.grpcEndpoint == "https://otel-collector.example.com:4317/")
             }
 
             // Signal-specific endpoints takes precedence.
             config.withEnvironmentOverrides(environment: [
+                "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc",
                 "OTEL_EXPORTER_OTLP_ENDPOINT": "https://otel-collector.example.com:4317",
                 "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT": "https://other-otel-collector.example.com:3123/custom",
             ]) { config in
                 #expect(config.logs.otlpExporter.endpoint == "https://otel-collector.example.com:4317")
+                #expect(config.logs.otlpExporter.grpcEndpoint == "https://otel-collector.example.com:4317")
                 #expect(config.metrics.otlpExporter.endpoint == "https://other-otel-collector.example.com:3123/custom")
+                #expect(config.metrics.otlpExporter.grpcEndpoint == "https://other-otel-collector.example.com:3123/custom")
                 #expect(config.traces.otlpExporter.endpoint == "https://otel-collector.example.com:4317")
+                #expect(config.traces.otlpExporter.grpcEndpoint == "https://otel-collector.example.com:4317")
             }
         }
     }


### PR DESCRIPTION
## Motivation

The default endpoint in the configuration datamodel is the `http://localhost:4318`, as defined by the OTel spec. This is the default endpoint for the OTLP/HTTP exporter. When using OTLP/gRPC and not explicitly setting an endpoint, the spec says that `http://localhost:4317` should be used.

## Modifications

- Add test for default OLTP/gRPC endpoint (both in-code, and environment overrides)
- Fix default endpoint for OTLP/gRPC endpoint.

## Result

When using OTLP/gRPC the endpoint will default to `http://localhost:4317`.