### PR TITLE
Ensure all run methods only complete on shutdown/cancel

### DIFF
--- a/Sources/OTel/OTLPHTTP/OTLPHTTPExporter.swift
+++ b/Sources/OTel/OTLPHTTP/OTLPHTTPExporter.swift
@@ -19,6 +19,7 @@ import Logging
 import NIOFoundationCompat
 import NIOHTTP1
 import NIOSSL
+import ServiceLifecycle
 import SwiftProtobuf
 
 import struct Foundation.Data
@@ -46,9 +47,9 @@ final class OTLPHTTPExporter<Request: Message, Response: Message>: Sendable {
         try? self.httpClient.syncShutdown()
     }
 
-    func run() async {
+    func run() async throws {
         // No background work needed, but we'll keep the run method running until its cancelled.
-        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+        try await gracefulShutdown()
     }
 
     func send(_ proto: Request) async throws -> Response {

--- a/Sources/OTel/OTLPHTTP/OTLPHTTPExporter.swift
+++ b/Sources/OTel/OTLPHTTP/OTLPHTTPExporter.swift
@@ -46,6 +46,11 @@ final class OTLPHTTPExporter<Request: Message, Response: Message>: Sendable {
         try? self.httpClient.syncShutdown()
     }
 
+    func run() async {
+        // No background work needed, but we'll keep the run method running until its cancelled.
+        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+    }
+
     func send(_ proto: Request) async throws -> Response {
         // https://opentelemetry.io/docs/specs/otlp/#otlphttp-request
         var request = HTTPClientRequest(url: self.configuration.endpoint)

--- a/Sources/OTel/OTLPHTTP/OTLPHTTPLogRecordExporter.swift
+++ b/Sources/OTel/OTLPHTTP/OTLPHTTPLogRecordExporter.swift
@@ -29,7 +29,9 @@ final class OTLPHTTPLogRecordExporter: OTelLogRecordExporter {
         exporter = try OTLPHTTPExporter(configuration: configuration)
     }
 
-    func run() async throws {}
+    func run() async throws {
+        try await exporter.run()
+    }
 
     func export(_ batch: some Collection<OTelLogRecord> & Sendable) async throws {
         guard !batch.isEmpty else { return }

--- a/Sources/OTel/OTLPHTTP/OTLPHTTPMetricExporter.swift
+++ b/Sources/OTel/OTLPHTTP/OTLPHTTPMetricExporter.swift
@@ -29,7 +29,9 @@ final class OTLPHTTPMetricExporter: OTelMetricExporter {
         exporter = try OTLPHTTPExporter(configuration: configuration)
     }
 
-    func run() async throws {}
+    func run() async throws {
+        try await exporter.run()
+    }
 
     func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {
         guard batch.contains(where: { $0.scopeMetrics.contains(where: { !$0.metrics.isEmpty }) }) else { return }

--- a/Sources/OTel/OTLPHTTP/OTLPHTTPSpanExporter.swift
+++ b/Sources/OTel/OTLPHTTP/OTLPHTTPSpanExporter.swift
@@ -29,7 +29,9 @@ final class OTLPHTTPSpanExporter: OTelSpanExporter {
         exporter = try OTLPHTTPExporter(configuration: configuration)
     }
 
-    func run() async throws {}
+    func run() async throws {
+        try await exporter.run()
+    }
 
     func export(_ batch: some Collection<OTelFinishedSpan> & Sendable) async throws {
         guard !batch.isEmpty else { return }

--- a/Sources/OTel/OTelCore/Logging/Exporting/OTelConsoleLogRecordExporter.swift
+++ b/Sources/OTel/OTelCore/Logging/Exporting/OTelConsoleLogRecordExporter.swift
@@ -14,7 +14,7 @@
 import struct Foundation.Date
 
 struct OTelConsoleLogRecordExporter: OTelLogRecordExporter {
-    func run() {
+    func run() async {
         /// > The exporter’s output format is unspecified and can vary between implementations. Documentation SHOULD
         /// > warn users about this. The following wording is recommended (modify as needed):
         /// > >
@@ -34,6 +34,8 @@ struct OTelConsoleLogRecordExporter: OTelLogRecordExporter {
             ---
             """
         )
+        // No background work needed, but we'll keep the run method running until its cancelled.
+        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
     }
 
     func export(_ batch: some Collection<OTelLogRecord> & Sendable) {

--- a/Sources/OTel/OTelCore/Logging/Exporting/OTelConsoleLogRecordExporter.swift
+++ b/Sources/OTel/OTelCore/Logging/Exporting/OTelConsoleLogRecordExporter.swift
@@ -12,9 +12,10 @@
 //===----------------------------------------------------------------------===//
 
 import struct Foundation.Date
+import ServiceLifecycle
 
 struct OTelConsoleLogRecordExporter: OTelLogRecordExporter {
-    func run() async {
+    func run() async throws {
         /// > The exporter’s output format is unspecified and can vary between implementations. Documentation SHOULD
         /// > warn users about this. The following wording is recommended (modify as needed):
         /// > >
@@ -35,7 +36,7 @@ struct OTelConsoleLogRecordExporter: OTelLogRecordExporter {
             """
         )
         // No background work needed, but we'll keep the run method running until its cancelled.
-        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+        try await gracefulShutdown()
     }
 
     func export(_ batch: some Collection<OTelLogRecord> & Sendable) {

--- a/Sources/OTel/OTelCore/Metrics/OTelMetricExporter/OTelConsoleMetricExporter.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelMetricExporter/OTelConsoleMetricExporter.swift
@@ -11,13 +11,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+import ServiceLifecycle
+
 /// A metric exporter that logs metrics to the console for debugging.
 struct OTelConsoleMetricExporter: OTelMetricExporter {
     /// Create a new ``OTelConsoleMetricExporter``.
 
-    func run() async {
+    func run() async throws {
         // No background work needed, but we'll keep the run method running until its cancelled.
-        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+        try await gracefulShutdown()
     }
 
     func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {

--- a/Sources/OTel/OTelCore/Metrics/OTelMetricExporter/OTelConsoleMetricExporter.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelMetricExporter/OTelConsoleMetricExporter.swift
@@ -15,7 +15,10 @@
 struct OTelConsoleMetricExporter: OTelMetricExporter {
     /// Create a new ``OTelConsoleMetricExporter``.
 
-    func run() async throws {}
+    func run() async {
+        // No background work needed, but we'll keep the run method running until its cancelled.
+        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+    }
 
     func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {
         for metric in batch {

--- a/Sources/OTel/OTelCore/OTelCore+GenericWrappers.swift
+++ b/Sources/OTel/OTelCore/OTelCore+GenericWrappers.swift
@@ -70,7 +70,7 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.run()
         #endif
-        case .console(let exporter): await exporter.run()
+        case .console(let exporter): try await exporter.run()
         case .none: break
         }
     }

--- a/Sources/OTel/OTelCore/OTelCore+GenericWrappers.swift
+++ b/Sources/OTel/OTelCore/OTelCore+GenericWrappers.swift
@@ -70,7 +70,7 @@ internal enum WrappedLogRecordExporter: OTelLogRecordExporter {
         #if OTLPHTTP
         case .http(let exporter): try await exporter.run()
         #endif
-        case .console(let exporter): exporter.run()
+        case .console(let exporter): await exporter.run()
         case .none: break
         }
     }

--- a/Sources/OTel/OTelCore/Tracing/Exporting/OTelNoOpSpanExporter.swift
+++ b/Sources/OTel/OTelCore/Tracing/Exporting/OTelNoOpSpanExporter.swift
@@ -15,8 +15,9 @@
 struct OTelNoOpSpanExporter: OTelSpanExporter {
     /// Initialize a no-op span exporter.
 
-    func run() async throws {
-        // no-op
+    func run() async {
+        // No background work needed, but we'll keep the run method running until its cancelled.
+        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
     }
 
     func export(_ batch: some Collection<OTelFinishedSpan>) async throws {

--- a/Sources/OTel/OTelCore/Tracing/Exporting/OTelNoOpSpanExporter.swift
+++ b/Sources/OTel/OTelCore/Tracing/Exporting/OTelNoOpSpanExporter.swift
@@ -11,13 +11,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+import ServiceLifecycle
+
 /// A span exporter that ignores all operations, used when no spans should be exported.
 struct OTelNoOpSpanExporter: OTelSpanExporter {
     /// Initialize a no-op span exporter.
 
-    func run() async {
+    func run() async throws {
         // No background work needed, but we'll keep the run method running until its cancelled.
-        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+        try await gracefulShutdown()
     }
 
     func export(_ batch: some Collection<OTelFinishedSpan>) async throws {

--- a/Sources/OTel/OTelCore/Tracing/Processing/OTelNoOpSpanProcessor.swift
+++ b/Sources/OTel/OTelCore/Tracing/Processing/OTelNoOpSpanProcessor.swift
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 import ServiceContextModule
+import ServiceLifecycle
 
 /// A span processor that ignores all operations, used when no spans should be processed.
 struct OTelNoOpSpanProcessor: OTelSpanProcessor, CustomStringConvertible {
@@ -20,9 +21,9 @@ struct OTelNoOpSpanProcessor: OTelSpanProcessor, CustomStringConvertible {
     /// Initialize a no-op span processor.
     init() {}
 
-    func run() async {
+    func run() async throws {
         // No background work needed, but we'll keep the run method running until its cancelled.
-        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+        try await gracefulShutdown()
     }
 
     func onStart(_ span: OTelSpan, parentContext: ServiceContext) {

--- a/Sources/OTel/OTelCore/Tracing/Processing/OTelNoOpSpanProcessor.swift
+++ b/Sources/OTel/OTelCore/Tracing/Processing/OTelNoOpSpanProcessor.swift
@@ -17,16 +17,12 @@ import ServiceContextModule
 struct OTelNoOpSpanProcessor: OTelSpanProcessor, CustomStringConvertible {
     let description = "OTelNoOpSpanProcessor"
 
-    private let stream: AsyncStream<Void>
-    private let continuation: AsyncStream<Void>.Continuation
-
     /// Initialize a no-op span processor.
-    init() {
-        (stream, continuation) = AsyncStream.makeStream()
-    }
+    init() {}
 
     func run() async {
-        for await _ in stream.cancelOnGracefulShutdown() {}
+        // No background work needed, but we'll keep the run method running until its cancelled.
+        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
     }
 
     func onStart(_ span: OTelSpan, parentContext: ServiceContext) {

--- a/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
@@ -303,9 +303,9 @@ final class MockMetricExporter: Sendable, OTelMetricExporter {
         self.behavior = behavior
     }
 
-    func run() async {
+    func run() async throws {
         // No background work needed, but we'll keep the run method running until its cancelled.
-        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+        try await gracefulShutdown()
     }
 
     func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {

--- a/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
@@ -303,7 +303,10 @@ final class MockMetricExporter: Sendable, OTelMetricExporter {
         self.behavior = behavior
     }
 
-    func run() async throws {}
+    func run() async {
+        // No background work needed, but we'll keep the run method running until its cancelled.
+        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+    }
 
     func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) async throws {
         switch behavior {

--- a/Tests/OTelTests/OTelTesting/OTelInMemoryLogRecordExporter.swift
+++ b/Tests/OTelTests/OTelTesting/OTelInMemoryLogRecordExporter.swift
@@ -26,7 +26,10 @@ actor OTelInMemoryLogRecordExporter: OTelLogRecordExporter {
         self.exportDelay = exportDelay
     }
 
-    func run() async throws {}
+    func run() async {
+        // No background work needed, but we'll keep the run method running until its cancelled.
+        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+    }
 
     func export(_ batch: some Collection<OTelLogRecord> & Sendable) async throws {
         if exportDelay != .zero {

--- a/Tests/OTelTests/OTelTesting/OTelInMemoryLogRecordExporter.swift
+++ b/Tests/OTelTests/OTelTesting/OTelInMemoryLogRecordExporter.swift
@@ -13,6 +13,7 @@
 
 import NIOConcurrencyHelpers
 @testable import OTel
+import ServiceLifecycle
 
 actor OTelInMemoryLogRecordExporter: OTelLogRecordExporter {
     private(set) var exportedBatches = [[OTelLogRecord]]()
@@ -26,9 +27,9 @@ actor OTelInMemoryLogRecordExporter: OTelLogRecordExporter {
         self.exportDelay = exportDelay
     }
 
-    func run() async {
+    func run() async throws {
         // No background work needed, but we'll keep the run method running until its cancelled.
-        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+        try await gracefulShutdown()
     }
 
     func export(_ batch: some Collection<OTelLogRecord> & Sendable) async throws {

--- a/Tests/OTelTests/OTelTesting/OTelInMemorySpanExporter.swift
+++ b/Tests/OTelTests/OTelTesting/OTelInMemorySpanExporter.swift
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 @testable import OTel
+import ServiceLifecycle
 
 /// An in-memory span exporter, collecting exported batches into ``OTelInMemorySpanExporter/exportedBatches``.
 final actor OTelInMemorySpanExporter: OTelSpanExporter {
@@ -25,9 +26,9 @@ final actor OTelInMemorySpanExporter: OTelSpanExporter {
         self.exportDelay = exportDelay
     }
 
-    func run() async {
+    func run() async throws {
         // No background work needed, but we'll keep the run method running until its cancelled.
-        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+        try await gracefulShutdown()
     }
 
     func export(_ batch: some Collection<OTelFinishedSpan>) async throws {

--- a/Tests/OTelTests/OTelTesting/OTelInMemorySpanExporter.swift
+++ b/Tests/OTelTests/OTelTesting/OTelInMemorySpanExporter.swift
@@ -25,8 +25,9 @@ final actor OTelInMemorySpanExporter: OTelSpanExporter {
         self.exportDelay = exportDelay
     }
 
-    func run() async throws {
-        // no-op
+    func run() async {
+        // No background work needed, but we'll keep the run method running until its cancelled.
+        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
     }
 
     func export(_ batch: some Collection<OTelFinishedSpan>) async throws {

--- a/Tests/OTelTests/OTelTesting/OTelStreamingLogRecordProcessor.swift
+++ b/Tests/OTelTests/OTelTesting/OTelStreamingLogRecordProcessor.swift
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 @testable import OTel
+import ServiceLifecycle
 
 /// A log record exporter streaming exported batches via an async sequence.
 final actor OTelStreamingLogRecordExporter: OTelLogRecordExporter {
@@ -26,9 +27,9 @@ final actor OTelStreamingLogRecordExporter: OTelLogRecordExporter {
         (batches, batchContinuation) = AsyncStream<[OTelLogRecord]>.makeStream()
     }
 
-    func run() async {
+    func run() async throws {
         // No background work needed, but we'll keep the run method running until its cancelled.
-        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+        try await gracefulShutdown()
     }
 
     func setErrorDuringNextExport(_ error: some Error) {

--- a/Tests/OTelTests/OTelTesting/OTelStreamingLogRecordProcessor.swift
+++ b/Tests/OTelTests/OTelTesting/OTelStreamingLogRecordProcessor.swift
@@ -26,7 +26,10 @@ final actor OTelStreamingLogRecordExporter: OTelLogRecordExporter {
         (batches, batchContinuation) = AsyncStream<[OTelLogRecord]>.makeStream()
     }
 
-    func run() async throws {}
+    func run() async {
+        // No background work needed, but we'll keep the run method running until its cancelled.
+        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+    }
 
     func setErrorDuringNextExport(_ error: some Error) {
         errorDuringNextExport = error

--- a/Tests/OTelTests/OTelTesting/OTelStreamingSpanExporter.swift
+++ b/Tests/OTelTests/OTelTesting/OTelStreamingSpanExporter.swift
@@ -30,7 +30,10 @@ final actor OTelStreamingSpanExporter: OTelSpanExporter {
         errorDuringNextExport = error
     }
 
-    func run() async throws {}
+    func run() async {
+        // No background work needed, but we'll keep the run method running until its cancelled.
+        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+    }
 
     func export(_ batch: some Collection<OTelFinishedSpan>) async throws {
         batchContinuation.yield(Array(batch))

--- a/Tests/OTelTests/OTelTesting/OTelStreamingSpanExporter.swift
+++ b/Tests/OTelTests/OTelTesting/OTelStreamingSpanExporter.swift
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 @testable import OTel
+import ServiceLifecycle
 
 /// A span exporter, streaming exported batches via an async sequence.
 final actor OTelStreamingSpanExporter: OTelSpanExporter {
@@ -30,9 +31,9 @@ final actor OTelStreamingSpanExporter: OTelSpanExporter {
         errorDuringNextExport = error
     }
 
-    func run() async {
+    func run() async throws {
         // No background work needed, but we'll keep the run method running until its cancelled.
-        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+        try await gracefulShutdown()
     }
 
     func export(_ batch: some Collection<OTelFinishedSpan>) async throws {

--- a/Tests/OTelTests/OTelTesting/RecordingMetricExporter.swift
+++ b/Tests/OTelTests/OTelTesting/RecordingMetricExporter.swift
@@ -27,7 +27,10 @@ struct RecordingMetricExporter: OTelMetricExporter {
 
     let recordedCalls = NIOLockedValueBox(RecordedCalls())
 
-    func run() async throws {}
+    func run() async {
+        // No background work needed, but we'll keep the run method running until its cancelled.
+        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+    }
 
     func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) {
         recordedCalls.withLockedValue { $0.exportCalls.append(batch) }

--- a/Tests/OTelTests/OTelTesting/RecordingMetricExporter.swift
+++ b/Tests/OTelTests/OTelTesting/RecordingMetricExporter.swift
@@ -14,6 +14,7 @@
 #if canImport(XCTest)
 import NIOConcurrencyHelpers
 @testable import OTel
+import ServiceLifecycle
 import XCTest
 
 struct RecordingMetricExporter: OTelMetricExporter {
@@ -27,9 +28,9 @@ struct RecordingMetricExporter: OTelMetricExporter {
 
     let recordedCalls = NIOLockedValueBox(RecordedCalls())
 
-    func run() async {
+    func run() async throws {
         // No background work needed, but we'll keep the run method running until its cancelled.
-        await AsyncStream.makeStream(of: Void.self).stream.cancelOnGracefulShutdown().first { _ in true }
+        try await gracefulShutdown()
     }
 
     func export(_ batch: some Collection<OTelResourceMetrics> & Sendable) {


### PR DESCRIPTION
## Motivation

In #236 we added a run method requirement to exporter protocols to support the OTLP/gRPC exporter migration to gRPC Swift 2, which requires a run method for the connection pool. As such, there became a need for the exporters to be run. This is currently done by the processor, but there are issues with the way the composition of these run methods works with graceful shutdown. Specifically, the main issue we have right now is how the processor behaves when the exporter exits early (cleanly or throws).

As part of trying to address that (future PR to come), I noticed that most of the exporters had an empty, no-op run method. This isn't great because anything that tries to formalise the shutdown semantics of the processor when the exporter early-exits will trigger for these exporters that immediately return from their run methods.

The semantics of a type with a run method should be that it "blocks" until the "background work" is finished—in our cases when the type is cancelled or shutdown.

## Modifications

- Ensure all run methods only complete on shutdown/cancel

## Result

All types with run method have usual semantics, which will unblock making the error handling of exporters more robust.
