### PR TITLE
Update examples packages to use exact: 1.0.0-alpha.1

### DIFF
--- a/Examples/hello-world-hummingbird-server-logging-metadata-provider/Package.swift
+++ b/Examples/hello-world-hummingbird-server-logging-metadata-provider/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", branch: "main"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-aplha.1"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-mtls/Package.swift
+++ b/Examples/hello-world-hummingbird-server-mtls/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", branch: "main"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-aplha.1"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-only-traces/Package.swift
+++ b/Examples/hello-world-hummingbird-server-only-traces/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", branch: "main"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-aplha.1"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-otlp-grpc/Package.swift
+++ b/Examples/hello-world-hummingbird-server-otlp-grpc/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", branch: "main"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-aplha.1"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-otlp-http-json/Package.swift
+++ b/Examples/hello-world-hummingbird-server-otlp-http-json/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", branch: "main"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-aplha.1"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-otlp-http-protobuf/Package.swift
+++ b/Examples/hello-world-hummingbird-server-otlp-http-protobuf/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", branch: "main"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-aplha.1"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-tls/Package.swift
+++ b/Examples/hello-world-hummingbird-server-tls/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", branch: "main"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-aplha.1"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
## Motivation

We're about to tag 1.0.0-alpha.1 and our examples should be robust against more development, so people can evaluate them.

## Modifications

Update examples packages to use exact: 1.0.0-alpha.1

## Result

Examples packages use exact: 1.0.0-alpha.1