### PR TITLE
Use canary service to support tests of service lifecycle graceful shutdown

### DIFF
--- a/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
+++ b/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
@@ -43,12 +43,14 @@ import Tracing
                     config.serviceName = "innie"
                     config.resourceAttributes = ["deployment.environment": "prod"]
                     let observability = try OTel.bootstrap(configuration: config)
-                    let serviceGroup = ServiceGroup(services: [observability], logger: .init(label: "service group"))
+                    let canary = Canary()
+                    let serviceGroup = ServiceGroup(services: [observability, canary], logger: ._otelDebug)
 
                     try await withThrowingTaskGroup { group in
                         group.addTask {
                             try await serviceGroup.run()
                         }
+                        await canary.running
                         group.addTask {
                             withSpan("mysterious and important work") { _ in
                                 withSpan("macrodata refinement") { _ in
@@ -107,13 +109,16 @@ import Tracing
                     config.traces.otlpExporter.protocol = .httpJSON
                     config.serviceName = "innie"
                     config.resourceAttributes = ["deployment.environment": "prod"]
+                    config.diagnosticLogLevel = .debug
                     let observability = try OTel.bootstrap(configuration: config)
-                    let serviceGroup = ServiceGroup(services: [observability], logger: .init(label: "service group"))
+                    let canary = Canary()
+                    let serviceGroup = ServiceGroup(services: [observability, canary], logger: ._otelDebug)
 
                     try await withThrowingTaskGroup { group in
                         group.addTask {
                             try await serviceGroup.run()
                         }
+                        await canary.running
                         group.addTask {
                             withSpan("mysterious and important work") { _ in
                                 withSpan("macrodata refinement") { _ in
@@ -173,12 +178,14 @@ import Tracing
                     config.serviceName = "innie"
                     config.resourceAttributes = ["deployment.environment": "prod"]
                     let observability = try OTel.bootstrap(configuration: config)
-                    let serviceGroup = ServiceGroup(services: [observability], logger: .init(label: "service group"))
+                    let canary = Canary()
+                    let serviceGroup = ServiceGroup(services: [observability, canary], logger: ._otelDebug)
 
                     try await withThrowingTaskGroup { group in
                         group.addTask {
                             try await serviceGroup.run()
                         }
+                        await canary.running
                         group.addTask {
                             Gauge(label: "break_room.coffee_temperature").record(85)
                             Counter(label: "macro_data_refinement.files.processed").increment(by: 12)
@@ -234,12 +241,14 @@ import Tracing
                     config.serviceName = "innie"
                     config.resourceAttributes = ["deployment.environment": "prod"]
                     let observability = try OTel.bootstrap(configuration: config)
-                    let serviceGroup = ServiceGroup(services: [observability], logger: .init(label: "service group"))
+                    let canary = Canary()
+                    let serviceGroup = ServiceGroup(services: [observability, canary], logger: ._otelDebug)
 
                     try await withThrowingTaskGroup { group in
                         group.addTask {
                             try await serviceGroup.run()
                         }
+                        await canary.running
                         group.addTask {
                             Gauge(label: "break_room.coffee_temperature").record(85)
                             Counter(label: "macro_data_refinement.files.processed").increment(by: 12)
@@ -296,13 +305,15 @@ import Tracing
                     config.serviceName = "innie"
                     config.resourceAttributes = ["deployment.environment": "prod"]
                     let observability = try OTel.bootstrap(configuration: config)
+                    let canary = Canary()
                     // In this test we intentionally disable logging from Service Lifecycle to isolate the user logging.
-                    let serviceGroup = ServiceGroup(services: [observability], logger: ._otelDisabled)
+                    let serviceGroup = ServiceGroup(services: [observability, canary], logger: ._otelDisabled)
 
                     try await withThrowingTaskGroup { group in
                         group.addTask {
                             try await serviceGroup.run()
                         }
+                        await canary.running
                         group.addTask {
                             let logger = Logger(label: "logger")
                             logger.debug(
@@ -363,13 +374,15 @@ import Tracing
                     config.serviceName = "innie"
                     config.resourceAttributes = ["deployment.environment": "prod"]
                     let observability = try OTel.bootstrap(configuration: config)
+                    let canary = Canary()
                     // In this test we intentionally disable logging from Service Lifecycle to isolate the user logging.
-                    let serviceGroup = ServiceGroup(services: [observability], logger: ._otelDisabled)
+                    let serviceGroup = ServiceGroup(services: [observability, canary], logger: ._otelDisabled)
 
                     try await withThrowingTaskGroup { group in
                         group.addTask {
                             try await serviceGroup.run()
                         }
+                        await canary.running
                         group.addTask {
                             let logger = Logger(label: "logger")
                             logger.debug(
@@ -422,11 +435,11 @@ import Tracing
             let observability = try OTel.bootstrap(configuration: config)
 
             try await withThrowingTaskGroup { group in
-                let serviceGroup = ServiceGroup(services: [observability], logger: ._otelDisabled)
+                let canary = Canary()
+                let serviceGroup = ServiceGroup(services: [observability, canary], logger: ._otelDisabled)
                 group.addTask { try await serviceGroup.run() }
+                await canary.running
                 group.addTask {
-                    // There's no API in Swift Service Lifecycle to wait for it to be "ready".
-                    try await Task.sleep(for: .seconds(0.1))
                     let logger = Logger(label: "Foo")
                     logger.info(
                         "Waffle party privileges have been revoked due to insufficient team spirit",
@@ -462,13 +475,15 @@ import Tracing
                     config.serviceName = "innie"
                     config.resourceAttributes = ["deployment.environment": "prod"]
                     let observability = try OTel.bootstrap(configuration: config)
+                    let canary = Canary()
                     // In this test we intentionally disable logging from Service Lifecycle to isolate the user logging.
-                    let serviceGroup = ServiceGroup(services: [observability], logger: ._otelDisabled)
+                    let serviceGroup = ServiceGroup(services: [observability, canary], logger: ._otelDisabled)
 
                     try await withThrowingTaskGroup { group in
                         group.addTask {
                             try await serviceGroup.run()
                         }
+                        await canary.running
                         group.addTask {
                             let logger = Logger(label: "logger")
                             withSpan("waffle party") { _ in

--- a/Tests/OTelTests/OTelCoreTests/Tracing/OTelTracerTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Tracing/OTelTracerTests.swift
@@ -266,15 +266,14 @@ final class OTelTracerTests: XCTestCase {
         )
 
         let logger = Logger(label: #function)
-        let serviceGroup = ServiceGroup(services: [tracer], logger: logger)
+        let canary = Canary()
+        let serviceGroup = ServiceGroup(services: [tracer, canary], logger: logger)
 
         Task {
             try await serviceGroup.run()
         }
 
-        // We use the processor's first sleep as an indicator for when the tracer started running.
-        var sleeps = clock.sleepCalls.makeAsyncIterator()
-        await sleeps.next()
+        await canary.running
 
         let span = tracer.startSpan("test")
         span.end()
@@ -420,7 +419,8 @@ final class OTelTracerTests: XCTestCase {
         )
 
         let logger = Logger(label: #function)
-        let serviceGroup = ServiceGroup(services: [tracer], logger: logger)
+        let canary = Canary()
+        let serviceGroup = ServiceGroup(services: [tracer, canary], logger: logger)
         Task {
             try await serviceGroup.run()
         }
@@ -431,9 +431,7 @@ final class OTelTracerTests: XCTestCase {
         let span = tracer.startSpan("test")
         span.end()
 
-        // We use the processor's first sleep as an indicator for when the tracer started running.
-        var sleeps = clock.sleepCalls.makeAsyncIterator()
-        await sleeps.next()
+        await canary.running
 
         await serviceGroup.triggerGracefulShutdown()
 

--- a/Tests/OTelTests/OTelTesting/Logger+TestHelpers.swift
+++ b/Tests/OTelTests/OTelTesting/Logger+TestHelpers.swift
@@ -18,4 +18,13 @@ extension Logger {
         label: "swift-otel-logging-disabled",
         factory: { _ in SwiftLogNoOpLogHandler() }
     )
+
+    static let _otelDebug = Logger(
+        label: "swift-otel-debug",
+        factory: { label in
+            var handler = StreamLogHandler.standardError(label: label)
+            handler.logLevel = .debug
+            return handler
+        }
+    )
 }


### PR DESCRIPTION
## Modifications

Right now Swift Service Lifecycle does not have API to wait for a service group to be running. This can make writing tests of the graceful shutdown behaviour hard. For example, the following naive test will probabilistically fail because run might try to run the the services after the shutdown:

```swift
@Test func test() async throws {
    struct S: Service {
        var name: String
        func run() async throws {
            print("\(name) running")
            await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { true }
            print("\(name) done")
        }
    }

    let serviceGroup = ServiceGroup(services: [S(name: "A"), S(name: "B")], logger: Logger(label: "group"))
    try await withThrowingTaskGroup { group in
        group.addTask { try await serviceGroup.run() }
        await serviceGroup.triggerGracefulShutdown()
        try await group.waitForAll()
    }
}
```

```
Caught error: ServiceGroupError: errorCode: The service group has already finished running the services.
```

We have a bunch of very fragile substitutes for this in our tests right now. For example, we'll hook into a test clock and wait for a specific number of sleep calls. As I've been refactoring to make more robust shutdown logic, these have been a problem.

This initial PR adds a different mechanism for waiting for the service group to be running before we shut it down in our tests of graceful shutdown.

## Modifications

- Move Logging+OTelDisabled to Logging+TestHelpers and add ._otelDebug
- Add canary service to support tests of graceful shutdown

## Result

Less fragile graceful shutdown tests.