### PR TITLE
Add support for console logs exporter

### DIFF
--- a/Sources/OTel/OTel+Backends.swift
+++ b/Sources/OTel/OTel+Backends.swift
@@ -116,11 +116,7 @@ extension OTel {
         let logger = configuration.makeDiagnosticLogger().withMetadata(component: "makeLoggingBackend")
         let resource = OTelResource(configuration: configuration)
         let exporter = try WrappedLogRecordExporter(configuration: configuration, logger: logger)
-        let processor: OTelBatchLogRecordProcessor = .init(
-            exporter: exporter,
-            configuration: OTelBatchLogRecordProcessorConfiguration(configuration: configuration.logs.batchLogRecordProcessor),
-            logger: logger
-        )
+        let processor = try WrappedLogRecordProcessor(configuration: configuration, exporter: exporter, logger: logger)
         let handler = OTelLogHandler(
             processor: processor,
             logLevel: Logger.Level(configuration.logs.level),

--- a/Sources/OTel/OTelCore+GenericWrappers.swift
+++ b/Sources/OTel/OTelCore+GenericWrappers.swift
@@ -64,6 +64,7 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
     #if OTLPHTTP
     case http(OTLPHTTPLogRecordExporter)
     #endif
+    case console(OTelConsoleLogRecordExporter)
     case none
 
     func run() async throws {
@@ -74,6 +75,7 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.run()
         #endif
+        case .console(let exporter): exporter.run()
         case .none: break
         }
     }
@@ -86,6 +88,7 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.export(batch)
         #endif
+        case .console(let exporter): exporter.export(batch)
         case .none: break
         }
     }
@@ -98,6 +101,7 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.forceFlush()
         #endif
+        case .console(let exporter): exporter.forceFlush()
         case .none: break
         }
     }
@@ -110,6 +114,7 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
         #if OTLPHTTP
         case .http(let exporter): await exporter.shutdown()
         #endif
+        case .console(let exporter): exporter.shutdown()
         case .none: break
         }
     }
@@ -137,9 +142,8 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
                 fatalError("Using the OTLP/HTTP exporter requires the `OTLPHTTP` trait enabled.")
                 #endif
             }
+        case .console: self = .console(OTelConsoleLogRecordExporter())
         case .none: self = .none
-        case .console:
-            throw NotImplementedError()
         }
     }
 }

--- a/Sources/OTelCore/Logging/Exporting/OTelConsoleLogRecordExporter.swift
+++ b/Sources/OTelCore/Logging/Exporting/OTelConsoleLogRecordExporter.swift
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+package struct OTelConsoleLogRecordExporter: OTelLogRecordExporter {
+    package init() {}
+
+    package func run() {
+        /// > The exporter’s output format is unspecified and can vary between implementations. Documentation SHOULD
+        /// > warn users about this. The following wording is recommended (modify as needed):
+        /// > >
+        /// > > This exporter is intended for debugging and learning purposes. It is not recommended for production use.
+        /// > > The output format is not standardized and can change at any time.
+        /// > >
+        /// > > If a standardized format for exporting logs to stdout is desired, consider using the File Exporter, if
+        /// > > available. However, please review the status of the File Exporter and verify if it is stable and
+        /// > > production-ready.
+        /// — source: https://opentelemetry.io/docs/specs/otel/logs/sdk_exporters/stdout/
+        print(
+            """
+            ---
+            WARNING: Using the console log exporter.
+            This exporter is intended for debugging and learning purposes. It is not recommended for production use.
+            The output format is not standardized and can change at any time.
+            ---
+            """
+        )
+    }
+
+    package func export(_ batch: some Collection<OTelLogRecord> & Sendable) {
+        for logRecord in batch {
+            print(logRecord)
+        }
+    }
+
+    package func forceFlush() {}
+
+    package func shutdown() {}
+}

--- a/Sources/OTelCore/Logging/Exporting/OTelConsoleLogRecordExporter.swift
+++ b/Sources/OTelCore/Logging/Exporting/OTelConsoleLogRecordExporter.swift
@@ -11,6 +11,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import struct Foundation.Date
+
 package struct OTelConsoleLogRecordExporter: OTelLogRecordExporter {
     package init() {}
 
@@ -38,11 +40,35 @@ package struct OTelConsoleLogRecordExporter: OTelLogRecordExporter {
 
     package func export(_ batch: some Collection<OTelLogRecord> & Sendable) {
         for logRecord in batch {
-            print(logRecord)
+            print(logRecord.consoleFormatted)
         }
     }
 
     package func forceFlush() {}
 
     package func shutdown() {}
+}
+
+extension OTelLogRecord {
+    var consoleFormatted: String {
+        // 2024-01-15 14:30:45.123 [INFO] user-api [req-456] User login successful user_id=abc123 duration_ms=245
+        let date = Date(timeIntervalSince1970: Double(self.timeNanosecondsSinceEpoch) / 1_000_000_000)
+        var fields: [String] = []
+        fields.append(date.formatted(.iso8601))
+        fields.append("[\(self.level)]")
+        switch self.resource.attributes["service.name"]?.toSpanAttribute() {
+        case .string(let serviceName): fields.append(serviceName)
+        default: fields.append("unknown")
+        }
+        if let spanContext = self.spanContext {
+            fields.append("[\(spanContext.spanID)]")
+        } else {
+            fields.append("[unknown]")
+        }
+        fields.append("\(self.body)")
+        for (key, value) in self.metadata.filter({ $0.key != "code.function" }) {
+            fields.append("\(key)=\(value)")
+        }
+        return fields.joined(separator: " ")
+    }
 }

--- a/Sources/OTelCore/Logging/Processing/OTelSimpleLogRecordProcessor.swift
+++ b/Sources/OTelCore/Logging/Processing/OTelSimpleLogRecordProcessor.swift
@@ -11,8 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-package import OTelCore
-
 package struct OTelSimpleLogRecordProcessor<Exporter: OTelLogRecordExporter>: OTelLogRecordProcessor {
     private let exporter: Exporter
     private let stream: AsyncStream<OTelLogRecord>

--- a/Sources/OTelCore/Logging/Processing/OTelSimpleLogRecordProcessor.swift
+++ b/Sources/OTelCore/Logging/Processing/OTelSimpleLogRecordProcessor.swift
@@ -11,35 +11,45 @@
 //
 //===----------------------------------------------------------------------===//
 
+package import Logging
+
 package struct OTelSimpleLogRecordProcessor<Exporter: OTelLogRecordExporter>: OTelLogRecordProcessor {
+    private let logger: Logger
     private let exporter: Exporter
     private let stream: AsyncStream<OTelLogRecord>
     private let continuation: AsyncStream<OTelLogRecord>.Continuation
 
-    package init(exporter: Exporter) {
+    package init(exporter: Exporter, logger: Logger) {
+        self.logger = logger.withMetadata(component: "OTelSimpleLogRecordProcessor")
         self.exporter = exporter
         (stream, continuation) = AsyncStream.makeStream()
     }
 
     package func run() async throws {
+        logger.info("Starting.")
         for try await record in stream.cancelOnGracefulShutdown() {
             do {
+                logger.debug("Exporting log record.")
                 try await exporter.export([record])
             } catch {
                 // simple log processor does not attempt retries
             }
         }
+        logger.info("Log stream ended, shutting down.")
     }
 
     package func onEmit(_ record: inout OTelLogRecord) {
+        logger.trace("Received log record.")
         continuation.yield(record)
     }
 
     package func forceFlush() async throws {
+        logger.info("Force flushing exporter.")
         try await exporter.forceFlush()
     }
 
     package func shutdown() async throws {
+        logger.info("Shutting down.")
         await exporter.shutdown()
     }
 }

--- a/Sources/OTelCore/OTel+Configuration.swift
+++ b/Sources/OTelCore/OTel+Configuration.swift
@@ -608,7 +608,6 @@ extension OTel.Configuration.LogsConfiguration {
         public static let none: Self = .init(backing: .none)
 
         /// Console exporter for logs (development/debugging).
-        @available(*, unavailable, message: "This option is not supported by Swift OTel")
         public static let console: Self = .init(backing: .console)
     }
 }

--- a/Tests/OTelCoreTests/Logging/Processing/OTelMultiplexLogRecordProcessorTests.swift
+++ b/Tests/OTelCoreTests/Logging/Processing/OTelMultiplexLogRecordProcessorTests.swift
@@ -90,3 +90,9 @@ final class OTelMultiplexLogRecordProcessorTests: XCTestCase {
         XCTAssertEqual(processor2ShutdownCount, 1)
     }
 }
+
+extension OTelSimpleLogRecordProcessor {
+    fileprivate init(exporter: Exporter) {
+        self.init(exporter: exporter, logger: ._otelDisabled)
+    }
+}

--- a/Tests/OTelTests/BackendTests.swift
+++ b/Tests/OTelTests/BackendTests.swift
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import OTel
+import OTelCore
+import OTLPGRPC
+import OTLPHTTP
+import Testing
+
+@Suite struct OTelBackendTests {
+    @Test func testAutomaticLogRecordProcessorSelectionForOTLPHTTPExporter() async throws {
+        let processor = try WrappedLogRecordProcessor(
+            configuration: .default,
+            exporter: .http(OTLPHTTPLogRecordExporter(configuration: .default, logger: ._otelDisabled)),
+            logger: ._otelDisabled
+        )
+        guard case .batch = processor else {
+            Issue.record("OTLP/HTTP exporter should be automatically paired with the batch processor, but paired with: \(processor)")
+            return
+        }
+    }
+
+    @available(gRPCSwift, *)
+    @Test func testAutomaticLogRecordProcessorSelectionForOTLPGRPCExporter() async throws {
+        var config = OTel.Configuration.default
+        config.logs.otlpExporter.protocol = .grpc
+        let processor = try WrappedLogRecordProcessor(
+            configuration: config,
+            exporter: .grpc(OTLPGRPCLogRecordExporter(configuration: config.logs.otlpExporter, logger: ._otelDisabled)),
+            logger: ._otelDisabled
+        )
+        guard case .batch = processor else {
+            Issue.record("OTLP/gRPC exporter should be automatically paired with the batch processor, but paired with: \(processor)")
+            return
+        }
+    }
+
+    @Test func testAutomaticLogRecordProcessorSelectionForConsoleExporter() async throws {
+        let processor = try WrappedLogRecordProcessor(
+            configuration: .default,
+            exporter: .console(OTelConsoleLogRecordExporter()),
+            logger: ._otelDisabled
+        )
+        guard case .simple = processor else {
+            Issue.record("Console exporter should be automatically paired with the batch processor, but paired with: \(processor)")
+            return
+        }
+    }
+
+    @Test func testAutomaticLogRecordProcessorSelectionForNoneExporter() async throws {
+        let processor = try WrappedLogRecordProcessor(
+            configuration: .default,
+            exporter: .none,
+            logger: ._otelDisabled
+        )
+        guard case .simple = processor else {
+            Issue.record("None exporter should be automatically paired with the simple processor, but paired with: \(processor)")
+            return
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

The OTel spec defines a console exporter for all three signals, which are intended to be used for local development[^1]. This is particularly useful for logs because, once the Swift logging subsystem is bootstrapped with an OTLP logger, no further logging will be visible on the console so it would be good for adopters to be able to choose a console logs exporter, either using the configuration API, or by `OTEL_LOGS_EXPORTER=console`.

The spec suggests a few requirements for the console exporter:

1. It should use the simple processor (not the batch processor)
2. It should print a warning when being used (and provides the wording)

We already had the simple processor implementation in the `OTelTesting` module, but it looks like it will need a little work, since it does not currently call its exporter's run method.

We also already had the configuration in place for this, but was marked always unavailable, since we didn't support it, so adding the new configuration API is trivial.

## Modifications

- Move `OTelSimpleLogRecordProcessor` from `OTelTesting` to `OTelCore`
- Add diagnostic logging to `OTelSimpleLogRecordProcessor`
- Update `SimpleLogRecordProcessor` to actually run its exporter
- Add `OTelConsoleLogRecordExporter` that just prints to stdout
- Format the log messages in the console exporter
- Add `console` case to `WrappedLogRecordExporter` enum
- Add `WrappedLogRecordProcessor` with automatic selection based on exporter
- Add tests for automatic processor selection based on exporter
- Enable console logs exporter in the configuration API
- Add end-to-end test for console logging exporter

## Result

- New API: `OTel.Configuration.LogsConfiguration.ExporterSelection.console`
- Support for `OTEL_LOGS_EXPORTER=console`

[^1]: https://opentelemetry.io/docs/specs/otel/logs/sdk_exporters/stdout/
