### PR TITLE
Publicly expose service context's trace ID

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,14 +31,17 @@ let package = Package(
         .package(url: "https://github.com/swift-otel/swift-w3c-trace-context.git", exact: "1.0.0-beta.3"),
 
         // MARK: - OTLPCore
+
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.30.0"),
 
         // MARK: - OTLPGRPC
+
         .package(url: "https://github.com/grpc/grpc-swift-2.git", from: "2.0.0"),
         .package(url: "https://github.com/grpc/grpc-swift-nio-transport.git", from: "2.0.0"),
         .package(url: "https://github.com/grpc/grpc-swift-protobuf.git", from: "2.0.0"),
 
         // MARK: - OTLPHTTP
+
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.25.0"),
 
         // MARK: - Plugins

--- a/Sources/OTel/OTelCore/Context/ServiceContext+OTelTraceID.swift
+++ b/Sources/OTel/OTelCore/Context/ServiceContext+OTelTraceID.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public import ServiceContextModule
+
+extension ServiceContext {
+    /// A hex string representation of this service context's trace ID.
+    public var otelTraceID: String? {
+        spanContext?.traceID.description
+    }
+}

--- a/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
+++ b/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
@@ -726,6 +726,20 @@ import Tracing
         }
     }
 
+    @Test func testTaskLocalServiceContextExposesCurrentTraceID() async {
+        await #expect(processExitsWith: .success, "Running in a separate process because test uses bootstrap") {
+            var bootstrapConfig = OTel.Configuration.default
+            bootstrapConfig.traces.exporter = .none
+            bootstrapConfig.diagnosticLogLevel = .trace
+            try InstrumentationSystem.bootstrap(OTel.makeTracingBackend(configuration: bootstrapConfig).factory)
+            #expect(ServiceContext.current?.otelTraceID == nil)
+            withSpan("span") { span in
+                #expect(ServiceContext.current?.otelTraceID != nil)
+                #expect(ServiceContext.current?.otelTraceID == span.context.otelTraceID)
+            }
+        }
+    }
+
     @Test func testMakeBackendThrowsWhenSignalIsDisabled() throws {
         do {
             let error = try #require(throws: (any Error).self) {

--- a/Tests/OTelTests/OTelCoreTests/Context/OTelSpanContextServiceContextTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Context/OTelSpanContextServiceContextTests.swift
@@ -13,19 +13,21 @@
 
 @testable import OTel
 import ServiceContextModule
-import XCTest
+import Testing
 
-final class OTelSpanContextServiceContextTests: XCTestCase {
-    func test_spanContext_storedInsideServiceContext() {
+@Suite
+struct OTelSpanContextServiceContextTests {
+    @Test
+    func spanContext_storedInsideServiceContext() {
         let spanContext = OTelSpanContext.localStub()
 
         var serviceContext = ServiceContext.topLevel
-        XCTAssertTrue(serviceContext.isEmpty)
-        XCTAssertNil(serviceContext.spanContext)
+        #expect(serviceContext.isEmpty)
+        #expect(serviceContext.spanContext == nil)
 
         serviceContext.spanContext = spanContext
-        XCTAssertEqual(serviceContext.count, 1)
+        #expect(serviceContext.count == 1)
 
-        XCTAssertEqual(serviceContext.spanContext, spanContext)
+        #expect(serviceContext.spanContext == spanContext)
     }
 }

--- a/Tests/OTelTests/OTelCoreTests/Context/ServiceContextPublicAPITests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Context/ServiceContextPublicAPITests.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import OTel // NOTE: Not @testable import, to test public API visibility.
+import ServiceContextModule
+import Testing
+import W3CTraceContext
+
+@Suite
+struct ServiceContextPublicAPITests {
+    @Test("Trace ID set to nil without span context")
+    func traceIDNil() throws {
+        let context = ServiceContext.topLevel
+
+        #expect(context.otelTraceID == nil)
+    }
+
+    @Test("Span context's trace ID exposed")
+    func traceIDNotNil() {
+        let context = ServiceContext.withTraceID(.oneToSixteen)
+
+        #expect(context.otelTraceID == "0102030405060708090a0b0c0d0e0f10")
+    }
+}

--- a/Tests/OTelTests/OTelTesting/ServiceContext+TraceIDStub.swift
+++ b/Tests/OTelTests/OTelTesting/ServiceContext+TraceIDStub.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import OTel
+import ServiceContextModule
+import W3CTraceContext
+
+extension ServiceContext {
+    /// A top-level service context with a span context containing the given trace ID.
+    ///
+    /// - Parameter value: The trace ID to store inside the service context's span context.
+    /// - Returns: A top-level service context with `traceID` stored in the span context.
+    static func withTraceID(_ traceID: TraceID) -> ServiceContext {
+        var context = ServiceContext.topLevel
+        context.spanContext = .localStub(traceID: traceID)
+        return context
+    }
+}


### PR DESCRIPTION
## Motivation

Users may want to access the task local `ServiceContext`'s trace ID to, for example, include it in response headers as part of a middleware. This is not currently possible using `1.0.0-alpha.1` because the entire span context stored inside `ServiceContext` is internal.

## Modifications

We explored various ways of exposing the trace ID in #293 and came to an agreement that we want to expose as little as possible and ensure that our dependency on [swift-otel/swift-w3c-trace-context](https://github.com/swift-otel/swift-w3c-trace-context) remains an implementation detail. Therefore, we only expose the trace ID's String representation.

## Result

Users can now obtain a String representation of a given `ServideContext`'s trace ID.

Closes #293