### PR TITLE
Throw error in make-backend APIs if the relevant signal is disabled

### DIFF
--- a/Sources/OTel/OTel+Backends.swift
+++ b/Sources/OTel/OTel+Backends.swift
@@ -110,6 +110,9 @@ extension OTel {
     ///   - `OTel.makeTracingBackend(configuration:)` for tracing backend creation
     ///   - `OTel.Configuration` for configuration options and environment variables
     public static func makeLoggingBackend(configuration: OTel.Configuration = .default) throws -> (factory: @Sendable (String) -> any LogHandler, service: some Service) {
+        guard configuration.logs.enabled else {
+            throw OTel.Configuration.Error.invalidConfiguration("makeLoggingBackend called but config has logs disabled")
+        }
         let logger = configuration.makeDiagnosticLogger().withMetadata(component: "makeLoggingBackend")
         let resource = OTelResource(configuration: configuration)
         let exporter = try WrappedLogRecordExporter(configuration: configuration, logger: logger)
@@ -212,6 +215,9 @@ extension OTel {
     ///   - `OTel.makeTracingBackend(configuration:)` for tracing backend creation
     ///   - `OTel.Configuration` for configuration options and environment variables
     public static func makeMetricsBackend(configuration: OTel.Configuration = .default) throws -> (factory: some MetricsFactory, service: some Service) {
+        guard configuration.metrics.enabled else {
+            throw OTel.Configuration.Error.invalidConfiguration("makeMetricsBackend called but config has metrics disabled")
+        }
         let logger = configuration.makeDiagnosticLogger().withMetadata(component: "makeMetricsBackend")
         let resource = OTelResource(configuration: configuration)
         let registry = OTelMetricRegistry(logger: logger)
@@ -309,6 +315,9 @@ extension OTel {
     ///   - `OTel.makeMetricsBackend(configuration:)` for metrics backend creation
     ///   - `OTel.Configuration` for configuration options and environment variables
     public static func makeTracingBackend(configuration: OTel.Configuration = .default) throws -> (factory: some Tracer, service: some Service) {
+        guard configuration.traces.enabled else {
+            throw OTel.Configuration.Error.invalidConfiguration("makeTracingBackend called but config has traces disabled")
+        }
         let logger = configuration.makeDiagnosticLogger().withMetadata(component: "makeTracingBackend")
         let resource = OTelResource(configuration: configuration)
         let sampler = WrappedSampler(configuration: configuration)

--- a/Sources/OTelCore/OTel+Configuration+Error.swift
+++ b/Sources/OTelCore/OTel+Configuration+Error.swift
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension OTel.Configuration {
+    package enum Error: Swift.Error, Equatable {
+        case invalidConfiguration(String)
+    }
+}

--- a/Tests/OTelTests/EndToEndTests.swift
+++ b/Tests/OTelTests/EndToEndTests.swift
@@ -527,5 +527,23 @@ import Tracing
             #expect(inside.contains(metadataKey))
         }
     }
+
+    @Test func testMakeBackendThrowsWhenSignalIsDisabled() {
+        #expect(throws: OTel.Configuration.Error.invalidConfiguration("makeLoggingBackend called but config has logs disabled")) {
+            var config = OTel.Configuration.default
+            config.logs.enabled = false
+            _ = try OTel.makeLoggingBackend(configuration: config)
+        }
+        #expect(throws: OTel.Configuration.Error.invalidConfiguration("makeMetricsBackend called but config has metrics disabled")) {
+            var config = OTel.Configuration.default
+            config.metrics.enabled = false
+            _ = try OTel.makeMetricsBackend(configuration: config)
+        }
+        #expect(throws: OTel.Configuration.Error.invalidConfiguration("makeTracingBackend called but config has traces disabled")) {
+            var config = OTel.Configuration.default
+            config.traces.enabled = false
+            _ = try OTel.makeTracingBackend(configuration: config)
+        }
+    }
 }
 #endif // compiler(>=6.2)


### PR DESCRIPTION
## Motivation

The `makeLoggingBackend(configuration:)`, `makeMetricsBackend(configuration:)`, and `makeTracingBackend(configuration:)` APIs do not currently check their respective configuration options: `logs.enabled`, `metrics.enabled`, and `traces.enabled`.

## Modifications

- Create a new internal error type
- Throw error in make<Signal>Backend APIs if signal disabled in config
- Add test to end-to-end tests to validate new behavour

## Result

- `makeLoggingBackend(configuration:)` will throw an error if `logs.enabled` is false in the given configuration
- `makeMetricsBackend(configuration:)` will throw an error if `metrics.enabled` is false in the given configuration
- `makeTracingBackend(configuration:)` will throw an error if `traces.enabled` is false in the given configuration

