### PR TITLE
Improve documentation structure with DocC topic curation

### DIFF
--- a/Sources/OTel/Docs.docc/Configuration.md
+++ b/Sources/OTel/Docs.docc/Configuration.md
@@ -1,0 +1,40 @@
+# ``OTel/OTel/Configuration``
+
+## Topics
+
+### Start with defaults
+
+- ``default``
+
+### General
+
+- ``serviceName``
+- ``resourceAttributes``
+- ``propagators``
+- ``Propagator``
+
+### Diagnostics
+
+- ``diagnosticLogLevel``
+- ``LogLevel``
+- ``diagnosticLogger``
+- ``DiagnosticLoggerSelection``
+
+### Logging backend
+
+- ``logs``
+- ``LogsConfiguration``
+
+### Metrics backend
+
+- ``metrics``
+- ``MetricsConfiguration``
+
+### Tracing backend
+
+- ``traces``
+- ``TracesConfiguration``
+
+### Logging metadata provider
+
+- ``LoggingMetadataProviderConfiguration``

--- a/Sources/OTel/Docs.docc/DiagnosticLoggerSelection.md
+++ b/Sources/OTel/Docs.docc/DiagnosticLoggerSelection.md
@@ -1,0 +1,11 @@
+# ``OTel/OTel/Configuration/DiagnosticLoggerSelection``
+
+## Topics
+
+### Built-in
+
+- ``console``
+
+### Custom
+
+- ``custom(_:)``

--- a/Sources/OTel/Docs.docc/LoggingMetadataProviderConfiguration.md
+++ b/Sources/OTel/Docs.docc/LoggingMetadataProviderConfiguration.md
@@ -1,0 +1,14 @@
+# ``OTel/OTel/Configuration/LoggingMetadataProviderConfiguration``
+
+## Topics
+
+
+### Start with defaults
+
+- ``default``
+
+### Customizing
+
+- ``traceIDKey``
+- ``spanIDKey``
+- ``traceFlagsKey``

--- a/Sources/OTel/Docs.docc/LogsConfiguration.md
+++ b/Sources/OTel/Docs.docc/LogsConfiguration.md
@@ -1,0 +1,22 @@
+# ``OTel/OTel/Configuration/LogsConfiguration``
+
+## Topics
+
+- ``enabled``
+
+### Severity
+
+- ``LogsConfiguration/level``
+
+### Processing
+
+- ``batchLogRecordProcessor``
+- ``BatchLogRecordProcessorConfiguration``
+
+### Exporting
+
+- ``exporter``
+- ``ExporterSelection``
+
+- ``otlpExporter``
+- ``OTLPExporterConfiguration``

--- a/Sources/OTel/Docs.docc/MetricsConfiguration.md
+++ b/Sources/OTel/Docs.docc/MetricsConfiguration.md
@@ -1,0 +1,16 @@
+# ``OTel/OTel/Configuration/MetricsConfiguration``
+
+## Topics
+
+- ``enabled``
+
+### Exporting
+
+- ``exportInterval``
+- ``exportTimeout``
+
+- ``exporter``
+- ``ExporterSelection``
+
+- ``otlpExporter``
+- ``OTLPExporterConfiguration``

--- a/Sources/OTel/Docs.docc/OTLPExporterConfiguration.md
+++ b/Sources/OTel/Docs.docc/OTLPExporterConfiguration.md
@@ -1,0 +1,36 @@
+# ``OTel/OTel/Configuration/OTLPExporterConfiguration``
+
+## Topics
+
+- ``default``
+
+### Endpoint
+
+- ``endpoint``
+- ``insecure``
+
+### TLS
+- ``certificateFilePath``
+
+### mTLS
+
+- ``clientCertificateFilePath``
+- ``clientKeyFilePath``
+
+### Headers
+ 
+- ``headers``
+
+### Compression
+
+- ``compression``
+- ``Compression``
+
+### Timeout
+
+- ``timeout``
+
+### Protocol
+
+- ``protocol``
+- ``Protocol``

--- a/Sources/OTel/Docs.docc/TracesConfiguration.md
+++ b/Sources/OTel/Docs.docc/TracesConfiguration.md
@@ -1,0 +1,23 @@
+# ``OTel/OTel/Configuration/TracesConfiguration``
+
+## Topics
+
+- ``enabled``
+
+### Sampling
+
+- ``sampler``
+- ``SamplerConfiguration``
+
+### Processing
+
+- ``batchSpanProcessor``
+- ``BatchSpanProcessorConfiguration``
+
+### Exporting
+
+- ``exporter``
+- ``ExporterSelection``
+
+- ``otlpExporter``
+- ``OTLPExporterConfiguration``

--- a/Sources/OTel/OTelAPI/OTel+Configuration.swift
+++ b/Sources/OTel/OTelAPI/OTel+Configuration.swift
@@ -166,11 +166,7 @@ extension OTel.Configuration {
 }
 
 extension OTel.Configuration {
-    /// Log level for internal diagnostic messages.
-    ///
-    /// Controls the minimum severity level for diagnostic output.
-    ///
-    /// This option is ignored for custom loggers.
+    /// Minimum severity of logging to enable.
     public struct LogLevel: Sendable {
         enum Backing: String, CaseIterable, Sendable {
             case error
@@ -295,6 +291,7 @@ extension OTel.Configuration {
         ///
         /// See individual property documentation for specific default values, which respect the OTel specification
         /// where possible.
+        @_documentation(visibility: internal)
         public static let `default`: Self = .init(
             enabled: true,
             sampler: .parentBasedAlwaysOn,
@@ -348,6 +345,7 @@ extension OTel.Configuration {
         ///
         /// See individual property documentation for specific default values, which respect the OTel specification
         /// where possible.
+        @_documentation(visibility: internal)
         public static let `default`: Self = .init(
             enabled: true,
             exportInterval: .seconds(60),
@@ -400,6 +398,7 @@ extension OTel.Configuration {
         ///
         /// See individual property documentation for specific default values, which respect the OTel specification
         /// where possible.
+        @_documentation(visibility: internal)
         public static let `default`: Self = .init(
             enabled: true,
             level: .info,
@@ -514,6 +513,7 @@ extension OTel.Configuration.TracesConfiguration {
         ///
         /// See individual property documentation for specific default values, which respect the OTel specification
         /// where possible.
+        @_documentation(visibility: internal)
         public static let `default`: Self = .init(
             scheduleDelay: .seconds(5),
             exportTimeout: .seconds(30),
@@ -648,6 +648,7 @@ extension OTel.Configuration.LogsConfiguration {
         ///
         /// See individual property documentation for specific default values, which respect the OTel specification
         /// where possible.
+        @_documentation(visibility: internal)
         public static let `default`: Self = .init(
             scheduleDelay: .seconds(1),
             exportTimeout: .seconds(30),
@@ -864,6 +865,7 @@ extension OTel.Configuration {
         ///
         /// See individual property documentation for specific default values, which respect the OTel specification
         /// where possible.
+        @_documentation(visibility: internal)
         public static let `default`: Self = .init(
             endpoint: "http://localhost:4318",
             insecure: false,
@@ -935,11 +937,26 @@ extension OTel.Configuration.OTLPExporterConfiguration {
 
 extension OTel.Configuration {
     /// Configuration for the batch logging metadata provider.
+    /// - TODO: should this be a property of the Configuratino struct?
     public struct LoggingMetadataProviderConfiguration: Sendable {
+        /// Logging metadata key used to record the trace ID.
+        ///
+        /// - Default value: `"trace_id"`
         public var traceIDKey: String
+
+        /// Logging metadata key used to record the span ID.
+        ///
+        /// - Default value: `"span_id"`
         public var spanIDKey: String
+
+        /// Logging metadata key used to record the trace flags.
+        ///
+        /// - Default value: `"trace_flags"`
         public var traceFlagsKey: String
 
+        /// Default logging metadata provider configuration.
+        ///
+        /// See individual property documentation for specific default values.
         public static let `default`: Self = .init(
             traceIDKey: "trace_id",
             spanIDKey: "span_id",


### PR DESCRIPTION
## Motivation

By default, the structure of documentation is to group the structures, instance properties, and type properties together. However, we can provide a better flow through the documentation by using DocC "curation". Topics grouped in the DocC documentation extension file, will result in a categorized sidebar.

We can use this to provide a flow through the configuration, by grouping the instance properties with the corresponding structs, and by grouping the signal-specific documentation.

## Modifications

- Add DocC documentation extension pages for configuration types with topic curation.
- Minor fixes to the documentation itself.

## Result

Documentation is much better structured.

## Notes

Here are some before and after screenshots.

#### Before (currently on Swift Package Index):

<img width="285" height="706" alt="image" src="https://github.com/user-attachments/assets/1b97cb52-f35f-4a40-887c-c8e4d56ce45d" />

#### After (with this PR)

<img width="299" height="815" alt="image" src="https://github.com/user-attachments/assets/ee916e48-a5f8-4183-b3b7-117f81f52a87" />
