### PR TITLE
Emit info diagnostic to console when bootstrapping logs

### DIFF
--- a/Sources/OTel/OTelAPI/OTel+Bootstrap.swift
+++ b/Sources/OTel/OTelAPI/OTel+Bootstrap.swift
@@ -124,32 +124,57 @@ extension OTel {
         var services: [Service] = []
 
         if configuration.logs.enabled {
-            try services.append(bootstrapLogs(configuration: configuration))
+            try services.append(bootstrapLogs(configuration: configuration, logger: logger))
         }
         if configuration.metrics.enabled {
-            try services.append(bootstrapMetrics(configuration: configuration))
+            try services.append(bootstrapMetrics(configuration: configuration, logger: logger))
         }
         if configuration.traces.enabled {
-            try services.append(bootstrapTraces(configuration: configuration))
+            try services.append(bootstrapTraces(configuration: configuration, logger: logger))
         }
 
         return ServiceGroup(services: services, logger: logger)
     }
 
-    internal static func bootstrapTraces(configuration: OTel.Configuration) throws -> some Service {
+    internal static func bootstrapTraces(configuration: OTel.Configuration, logger: Logger) throws -> some Service {
         let backend = try makeTracingBackend(configuration: configuration)
         InstrumentationSystem.bootstrap(backend.factory)
         return backend.service
     }
 
-    internal static func bootstrapMetrics(configuration: OTel.Configuration) throws -> some Service {
+    internal static func bootstrapMetrics(configuration: OTel.Configuration, logger: Logger) throws -> some Service {
         let backend = try makeMetricsBackend(configuration: configuration)
         MetricsSystem.bootstrap(backend.factory)
         return backend.service
     }
 
-    internal static func bootstrapLogs(configuration: OTel.Configuration) throws -> some Service {
+    internal static func bootstrapLogs(configuration: OTel.Configuration, logger: Logger) throws -> some Service {
         let backend = try makeLoggingBackend(configuration: configuration)
+        if configuration.logs.exporter.backing != .console {
+            logger.info(
+                """
+
+                Bootstapping logging system
+                ---
+                Only diagnostic logging will use the console logger.
+
+                If you require console logging for local development, use the
+                console logs exporter, which can be enabled using the
+                following configuration:
+
+                    config.logs.exporter = .console
+
+                Or, run your process with the following environment variable:
+
+                    OTEL_LOGS_EXPORTER=console
+
+                If you require logs to go to both the console and another
+                exporter, manually bootstrap the logging subsystem with a
+                multiplex log hander and the result of `makeLoggingBackend`.
+                ---
+                """
+            )
+        }
         LoggingSystem.bootstrap(backend.factory)
         return backend.service
     }

--- a/Sources/OTel/OTelAPI/OTel+Bootstrap.swift
+++ b/Sources/OTel/OTelAPI/OTel+Bootstrap.swift
@@ -150,13 +150,19 @@ extension OTel {
 
     internal static func bootstrapLogs(configuration: OTel.Configuration, logger: Logger) throws -> some Service {
         let backend = try makeLoggingBackend(configuration: configuration)
+        let exporterName = switch (configuration.logs.exporter.backing, configuration.logs.otlpExporter.protocol.backing) {
+        case (.console, _): "console"
+        case (.none, _): "none"
+        case (.otlp, .httpProtobuf): "OTLP/HTTP+Protobuf"
+        case (.otlp, .httpJSON): "OTLP/HTTP+json"
+        case (.otlp, .grpc): "OTLP/gRPC"
+        }
         if configuration.logs.exporter.backing != .console {
             logger.info(
                 """
-
-                Bootstapping logging system
+                Bootstrapping logging system with \(exporterName) exporter.
                 ---
-                Only diagnostic logging will use the console logger.
+                Only Swift OTel diagnostic logging will use the console logger.
 
                 If you require console logging for local development, use the
                 console logs exporter, which can be enabled using the
@@ -170,7 +176,8 @@ extension OTel {
 
                 If you require logs to go to both the console and another
                 exporter, manually bootstrap the logging subsystem with a
-                multiplex log hander and the result of `makeLoggingBackend`.
+                multiplex log handler. See the documentation of
+                `makeLoggingBackend` for details.
                 ---
                 """
             )

--- a/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
+++ b/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
@@ -656,6 +656,22 @@ import Tracing
         }
     }
 
+    @Test func testBootstrapLogsHandoffMessage() async throws {
+        let result = try await #require(processExitsWith: .success, observing: [\.standardErrorContent], "Running in a separate process because test uses bootstrap") {
+            var config = OTel.Configuration.default
+            config.metrics.enabled = false
+            config.traces.enabled = false
+            Logger(label: "test").info("before bootstrap")
+            _ = try OTel.bootstrap(configuration: config)
+            Logger(label: "test").info("after bootstrap")
+        }
+        let lines = try #require(String(bytes: result.standardErrorContent, encoding: .utf8)).split(separator: "\n")
+        print(lines.joined(separator: "\n"))
+        #expect(lines.contains { $0.contains("before bootstrap") })
+        #expect(lines.contains { $0.contains("Only diagnostic logging will use the console") })
+        #expect(!lines.contains { $0.contains("after bootstrap") })
+    }
+
     @Test func testLogsIncludeSpanContext() async throws {
         let result = try await #require(processExitsWith: .success, observing: [\.standardErrorContent], "Running in a separate process because test uses bootstrap") {
             var bootstrapConfig = OTel.Configuration.default

--- a/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
+++ b/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
@@ -665,10 +665,10 @@ import Tracing
             _ = try OTel.bootstrap(configuration: config)
             Logger(label: "test").info("after bootstrap")
         }
-        let lines = try #require(String(bytes: result.standardErrorContent, encoding: .utf8)).split(separator: "\n")
+        let lines = try #require(String(bytes: result.standardErrorContent, encoding: .utf8)).split(separator: "\n", omittingEmptySubsequences: false)
         print(lines.joined(separator: "\n"))
         #expect(lines.contains { $0.contains("before bootstrap") })
-        #expect(lines.contains { $0.contains("Only diagnostic logging will use the console") })
+        #expect(lines.contains { $0.contains("Only Swift OTel diagnostic logging will use the console") })
         #expect(!lines.contains { $0.contains("after bootstrap") })
     }
 


### PR DESCRIPTION
## Motivation

If an adopter is using Swift OTel with the OTLP logging backend then their local development experience changes significantly because all logging that uses the bootstrapped backend—from their own application and all the libraries they depend on—will no longer be printed to the console, but be exported to the OTLP endpoint. It's likely that users will not want to set up a local OTLP endpoint just to see their logs during development either.

We now have the console log exporter, added in #292, which is exactly for this purpose. However, we want to make sure that adopters get a great out-of-the box experience when they try out the package, so we should signpost this when we bootstrap the logging system with an OTLP backend.

## Modifications 

- Emit info diagnostic to console when bootstrapping logs

## Result

When users call `bootstrap`, a prominent message will be emitted to the console explaining how to enable console logging for local development.

