### PR TITLE
Use consistent withTimeout logic across processors

### DIFF
--- a/Sources/OTel/OTelCore/Helpers/Timeout.swift
+++ b/Sources/OTel/OTelCore/Helpers/Timeout.swift
@@ -11,28 +11,85 @@
 //
 //===----------------------------------------------------------------------===//
 
-func withTimeout<ClockType: Clock, ChildTaskResult>(
-    _ timeout: ClockType.Duration,
-    priority: TaskPriority? = nil,
-    clock: ClockType,
-    operation: @escaping @Sendable () async throws -> ChildTaskResult
-) async rethrows -> ChildTaskResult where ChildTaskResult: Sendable {
-    try await withThrowingTaskGroup(of: ChildTaskResult.self) { group in
-        group.addTask(priority: priority) {
-            try await clock.sleep(for: timeout)
-            throw CancellationError()
-        }
-        group.addTask(priority: priority, operation: operation)
-        let result = try await group.next()!
-        group.cancelAll()
-        return result
-    }
+struct TimeoutError: Error {
+    var underlyingError: any Error
 }
 
-func withTimeout<ChildTaskResult>(
+func withTimeout<T: Sendable>(
     _ timeout: Duration,
-    priority: TaskPriority? = nil,
-    operation: @escaping @Sendable () async throws -> ChildTaskResult
-) async rethrows -> ChildTaskResult where ChildTaskResult: Sendable {
-    try await withTimeout(timeout, priority: priority, clock: ContinuousClock(), operation: operation)
+    isolation: isolated(any Actor)? = #isolation,
+    operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try await withTimeout(timeout, clock: ContinuousClock(), operation: operation)
+}
+
+func withTimeout<T: Sendable, Clock: _Concurrency.Clock>(
+    _ timeout: Clock.Duration,
+    clock: Clock,
+    isolation: isolated(any Actor)? = #isolation,
+    operation: @escaping () async throws -> T
+) async throws -> T {
+    nonisolated(unsafe) let operation = { operation }
+    let result: Result<T, any Error> = await withTaskGroup(of: TaskResult<T>.self) { group in
+        let operation = operation()
+        group.addTask {
+            do {
+                try await clock.sleep(for: timeout, tolerance: .zero)
+                return .timedOut
+            } catch {
+                return .cancelled
+            }
+        }
+        group.addTask {
+            do {
+                return try await .success(operation())
+            } catch {
+                return .error(error)
+            }
+        }
+
+        switch await group.next() {
+        case .success(let result):
+            // Work returned a result. Cancel the timer task and return
+            group.cancelAll()
+            return .success(result)
+        case .error(let error):
+            // Work threw. Cancel the timer task and rethrow
+            group.cancelAll()
+            return .failure(error)
+        case .timedOut:
+            // Timed out, cancel the work task.
+            group.cancelAll()
+
+            switch await group.next() {
+            case .success(let result):
+                return .success(result)
+            case .error(let error):
+                return .failure(TimeoutError(underlyingError: error))
+            case .timedOut, .cancelled, .none:
+                // We already got a result from the sleeping task so we can't get another one or none.
+                preconditionFailure("Unexpected task result")
+            }
+        case .cancelled:
+            switch await group.next() {
+            case .success(let result):
+                return .success(result)
+            case .error(let error):
+                return .failure(TimeoutError(underlyingError: error))
+            case .timedOut, .cancelled, .none:
+                // We already got a result from the sleeping task so we can't get another one or none.
+                preconditionFailure("Unexpected task result")
+            }
+        case .none:
+            preconditionFailure("Unexpected task result")
+        }
+    }
+    return try result.get()
+}
+
+private enum TaskResult<T: Sendable>: Sendable {
+    case success(T)
+    case error(any Error)
+    case timedOut
+    case cancelled
 }

--- a/Sources/OTel/OTelCore/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReader.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReader.swift
@@ -57,7 +57,7 @@ struct OTelPeriodicExportingMetricsReader<Clock: _Concurrency.Clock> where Clock
             try await withTimeout(configuration.exportTimeout, clock: clock) {
                 try await exporter.export(batch)
             }
-        } catch is CancellationError {
+        } catch is TimeoutError {
             logger.warning("Timed out exporting metrics.", metadata: ["timeout": "\(configuration.exportTimeout)"])
         } catch {
             logger.error("Failed to export metrics.", metadata: ["error": "\(error)"])

--- a/Sources/OTel/OTelCore/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
+++ b/Sources/OTel/OTelCore/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
@@ -125,7 +125,7 @@ actor OTelBatchSpanProcessor<Exporter: OTelSpanExporter, Clock: _Concurrency.Clo
         do {
             try await exporter.export(batch)
             exportLogger.trace("Exported batch.")
-        } catch is CancellationError {
+        } catch is TimeoutError {
             exportLogger.debug("Export timed out.")
         } catch {
             exportLogger.debug("Failed to export batch.", metadata: [

--- a/Sources/OTel/OTelCore/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
+++ b/Sources/OTel/OTelCore/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
@@ -69,66 +69,51 @@ actor OTelBatchSpanProcessor<Exporter: OTelSpanExporter, Clock: _Concurrency.Clo
     }
 
     func forceFlush() async throws {
-        let chunkSize = Int(configuration.maximumExportBatchSize)
-        let batches = stride(from: 0, to: buffer.count, by: chunkSize).map {
-            buffer[$0 ..< min($0 + Int(configuration.maximumExportBatchSize), buffer.count)]
+        guard !buffer.isEmpty else {
+            logger.debug("Skipping force flush: buffer is empty")
+            return
         }
-
-        if !buffer.isEmpty {
-            logger.debug("Force flushing spans.", metadata: ["buffer_size": "\(buffer.count)"])
-
-            buffer.removeAll()
-
-            await withThrowingTaskGroup(of: Void.self) { group in
-                for batch in batches {
+        logger.info("Force flushing.", metadata: ["buffer_size": "\(buffer.count)"])
+        try await withTimeout(configuration.exportTimeout, clock: clock) {
+            await withTaskGroup { group in
+                var buffer = self.buffer
+                while !buffer.isEmpty {
+                    let batch = buffer.prefix(Int(self.configuration.maximumExportBatchSize))
+                    buffer.removeFirst(batch.count)
                     group.addTask { await self.export(batch) }
                 }
-
-                group.addTask {
-                    try await Task.sleep(for: self.configuration.exportTimeout, clock: self.clock)
-                    self.logger.debug("Force flush timed out.")
-                    throw CancellationError()
+                await group.waitForAll()
+                do {
+                    try await self.exporter.forceFlush()
+                } catch {
+                    self.logger.error("Force flush failed", metadata: ["error": "\(error)"])
                 }
-
-                try? await group.next()
-                group.cancelAll()
             }
         }
-
-        try await exporter.forceFlush()
     }
 
     private func tick() async {
         let batch = buffer.prefix(Int(configuration.maximumExportBatchSize))
         buffer.removeFirst(batch.count)
-
-        await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask { await self.export(batch) }
-            group.addTask {
-                try await Task.sleep(for: self.configuration.exportTimeout, clock: self.clock)
-                throw CancellationError()
-            }
-
-            try? await group.next()
-            group.cancelAll()
-        }
+        await export(batch)
     }
 
     private func export(_ batch: some Collection<OTelFinishedSpan> & Sendable) async {
         let batchID = batchID
         self.batchID += 1
 
-        var exportLogger = logger
-        exportLogger[metadataKey: "batch_id"] = "\(batchID)"
-        exportLogger.trace("Export batch.", metadata: ["batch_size": "\(batch.count)"])
+        var logger = logger
+        logger[metadataKey: "batch_id"] = "\(batchID)"
+        logger[metadataKey: "batch_size"] = "\(batch.count)"
+        logger.trace("Export batch.", metadata: ["batch_size": "\(batch.count)"])
 
         do {
-            try await exporter.export(batch)
-            exportLogger.trace("Exported batch.")
-        } catch is TimeoutError {
-            exportLogger.debug("Export timed out.")
+            try await withTimeout(configuration.exportTimeout, clock: clock) {
+                try await self.exporter.export(batch)
+                logger.trace("Exported batch.")
+            }
         } catch {
-            exportLogger.debug("Failed to export batch.", metadata: [
+            logger.warning("Failed to export batch.", metadata: [
                 "error": "\(String(describing: type(of: error)))",
                 "error_description": "\(error)",
             ])


### PR DESCRIPTION
## Motivation

We have a `withTimeout` helper which was useful, but needed some improvements: it conflated task cancellation with timeout. Additionally, this was not being consistently used across the project, with the processors having their own task group for the timeouts. This led to much more complicated run methods than necessary. Finally, the BatchSpanProcessor and the BatchLogRecordProcessor have essentially the same semantics, but their internal workings were very different.

## Modifications

- Update withTimeout helper to cover corner cases
- Adopt withTimeout in BatchLogRecordProcessor
- Wait for buffer in to fill in BatchLogRecordProcessorTests
- Adopt withTimer in BatchSpanProcessor
- Align BatchLogRecordProcessor with BatchSpanProcessor

## Result

- Better tests
- Simpler processor logic
- Consisten processor logic