### PR TITLE
Fix jq expression in check-example-dependencies script

### DIFF
--- a/scripts/check-example-dependencies.sh
+++ b/scripts/check-example-dependencies.sh
@@ -27,7 +27,7 @@ fi
 
 swift_otel_dependencies=$(swift package show-dependencies --format json | jq -er '
   .dependencies[]
-  | select((.identity | startswith("swift-otel")))
+  | select(.name == "swift-otel")
   | .dependencies[].identity')
 
 log "Checking traits used for swift-otel dependency..."


### PR DESCRIPTION
## Motivation

The script that checks example dependencies was a little fragile when run with local path dependencies because it relied on identity (not name).

## Modifications

Use name field from `swift package show-dependencies` JSON output.

## Result

Script should work with local dependencies too.