### PR TITLE
Fix all compiler warnings and use -warnings-as-errors in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: swift package resolve
 
       - name: Run Unit Tests
-        run: swift test --enable-code-coverage
+        run: swift test -Xswiftc -warnings-as-errors --enable-code-coverage
 
       - name: Merge code coverage
         if: matrix.swift == 'latest'

--- a/Tests/OTelTests/OTelCoreTests/Logging/Processing/OTelBatchLogRecordProcessorTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Logging/Processing/OTelBatchLogRecordProcessorTests.swift
@@ -48,7 +48,7 @@ final class OTelBatchLogRecordProcessorTests: XCTestCase {
             // advance past "tick"
             clock.advance(by: scheduleDelay)
 
-            var batches = await exporter.batches.makeAsyncIterator()
+            var batches = exporter.batches.makeAsyncIterator()
             let batch = await batches.next()
             XCTAssertEqual(try XCTUnwrap(batch).map(\.body), messages)
 
@@ -75,7 +75,7 @@ final class OTelBatchLogRecordProcessorTests: XCTestCase {
             var record2 = OTelLogRecord.stub(body: "2")
             processor.onEmit(&record2)
 
-            var batches = await exporter.batches.makeAsyncIterator()
+            var batches = exporter.batches.makeAsyncIterator()
             let batch = await batches.next()
             XCTAssertEqual(try XCTUnwrap(batch).map(\.body), ["1", "2"])
 
@@ -114,7 +114,7 @@ final class OTelBatchLogRecordProcessorTests: XCTestCase {
             // await sleep for export timeout
             await sleeps.next()
 
-            var batches = await exporter.batches.makeAsyncIterator()
+            var batches = exporter.batches.makeAsyncIterator()
             let failedBatch = await batches.next()
             XCTAssertEqual(try XCTUnwrap(failedBatch).map(\.body), ["1"])
 
@@ -212,7 +212,7 @@ final class OTelBatchLogRecordProcessorTests: XCTestCase {
 
             shutdownTrigger.triggerGracefulShutdown()
 
-            var batches = await exporter.batches.makeAsyncIterator()
+            var batches = exporter.batches.makeAsyncIterator()
             /*
              Forced flush exports occur concurrently, so we check that all messages got exported,
              without checking the specific order they were exported in.

--- a/Tests/OTelTests/OTelCoreTests/Logging/Processing/OTelMultiplexLogRecordProcessorTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Logging/Processing/OTelMultiplexLogRecordProcessorTests.swift
@@ -37,11 +37,11 @@ final class OTelMultiplexLogRecordProcessorTests: XCTestCase {
 
             try await processor.forceFlush()
 
-            var exporter1Iterator = await exporter1.batches.makeAsyncIterator()
+            var exporter1Iterator = exporter1.batches.makeAsyncIterator()
             let exporter1Batch = await exporter1Iterator.next()
             XCTAssertEqual(try XCTUnwrap(exporter1Batch).map(\.body), ["test"])
 
-            var exporter2Iterator = await exporter2.batches.makeAsyncIterator()
+            var exporter2Iterator = exporter2.batches.makeAsyncIterator()
             let exporter2Batch = await exporter2Iterator.next()
             XCTAssertEqual(try XCTUnwrap(exporter2Batch).map(\.body), ["test"])
 

--- a/Tests/OTelTests/OTelCoreTests/Tracing/OTelTracerTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Tracing/OTelTracerTests.swift
@@ -180,7 +180,7 @@ final class OTelTracerTests: XCTestCase {
         let sampler = OTelConstantSampler(isOn: true)
         let propagator = OTelW3CPropagator()
         let exporter = OTelStreamingSpanExporter()
-        var batches = await exporter.batches.makeAsyncIterator()
+        var batches = exporter.batches.makeAsyncIterator()
         let processor = OTelSimpleSpanProcessor(exporter: exporter)
 
         let tracer = OTelTracer(
@@ -217,7 +217,7 @@ final class OTelTracerTests: XCTestCase {
         }
         let propagator = OTelW3CPropagator()
         let exporter = OTelStreamingSpanExporter()
-        var batches = await exporter.batches.makeAsyncIterator()
+        var batches = exporter.batches.makeAsyncIterator()
         let processor = OTelSimpleSpanProcessor(exporter: exporter)
 
         let tracer = OTelTracer(
@@ -280,7 +280,7 @@ final class OTelTracerTests: XCTestCase {
 
         tracer.forceFlush()
 
-        var batches = await exporter.batches.makeAsyncIterator()
+        var batches = exporter.batches.makeAsyncIterator()
         let batch = await batches.next()
 
         XCTAssertEqual(try XCTUnwrap(batch).map(\.operationName), ["test"])
@@ -435,7 +435,7 @@ final class OTelTracerTests: XCTestCase {
 
         await serviceGroup.triggerGracefulShutdown()
 
-        var batches = await exporter.batches.makeAsyncIterator()
+        var batches = exporter.batches.makeAsyncIterator()
         let batch = await batches.next()
         XCTAssertEqual(try XCTUnwrap(batch).map(\.operationName), ["test"])
     }

--- a/Tests/OTelTests/OTelCoreTests/Tracing/Processing/Batch/OTelBatchSpanProcessorTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Tracing/Processing/Batch/OTelBatchSpanProcessorTests.swift
@@ -46,7 +46,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
         await sleeps.next()
         clock.advance(by: .seconds(2))
 
-        var batches = await exporter.batches.makeAsyncIterator()
+        var batches = exporter.batches.makeAsyncIterator()
         let batch = await batches.next()
         XCTAssertEqual(try XCTUnwrap(batch).map(\.operationName), ["1", "2", "3"])
     }
@@ -79,7 +79,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
         await sleeps.next()
         clock.advance(by: .seconds(2))
 
-        var batches = await exporter.batches.makeAsyncIterator()
+        var batches = exporter.batches.makeAsyncIterator()
         let batch = await batches.next()
         XCTAssertEqual(try XCTUnwrap(batch).map(\.operationName), ["1"])
     }
@@ -115,7 +115,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
         // add final span to reach maximum queue size
         await processor.onEnd(span3)
 
-        var batches = await exporter.batches.makeAsyncIterator()
+        var batches = exporter.batches.makeAsyncIterator()
         let batch = await batches.next()
         XCTAssertEqual(try XCTUnwrap(batch).map(\.operationName), ["1", "2", "3"])
     }
@@ -151,7 +151,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
         // await sleep for export timeout
         await sleeps.next()
 
-        var batches = await exporter.batches.makeAsyncIterator()
+        var batches = exporter.batches.makeAsyncIterator()
         let failedBatch = await batches.next()
         XCTAssertEqual(try XCTUnwrap(failedBatch).map { $0.map(\.operationName) }, ["1"])
 

--- a/Tests/OTelTests/OTelCoreTests/Tracing/Processing/OTelSimpleSpanProcessorTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Tracing/Processing/OTelSimpleSpanProcessorTests.swift
@@ -27,7 +27,7 @@ final class OTelSimpleSpanProcessorTests: XCTestCase {
         processor.onEnd(span)
 
         // wait for batch to be exported
-        var exportedBatchess = await exporter.batches.makeAsyncIterator()
+        var exportedBatchess = exporter.batches.makeAsyncIterator()
         let batch = await exportedBatchess.next()
 
         XCTAssertEqual(try XCTUnwrap(batch).map(\.operationName), ["test"])


### PR DESCRIPTION
## Motivation

There were a few trivial compiler warnings kicking around (unnecessary `await` for expressions that are not async). We can get the project to be warning-free and lock in the win with CI.

## Modifications

- Fix all compiler warnings
- Update CI to build with `-warnings-as-errors`

## Result

Project has no compiler warnings.