### PR TITLE
Lean into ServiceGroup for consistent handling of shutdown of nested services

### DIFF
--- a/Sources/OTel/OTelAPI/OTel+Backends.swift
+++ b/Sources/OTel/OTelAPI/OTel+Backends.swift
@@ -345,6 +345,16 @@ extension OTel {
             resource: resource,
             logger: logger
         )
-        return (tracer, tracer)
+        // Return a nested service group, which will handle the ordered shutdown.
+        var serviceConfigs: [ServiceGroupConfiguration.ServiceConfiguration] = []
+        for service in [exporter, processor, tracer] as [Service] {
+            serviceConfigs.append(.init(
+                service: service,
+                successTerminationBehavior: .gracefullyShutdownGroup,
+                failureTerminationBehavior: .gracefullyShutdownGroup
+            ))
+        }
+        let serviceGroup = ServiceGroup(configuration: .init(services: serviceConfigs, logger: logger))
+        return (tracer, serviceGroup)
     }
 }

--- a/Sources/OTel/OTelCore/Logging/Processing/Batch/OTelBatchLogRecordProcessor.swift
+++ b/Sources/OTel/OTelCore/Logging/Processing/Batch/OTelBatchLogRecordProcessor.swift
@@ -65,31 +65,20 @@ actor OTelBatchLogRecordProcessor<Exporter: OTelLogRecordExporter, Clock: _Concu
         let timerSequence = AsyncTimerSequence(interval: configuration.scheduleDelay, clock: clock).map { _ in }
         let mergedSequence = merge(timerSequence, explicitTickStream).cancelOnGracefulShutdown()
 
-        try await withTaskCancellationOrGracefulShutdownHandler {
-            try await withThrowingTaskGroup { taskGroup in
-                taskGroup.addTask {
-                    try await self.exporter.run()
+        await withTaskGroup { taskGroup in
+            taskGroup.addTask {
+                for await log in self.logStream.cancelOnGracefulShutdown() {
+                    await self._onLog(log)
                 }
-                taskGroup.addTask {
-                    for try await _ in mergedSequence where await !(self.buffer.isEmpty) {
-                        await self.tick()
-                    }
-                }
-                taskGroup.addTask {
-                    for await log in self.logStream {
-                        await self._onLog(log)
-                    }
-                    self.logger.debug("Shutting down.")
-                    self.explicitTick.finish()
-                    try? await self.forceFlush()
-                    await self.exporter.shutdown()
-                    self.logger.debug("Shut down.")
-                }
-                try await taskGroup.next()
             }
-        } onCancelOrGracefulShutdown: {
-            self.logContinuation.finish()
-            self.explicitTick.finish()
+            for await _ in mergedSequence where !(self.buffer.isEmpty) {
+                await self.tick()
+            }
+            self.logger.debug("Shutting down.")
+            try? await self.forceFlush()
+            await self.exporter.shutdown()
+            self.logger.debug("Shut down.")
+            await taskGroup.waitForAll()
         }
     }
 

--- a/Sources/OTel/OTelCore/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
+++ b/Sources/OTel/OTelCore/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
@@ -60,21 +60,34 @@ actor OTelBatchSpanProcessor<Exporter: OTelSpanExporter, Clock: _Concurrency.Clo
         let timerSequence = AsyncTimerSequence(interval: configuration.scheduleDelay, clock: clock).map { _ in }
         let mergedSequence = merge(timerSequence, explicitTickStream).cancelOnGracefulShutdown()
 
-        try await withThrowingTaskGroup { group in
-            group.addTask {
-                try await self.exporter.run()
+        try await withTaskCancellationOrGracefulShutdownHandler {
+            try await withThrowingTaskGroup { group in
+                group.addTask {
+                    try await self.exporter.run()
+                }
+                group.addTask {
+                    for await _ in mergedSequence where await !self.buffer.isEmpty {
+                        await self.tick()
+                    }
+                    self.logger.debug("Shutting down.")
+                    try? await self.forceFlush()
+                    await self.exporter.shutdown()
+                    self.logger.debug("Shut down.")
+                }
+                do {
+                    try await group.next()
+                    self.logger.warning("Exporter finished")
+                    group.cancelAll()
+                    try await group.waitForAll()
+                } catch {
+                    self.logger.warning("Exporter threw an error")
+                    group.cancelAll()
+                    try await group.waitForAll()
+                }
             }
-
-            for try await _ in mergedSequence where !buffer.isEmpty {
-                await tick()
-            }
-
-            logger.debug("Shutting down.")
-            try? await forceFlush()
-            await exporter.shutdown()
-            try await group.waitForAll()
+        } onCancelOrGracefulShutdown: {
+            self.explicitTick.finish()
         }
-        logger.debug("Shut down.")
     }
 
     func forceFlush() async throws {

--- a/Tests/OTelTests/OTelCoreTests/Logging/Processing/OTelBatchLogRecordProcessorTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Logging/Processing/OTelBatchLogRecordProcessorTests.swift
@@ -281,6 +281,90 @@ final class OTelBatchLogRecordProcessorTests: XCTestCase {
         let numberOfShutdowns = await exporter.numberOfShutdowns
         XCTAssertEqual(numberOfShutdowns, 1)
     }
+
+    func test_run_exporterRunMethodFinishes_shutsDownProcessor() async throws {
+        struct ExitingExporter: OTelLogRecordExporter {
+            let trigger = AsyncStream<Void>.makeStream(of: Void.self)
+            func run() async throws {
+                await trigger.stream.first { true }
+            }
+
+            func export(_ batch: some Collection<OTelLogRecord> & Sendable) async throws {}
+            func forceFlush() async throws {}
+            func shutdown() async {}
+        }
+
+        let exporter = ExitingExporter()
+        let processorClock = TestClock()
+        let processor = OTelBatchLogRecordProcessor(
+            exporter: exporter,
+            configuration: .init(environment: [:], scheduleDelay: .seconds(1), exportTimeout: .seconds(1)),
+            clock: processorClock
+        )
+
+        try await withThrowingTaskGroup { group in
+            group.addTask {
+                let serviceGroup = ServiceGroup(services: [exporter, processor], logger: Logger(label: #function))
+                try await serviceGroup.run()
+                XCTFail("Expected service group task throw")
+            }
+
+            var processorSleeps = processorClock.sleepCalls.makeAsyncIterator()
+            await processorSleeps.next()
+            exporter.trigger.continuation.yield()
+
+            do {
+                try await group.next()
+                XCTFail("Expected service group task throw")
+            } catch {
+                let serviceGroupError = try XCTUnwrap(error as? ServiceGroupError)
+                XCTAssertEqual(serviceGroupError, ServiceGroupError.serviceFinishedUnexpectedly())
+            }
+        }
+    }
+
+    func test_run_exporterRunMethodThrows_shutsDownProcessor() async throws {
+        struct ThrowingExporter: OTelLogRecordExporter {
+            let trigger = AsyncStream<Void>.makeStream(of: Void.self)
+            func run() async throws {
+                await trigger.stream.first(where: { true })
+                throw ExporterFailed()
+            }
+
+            struct ExporterFailed: Error {}
+            func export(_ batch: some Collection<OTelLogRecord> & Sendable) async throws {}
+            func forceFlush() async throws {}
+            func shutdown() async {}
+        }
+
+        let exporter = ThrowingExporter()
+        let processorClock = TestClock()
+        let processor = OTelBatchLogRecordProcessor(
+            exporter: exporter,
+            configuration: .init(environment: [:], scheduleDelay: .seconds(1), exportTimeout: .seconds(1)),
+            clock: processorClock
+        )
+
+        try await withThrowingTaskGroup { group in
+            group.addTask {
+                let serviceGroup = ServiceGroup(services: [exporter, processor], logger: Logger(label: #function))
+                try await serviceGroup.run()
+                XCTFail("Expected service group task throw")
+            }
+
+            var processorSleeps = processorClock.sleepCalls.makeAsyncIterator()
+            await processorSleeps.next()
+            exporter.trigger.continuation.yield()
+
+            do {
+                try await group.next()
+                XCTFail("Expected service group task throw")
+            } catch {
+                XCTAssert(error is ThrowingExporter.ExporterFailed, "Different error: \(error)")
+            }
+            try await group.waitForAll()
+        }
+    }
 }
 
 private struct ShutdownTrigger: Service {

--- a/Tests/OTelTests/OTelCoreTests/Tracing/OTelTracerTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Tracing/OTelTracerTests.swift
@@ -193,7 +193,7 @@ final class OTelTracerTests: XCTestCase {
         )
 
         let logger = Logger(label: #function)
-        let serviceGroup = ServiceGroup(services: [tracer], logger: logger)
+        let serviceGroup = ServiceGroup(services: [exporter, processor, tracer], logger: logger)
 
         Task {
             try await serviceGroup.run()
@@ -230,7 +230,7 @@ final class OTelTracerTests: XCTestCase {
         )
 
         let logger = Logger(label: #function)
-        let serviceGroup = ServiceGroup(services: [tracer], logger: logger)
+        let serviceGroup = ServiceGroup(services: [exporter, processor, tracer], logger: logger)
 
         Task {
             try await serviceGroup.run()
@@ -267,7 +267,7 @@ final class OTelTracerTests: XCTestCase {
 
         let logger = Logger(label: #function)
         let canary = Canary()
-        let serviceGroup = ServiceGroup(services: [tracer, canary], logger: logger)
+        let serviceGroup = ServiceGroup(services: [exporter, processor, tracer, canary], logger: logger)
 
         Task {
             try await serviceGroup.run()
@@ -420,7 +420,7 @@ final class OTelTracerTests: XCTestCase {
 
         let logger = Logger(label: #function)
         let canary = Canary()
-        let serviceGroup = ServiceGroup(services: [tracer, canary], logger: logger)
+        let serviceGroup = ServiceGroup(services: [exporter, processor, tracer, canary], logger: logger)
         Task {
             try await serviceGroup.run()
         }

--- a/Tests/OTelTests/OTelCoreTests/Tracing/Processing/Batch/OTelBatchSpanProcessorTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Tracing/Processing/Batch/OTelBatchSpanProcessorTests.swift
@@ -33,7 +33,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
         let span2 = OTelFinishedSpan.stub(traceFlags: .sampled, operationName: "2")
         let span3 = OTelFinishedSpan.stub(traceFlags: .sampled, operationName: "3")
 
-        let serviceGroup = ServiceGroup(services: [processor], logger: Logger(label: #function))
+        let serviceGroup = ServiceGroup(services: [exporter, processor], logger: Logger(label: #function))
         Task {
             try await serviceGroup.run()
         }
@@ -66,7 +66,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
         let span1 = OTelFinishedSpan.stub(traceFlags: .sampled, operationName: "1")
         let span2 = OTelFinishedSpan.stub(traceFlags: [], operationName: "2")
 
-        let serviceGroup = ServiceGroup(services: [processor], logger: Logger(label: #function))
+        let serviceGroup = ServiceGroup(services: [exporter, processor], logger: Logger(label: #function))
         Task {
             try await serviceGroup.run()
         }
@@ -100,7 +100,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
         let span2 = OTelFinishedSpan.stub(traceFlags: .sampled, operationName: "2")
         let span3 = OTelFinishedSpan.stub(traceFlags: .sampled, operationName: "3")
 
-        let serviceGroup = ServiceGroup(services: [processor], logger: Logger(label: #function))
+        let serviceGroup = ServiceGroup(services: [exporter, processor], logger: Logger(label: #function))
         Task {
             try await serviceGroup.run()
         }
@@ -137,7 +137,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
         let span1 = OTelFinishedSpan.stub(traceFlags: .sampled, operationName: "1")
         let span2 = OTelFinishedSpan.stub(traceFlags: .sampled, operationName: "2")
 
-        let serviceGroup = ServiceGroup(services: [processor], logger: Logger(label: #function))
+        let serviceGroup = ServiceGroup(services: [exporter, processor], logger: Logger(label: #function))
         Task {
             try await serviceGroup.run()
         }
@@ -186,7 +186,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
 
         let finishExpectation = expectation(description: "Expected processor to finish shutting down.")
 
-        let serviceGroup = ServiceGroup(services: [processor], logger: Logger(label: #function))
+        let serviceGroup = ServiceGroup(services: [exporter, processor], logger: Logger(label: #function))
         Task {
             try await serviceGroup.run()
             finishExpectation.fulfill()
@@ -229,7 +229,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
 
         let finishExpectation = expectation(description: "Expected processor to finish shutting down.")
 
-        let serviceGroup = ServiceGroup(services: [processor], logger: Logger(label: #function))
+        let serviceGroup = ServiceGroup(services: [exporter, processor], logger: Logger(label: #function))
         Task {
             do {
                 try await serviceGroup.run()
@@ -281,7 +281,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
 
         try await withThrowingTaskGroup { group in
             group.addTask {
-                let serviceGroup = ServiceGroup(services: [processor], logger: Logger(label: #function))
+                let serviceGroup = ServiceGroup(services: [exporter, processor], logger: Logger(label: #function))
                 try await serviceGroup.run()
                 XCTFail("Expected service group task throw")
             }
@@ -324,7 +324,7 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
 
         try await withThrowingTaskGroup { group in
             group.addTask {
-                let serviceGroup = ServiceGroup(services: [processor], logger: Logger(label: #function))
+                let serviceGroup = ServiceGroup(services: [exporter, processor], logger: Logger(label: #function))
                 try await serviceGroup.run()
                 XCTFail("Expected service group task throw")
             }

--- a/Tests/OTelTests/OTelCoreTests/Tracing/Processing/Batch/OTelBatchSpanProcessorTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Tracing/Processing/Batch/OTelBatchSpanProcessorTests.swift
@@ -231,7 +231,11 @@ final class OTelBatchSpanProcessorTests: XCTestCase {
 
         let serviceGroup = ServiceGroup(services: [processor], logger: Logger(label: #function))
         Task {
-            try await serviceGroup.run()
+            do {
+                try await serviceGroup.run()
+            } catch {
+                finishExpectation.fulfill()
+            }
             finishExpectation.fulfill()
         }
 


### PR DESCRIPTION
## Motivation

Some of the backends have a set of nested types, that each have a run method. An example is the tracer, which holds a processor, which holds an exporter. Currently, we rely on the outer type to run the inner type's run method as part of the outer type's run method. However, this has some sharp edges.

Consider the following pattern:

```swift
func run() async throws {
    withThrowingTaskGroup { group in
        group.add { try await self.inner.run() }
        for try await _ in timer {
            // outer work
            // ...
        }
        // outer work done, shut down
        // ...
        try await group.waitForAll()
    }
}
```

If the inner run method finishes early, either by throwing or by exiting cleanly, then nothing will notice this. The outer type will just carry on, as normal.

We _could_ fix this by a judicial use of `try await group.next()`. This will cancel the remaining child tasks and throw the error if the child task throws, but if it exits cleanly then you'll need some other construction, something like this:

```swift
func run() async throws {
    withThrowingTaskGroup { group in
        group.add { try await self.inner.run() }
        for try await _ in timer {
            // outer work
        }
        // outer work done, shut down
        do {
            try await group.next()
            // shutdown logic
        } catch {
            // shutdown logic
        }
    }
}
```

At this point, we're reinventing the wheel and probably still have some corner cases that aren't covered well.

This is the whole purpose of `ServiceGroup`—to keep track of a set of related tasks and coordinate their lifetimes.

Since the types in each backend share a fate, we can use a nested group to represent that service. We can also leverage the graceful shutdown termination behaviour if one of them fails which is nice. For example, if the exporter fails, there's no hope for any additional telemetry being exported on graceful shutdown, but, if the processor failed instead, then allowing the exporter to flush might give a little more useful observability for services.

Leaning into this pattern allows for each type to pretty much eliminate its inner task group and devote its run method only to its own work, which makes it much easier to understand.

## Modifications

- Add tests for BLRP shutdown when exporter exits or throws
- Add tests for PEMR shutdown when exporter exits or throws
- Add tests for BSP shutdown when exporter exits or throws
- Use nested service group to manage lifecycle of logging backend services
- Use nested service group to manage lifecycle of metrics backend services
- Use nested service group to manage lifecycle of tracing backend services

## Result

Much more structured shutdown behaviour of nested types.