### PR TITLE
Add example: Using the OTel logging metadata provider

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -26,7 +26,9 @@ logs, metrics, and traces to file, Prometheus, and Jaeger, respectively, via an 
 - [hello-world-hummingbird-server-mtls](./hello-world-hummingbird-server-mtls) - HTTP server
   with instrumentation middleware, exporting telemetry over OTLP/HTTP with mTLS.
 - TODO: Bootstrapping a subset of backends
-- TODO: Using logging metadata provider
+  with instrumentation middleware, with metrics and logging backends disabled.
+- [hello-world-hummingbird-server-logging-metadata-provider](./hello-world-hummingbird-server-logging-metadata-provider) - HTTP server
+  with instrumentation middleware, using logging metadata provider with separate logging backend.
 
 ## Pruning dependencies with traits
 

--- a/Examples/hello-world-hummingbird-server-logging-metadata-provider/.gitignore
+++ b/Examples/hello-world-hummingbird-server-logging-metadata-provider/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+docker/logs/

--- a/Examples/hello-world-hummingbird-server-logging-metadata-provider/Package.swift
+++ b/Examples/hello-world-hummingbird-server-logging-metadata-provider/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "hello-world-hummingbird-server-otlp-http-protobuf",
+    platforms: [.macOS(.v14)],
+    dependencies: [
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+        // TODO: update this to `from: 1.0.0` when we release 1.0.
+        .package(url: "https://github.com/swift-otel/swift-otel.git", branch: "main"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "HelloWorldHummingbirdServer",
+            dependencies: [
+                .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "OTel", package: "swift-otel"),
+            ]
+        ),
+    ]
+)

--- a/Examples/hello-world-hummingbird-server-logging-metadata-provider/README.md
+++ b/Examples/hello-world-hummingbird-server-logging-metadata-provider/README.md
@@ -1,0 +1,119 @@
+# Hello World HTTP server with OTel logging metadata provider
+
+An HTTP server that uses middleware to emit telemetry for each HTTP request.
+
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
+## Overview
+
+This example bootstraps the only the tracing Swift subsystems to export
+traces to Jaeger, via an OTel Collector. The logging and metrics backends are
+disabled. It then bootstraps a standard error logger using the Swift OTel logging
+metadata provider, which includes the span and trace ID for the current span in
+the structured logging metadata.
+
+It then starts a Hummingbird HTTP server along with its associated middleware for instrumentation.
+
+Traces are exported using OTLP/HTTP+Protobuf. Logs are exported to standard error.
+
+## Notable Configuration
+
+```swift
+config.logs.enabled = false
+config.metrics.enabled = false
+...
+LoggingSystem.bootstrap(
+    StreamLogHandler.standardError(label:metadataProvider:),
+    metadataProvider: OTel.makeLoggingMetadataProvider()
+)
+```
+
+## Testing
+
+The example uses [Docker Compose](https://docs.docker.com/compose) to run a set of containers to collect and
+visualize the telemetry from the server, which is running on your local machine.
+
+```none
+┌──────────────────────────────────────────────────────────────────────┐
+│                                                                  Host│
+│                       ┌────────────────────────────────────────────┐ │
+│                       │                              Docker Compose│ │
+│        ┌────────────┐ │ ┌───────────┐                              │ │
+│     ┌─▶│   stderr   │ │ │           │                              │ │
+│     │  └────────────┘ │ │           │                              │ │
+│ Logs│                 │ │           │                              │ │
+│     │                 │ │           │   Traces      ┌────────────┐ │ │
+│ ┌───┴────┐            │ │   OTel    ├──────────────▶│   Jaeger   │ │ │
+│ │        │            │ │ Collector │               └────────────┘ │ │
+│ │  HTTP  │            │ │           │                              │ │
+│ │ Server │────────────┼▶│           │                              │ │
+│ │        │            │ │           │                              │ │
+│ └────────┘            │ │           │   Debug       ┌────────────┐ │ │
+│      ▲      ┌──────┐  │ │           ├──────────────▶│   stderr   │ │ │
+│      └──────│ curl │  │ └───────────┘               └────────────┘ │ │
+│  GET /hello └──────┘  └────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The server sends requests to OTel Collector, which is configured with an OTLP receiver for traces;
+and an exporter for Jaeger. The Collector is also
+configured with a debug exporter so we can see the events it receives in the container logs.
+
+### Running the collector and visualization containers
+
+In one terminal window, run the following command:
+
+```console
+% docker compose -f docker/docker-compose.yaml up
+[+] Running 2/2
+ ✔ Container docker-jaeger-1          Created                       0.5s
+ ✔ Container docker-otel-collector-1  Created                       0.5s
+...
+```
+
+At this point the tracing collector and visualization tools are running.
+
+### Running the server
+
+Now, in another terminal, run the server locally using the following command:
+
+```console
+% swift run
+```
+
+### Making some requests
+
+Finally, in a third terminal, make a few requests to the server:
+
+```console
+% for i in {1..5}; do curl localhost:8080/hello; done
+hello
+hello
+hello
+hello
+hello
+```
+
+### Viewing the logs
+
+In the terminal where the Swift server is running, you should see the logging output from the standard error logger.
+Logs related to HTTP requests have the span and trace ID inclueded in the structured logging metadata automatically:
+
+```console
+2025-07-28T20:34:54+0100 info Hummingbird : [HummingbirdCore] Server started and listening on 127.0.0.1:8080
+2025-07-28T20:35:04+0100 info Hummingbird : hb.request.id=3c0e940f183620ad41e5690bded6b48 hb.request.method=GET hb.request.path=/hello span_id=eb674e50dd49e7d3 trace_flags=1 trace_id=e378e2d400c17feab82671124e13f2f6 [Hummingbird] Request
+```
+
+In the output from the OTel Collector, you should see debug messages for the received OTLP events.
+
+### Visualizing the traces using Jaeger UI
+
+Visit Jaeger UI in your browser at [localhost:16686](http://localhost:16686).
+
+Select `hello_world` from the dropdown and click `Find Traces`, or use
+[this pre-canned link](http://localhost:16686/search?service=hello_world).
+
+See the traces for the recent requests and click to select a trace for a given request.
+
+Click to expand the trace, the metadata associated with the request and the
+process, and the events.

--- a/Examples/hello-world-hummingbird-server-logging-metadata-provider/Sources/HelloWorldHummingbirdServer/HelloWorldHummingbirdServer.swift
+++ b/Examples/hello-world-hummingbird-server-logging-metadata-provider/Sources/HelloWorldHummingbirdServer/HelloWorldHummingbirdServer.swift
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Hummingbird
+import Logging
+import OTel
+
+@main
+enum HelloWorldHummingbirdServer {
+    static func main() async throws {
+        // Bootstrap only the tracing backend (logs and metrics OTLP backends disabled).
+        var config = OTel.Configuration.default
+        config.serviceName = "hello_world"
+        config.diagnosticLogLevel = .error
+        config.logs.enabled = false
+        config.metrics.enabled = false
+        config.traces.batchSpanProcessor.scheduleDelay = .seconds(3)
+        let observability = try OTel.bootstrap(configuration: config)
+
+        // Bootstrap the logging backend using stderr, with OTel span metadata.
+        LoggingSystem.bootstrap(
+            StreamLogHandler.standardError(label:metadataProvider:),
+            metadataProvider: OTel.makeLoggingMetadataProvider()
+        )
+
+        // Create an HTTP server with instrumentation middlewares added.
+        let router = Router()
+        router.middlewares.add(TracingMiddleware())
+        router.middlewares.add(LogRequestsMiddleware(.info))
+        router.get("hello") { _, _ in "hello" }
+        var app = Application(router: router)
+
+        // Add the observability service to the Hummingbird service group and run the server.
+        app.addServices(observability)
+        try await app.runService()
+    }
+}

--- a/Examples/hello-world-hummingbird-server-logging-metadata-provider/docker/docker-compose.yaml
+++ b/Examples/hello-world-hummingbird-server-logging-metadata-provider/docker/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: "3.5"
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+      - ./logs:/logs:rw
+    ports:
+      - "4317:4317"  # OTLP/gRPC receiver
+      - "4318:4318"  # OTLP/HTTP receiver
+
+  jaeger:
+    image: jaegertracing/all-in-one
+    ports:
+      - "16686:16686"  # Jaeger Web UI
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json

--- a/Examples/hello-world-hummingbird-server-logging-metadata-provider/docker/otel-collector-config.yaml
+++ b/Examples/hello-world-hummingbird-server-logging-metadata-provider/docker/otel-collector-config.yaml
@@ -1,0 +1,24 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "otel-collector:4317"
+      http:
+        endpoint: "otel-collector:4318"
+
+exporters:
+  debug:  # Data sources: traces, metrics, logs
+    verbosity: basic
+
+  otlp/jaeger:  # Data sources: traces
+    endpoint: "jaeger:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/jaeger, debug]
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/srikanthccv/otelcol-jsonschema/main/schema.json


### PR DESCRIPTION
## Motivation

In recent PRs we've been extending the collection of example packages. This PR adds an example that uses the logging metadata provider.

## Modifications

- Add example: Using the OTel logging metadata provider

## Result

Example showing how to correlate logs using a different logging provider.