### PR TITLE
Update docs link in README and DocC root to point to main branch docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ try await app.runService()
 > This, and other examples, can be be found in the [Examples][examples] directory.
 
 [otlp]: https://opentelemetry.io/docs/specs/otel/protocol
-[docs]: https://swiftpackageindex.com/swift-otel/swift-otel/documentation
+<!-- TODO: Remove /main/ from following URL once 1.0.0 ships -->
+[docs]: https://swiftpackageindex.com/swift-otel/swift-otel/main/documentation
 [examples]: https://github.com/swift-otel/swift-otel/tree/main/Examples/
 [license]: https://github.com/swift-otel/swift-otel/tree/main/LICENSE.txt
 [swift-log]: https://github.com/apple/swift-log

--- a/Sources/OTel/Docs.docc/_OTel.md
+++ b/Sources/OTel/Docs.docc/_OTel.md
@@ -123,7 +123,8 @@ try await app.runService()
 > This, and other examples, can be be found in the [Examples][examples] directory.
 
 [otlp]: https://opentelemetry.io/docs/specs/otel/protocol
-[docs]: https://swiftpackageindex.com/swift-otel/swift-otel/documentation
+<!-- TODO: Remove /main/ from following URL once 1.0.0 ships -->
+[docs]: https://swiftpackageindex.com/swift-otel/swift-otel/main/documentation
 [examples]: https://github.com/swift-otel/swift-otel/tree/main/Examples/
 [license]: https://github.com/swift-otel/swift-otel/tree/main/LICENSE.txt
 [swift-log]: https://github.com/apple/swift-log


### PR DESCRIPTION
## Motivation

We're currently using https://swiftpackageindex.com/swift-otel/swift-otel/documentation/otel in our README and DocC root, which redirects to the "latest release". Unfortunately, SPI considers this to be 0.12.0 and not 1.0.0-alpha.1, which it considers the "latest beta release".

## Modifications

Update docs link in README and DocC root to point to main branch docs

## Result

The link from the README and the DocC root will point to more relevant docs.