### PR TITLE
Add support for enabled backends with no exporter

### DIFF
--- a/Sources/OTel/OTelCore+GenericWrappers.swift
+++ b/Sources/OTel/OTelCore+GenericWrappers.swift
@@ -64,6 +64,7 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
     #if OTLPHTTP
     case http(OTLPHTTPLogRecordExporter)
     #endif
+    case none
 
     func run() async throws {
         switch self {
@@ -73,6 +74,7 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.run()
         #endif
+        case .none: break
         }
     }
 
@@ -84,6 +86,7 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.export(batch)
         #endif
+        case .none: break
         }
     }
 
@@ -95,6 +98,7 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.forceFlush()
         #endif
+        case .none: break
         }
     }
 
@@ -106,6 +110,7 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
         #if OTLPHTTP
         case .http(let exporter): await exporter.shutdown()
         #endif
+        case .none: break
         }
     }
 
@@ -132,9 +137,9 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
                 fatalError("Using the OTLP/HTTP exporter requires the `OTLPHTTP` trait enabled.")
                 #endif
             }
+        case .none: self = .none
         case .console:
             throw NotImplementedError()
-        case .none: preconditionFailure()
         }
     }
 }
@@ -146,6 +151,7 @@ internal enum WrappedMetricExporter: OTelMetricExporter {
     #if OTLPHTTP
     case http(OTLPHTTPMetricExporter)
     #endif
+    case none
 
     func run() async throws {
         switch self {
@@ -155,6 +161,7 @@ internal enum WrappedMetricExporter: OTelMetricExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.run()
         #endif
+        case .none: break
         }
     }
 
@@ -166,6 +173,7 @@ internal enum WrappedMetricExporter: OTelMetricExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.export(batch)
         #endif
+        case .none: break
         }
     }
 
@@ -177,6 +185,7 @@ internal enum WrappedMetricExporter: OTelMetricExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.forceFlush()
         #endif
+        case .none: break
         }
     }
 
@@ -188,6 +197,7 @@ internal enum WrappedMetricExporter: OTelMetricExporter {
         #if OTLPHTTP
         case .http(let exporter): await exporter.shutdown()
         #endif
+        case .none: break
         }
     }
 
@@ -214,9 +224,9 @@ internal enum WrappedMetricExporter: OTelMetricExporter {
                 fatalError("Using the OTLP/HTTP exporter requires the `OTLPHTTP` trait enabled.")
                 #endif
             }
+        case .none: self = .none
         case .prometheus, .console:
             throw NotImplementedError()
-        case .none: preconditionFailure()
         }
     }
 }
@@ -228,6 +238,7 @@ internal enum WrappedSpanExporter: OTelSpanExporter {
     #if OTLPHTTP
     case http(OTLPHTTPSpanExporter)
     #endif
+    case none
 
     func run() async throws {
         switch self {
@@ -237,6 +248,7 @@ internal enum WrappedSpanExporter: OTelSpanExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.run()
         #endif
+        case .none: break
         }
     }
 
@@ -248,6 +260,7 @@ internal enum WrappedSpanExporter: OTelSpanExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.export(batch)
         #endif
+        case .none: break
         }
     }
 
@@ -259,6 +272,7 @@ internal enum WrappedSpanExporter: OTelSpanExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.forceFlush()
         #endif
+        case .none: break
         }
     }
 
@@ -270,6 +284,7 @@ internal enum WrappedSpanExporter: OTelSpanExporter {
         #if OTLPHTTP
         case .http(let exporter): await exporter.shutdown()
         #endif
+        case .none: break
         }
     }
 
@@ -296,9 +311,9 @@ internal enum WrappedSpanExporter: OTelSpanExporter {
                 fatalError("Using the OTLP/HTTP exporter requires the `OTLPHTTP` trait enabled.")
                 #endif
             }
+        case .none: self = .none
         case .console, .jaeger, .zipkin:
             throw NotImplementedError()
-        case .none: preconditionFailure()
         }
     }
 }

--- a/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
+++ b/Sources/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
@@ -32,7 +32,6 @@ extension OTel.Configuration.TracesConfiguration {
         sampler.applyEnvironmentOverrides(environment: environment, logger: logger)
         batchSpanProcessor.applyEnvironmentOverrides(environment: environment, logger: logger)
         exporter.override(using: .tracesExporter, from: environment, logger: logger)
-        if exporter.backing == .none { enabled = false }
         otlpExporter.applyEnvironmentOverrides(environment: environment, signal: .traces, logger: logger)
     }
 }
@@ -42,7 +41,6 @@ extension OTel.Configuration.MetricsConfiguration {
         exportInterval.override(using: .metricExportInterval, from: environment, logger: logger)
         exportTimeout.override(using: .metricExportTimeout, from: environment, logger: logger)
         exporter.override(using: .metricsExporter, from: environment, logger: logger)
-        if exporter.backing == .none { enabled = false }
         otlpExporter.applyEnvironmentOverrides(environment: environment, signal: .metrics, logger: logger)
     }
 }
@@ -51,7 +49,6 @@ extension OTel.Configuration.LogsConfiguration {
     internal mutating func applyEnvironmentOverrides(environment: [String: String], logger: Logger) {
         batchLogRecordProcessor.applyEnvironmentOverrides(environment: environment, logger: logger)
         exporter.override(using: .logsExporter, from: environment, logger: logger)
-        if exporter.backing == .none { enabled = false }
         otlpExporter.applyEnvironmentOverrides(environment: environment, signal: .logs, logger: logger)
     }
 }

--- a/Sources/OTelCore/OTel+Configuration.swift
+++ b/Sources/OTelCore/OTel+Configuration.swift
@@ -541,6 +541,9 @@ extension OTel.Configuration.TracesConfiguration {
         /// OTLP (OpenTelemetry Protocol) exporter for traces.
         public static let otlp: Self = .init(backing: .otlp)
 
+        /// No automatically configured exporter for traces.
+        public static let none: Self = .init(backing: .none)
+
         /// Jaeger exporter for traces.
         @available(*, unavailable, message: "This option is not supported by Swift OTel")
         public static let jaeger: Self = .init(backing: .jaeger)
@@ -572,6 +575,9 @@ extension OTel.Configuration.MetricsConfiguration {
         /// OTLP (OpenTelemetry Protocol) exporter for metrics.
         public static let otlp: Self = .init(backing: .otlp)
 
+        /// No automatically configured exporter for metrics.
+        public static let none: Self = .init(backing: .none)
+
         /// Prometheus exporter for metrics.
         @available(*, unavailable, message: "This option is not supported by Swift OTel")
         public static let prometheus: Self = .init(backing: .prometheus)
@@ -597,6 +603,9 @@ extension OTel.Configuration.LogsConfiguration {
 
         /// OTLP (OpenTelemetry Protocol) exporter for logs.
         public static let otlp: Self = .init(backing: .otlp)
+
+        /// No automatically configured exporter for logs.
+        public static let none: Self = .init(backing: .none)
 
         /// Console exporter for logs (development/debugging).
         @available(*, unavailable, message: "This option is not supported by Swift OTel")

--- a/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
+++ b/Tests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
@@ -437,9 +437,12 @@ import Testing
         #expect(OTel.Configuration.default.traces.enabled == true)
         #expect(OTel.Configuration.default.traces.exporter.backing == .otlp)
 
-        #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+        OTel.Configuration.default.withEnvironmentOverrides(environment: [
             "OTEL_TRACES_EXPORTER": "none",
-        ]).traces.enabled == false)
+        ]) { config in
+            #expect(config.traces.enabled == true)
+            #expect(config.traces.exporter.backing == .none)
+        }
 
         #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
             "OTEL_TRACES_EXPORTER": "jaeger",
@@ -474,8 +477,15 @@ import Testing
         ]).metrics.exporter.backing == .console)
 
         #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_METRICS_EXPORTER": "otlp",
+        ]).metrics.exporter.backing == .otlp)
+
+        OTel.Configuration.default.withEnvironmentOverrides(environment: [
             "OTEL_METRICS_EXPORTER": "none",
-        ]).metrics.enabled == false)
+        ]) { config in
+            #expect(config.metrics.enabled == true)
+            #expect(config.metrics.exporter.backing == .none)
+        }
     }
 
     // OTEL_LOGS_EXPORTER
@@ -490,8 +500,15 @@ import Testing
         ]).logs.exporter.backing == .console)
 
         #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_LOGS_EXPORTER": "otlp",
+        ]).logs.exporter.backing == .otlp)
+
+        OTel.Configuration.default.withEnvironmentOverrides(environment: [
             "OTEL_LOGS_EXPORTER": "none",
-        ]).logs.enabled == false)
+        ]) { config in
+            #expect(config.logs.enabled == true)
+            #expect(config.logs.exporter.backing == .none)
+        }
     }
 
     // OTEL_EXPORTER_OTLP_ENDPOINT (OTLP/HTTP edition).

--- a/Tests/OTelTests/EndToEndTests.swift
+++ b/Tests/OTelTests/EndToEndTests.swift
@@ -481,8 +481,11 @@ import Tracing
 
     @Test func testLogsIncludeSpanContext() async throws {
         let result = try await #require(processExitsWith: .success, observing: [\.standardErrorContent], "Running in a separate process because test uses bootstrap") {
+            var bootstrapConfig = OTel.Configuration.default
+            bootstrapConfig.traces.exporter = .none
+            bootstrapConfig.diagnosticLogLevel = .trace
+            try InstrumentationSystem.bootstrap(OTel.makeTracingBackend(configuration: bootstrapConfig).factory)
             let config = OTel.Configuration.LoggingMetadataProviderConfiguration.default
-            try InstrumentationSystem.bootstrap(OTel.makeTracingBackend().factory)
             let logger = Logger(label: "test") { label in
                 StreamLogHandler.standardError(
                     label: label,
@@ -505,11 +508,14 @@ import Tracing
     // https://github.com/swiftlang/swift/issues/82783
     @Test func testLogsIncludeSpanContextWithCustomKeys() async throws {
         let result = try await #require(processExitsWith: .success, observing: [\.standardErrorContent], "Running in a separate process because test uses bootstrap") {
+            var bootstrapConfig = OTel.Configuration.default
+            bootstrapConfig.traces.exporter = .none
+            bootstrapConfig.diagnosticLogLevel = .trace
+            try InstrumentationSystem.bootstrap(OTel.makeTracingBackend(configuration: bootstrapConfig).factory)
             var config = OTel.Configuration.LoggingMetadataProviderConfiguration.default
             config.spanIDKey = "🔧"
             config.traceIDKey = "🫆"
             config.traceFlagsKey = "🏴‍☠️"
-            try InstrumentationSystem.bootstrap(OTel.makeTracingBackend().factory)
             let logger = Logger(label: "test") { label in
                 StreamLogHandler.standardError(
                     label: label,


### PR DESCRIPTION
## Motivation

The OTel spec defines support for a backend that is enabled but without an exporter, and even supports the environment variable overrides for this, e.g. `OTEL_TRACES_EXPORTER=none`. Until now, this has been conflated with disabling the backend altogether.

However, this is not desirable since we have a specific use case that requires exactly this. If a user wants to have logs with span and trace IDs but is not interested in exporting traces (regardless of whether they use the OTLP logging backend or just the logging metadata provider with their own backend).

We even have an end-to-end test for this use case already, added in #256, but this test bootstraps the tracing backend with the default configuration. While that will be sufficient, it will result in an OTLP exporter continually running and not being able to export.

We should instead support having the backends enabled but not exporting.

Thankfully, because we have the generic wrapper types, which we use from the public API, this is pretty trivial, and also removes a precondition failure for code that we claimed was previously unreachable.

We also already had defined `case none` in the backing enum in the config API (so we can detect it from environment variables), but it wasn't reachable by the public configuration API.

## Modifications

- Support `case none` in the wrapped exporter enums.
- Add public API for `Configuration.[Logs,Metrics,Traces].ExporterSelection.none`
- Stop conflating `OTEL_<SIGNAL>_EXPORTER=none` with disabling the backend entirely
- Update the configuration tests
- Update the end-to-end that uses the logging metadata provider to correlate logs with active spans to not require an exporter.

## Result

- Can now bootstrap backends without an exporter
- New API `Configuration.Logs.ExporterSelection.none`
- New API `Configuration.Metrics.ExporterSelection.none`
- New API `Configuration.Traces.ExporterSelection.none`
- Support for `OTEL_LOGS_EXPORTER=none`
- Support for `OTEL_METRICS_EXPORTER=none`
- Support for `OTEL_TRACES_EXPORTER=none`