### PR TITLE
Use FoundationEssentials on platforms where it is available

### DIFF
--- a/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/common/v1/common.pb.swift
+++ b/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/common/v1/common.pb.swift
@@ -25,7 +25,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationEssentials)
+package import FoundationEssentials
+#else
 package import Foundation
+#endif
 package import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file

--- a/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/logs/v1/logs.pb.swift
+++ b/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/logs/v1/logs.pb.swift
@@ -25,7 +25,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationEssentials)
+package import FoundationEssentials
+#else
 package import Foundation
+#endif
 package import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file

--- a/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/metrics/v1/metrics.pb.swift
+++ b/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/metrics/v1/metrics.pb.swift
@@ -25,7 +25,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationEssentials)
+package import FoundationEssentials
+#else
 package import Foundation
+#endif
 package import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file

--- a/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/trace/v1/trace.pb.swift
+++ b/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/trace/v1/trace.pb.swift
@@ -25,7 +25,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if canImport(FoundationEssentials)
+package import FoundationEssentials
+#else
 package import Foundation
+#endif
 package import SwiftProtobuf
 
 // If the compiler emits an error on this type, it is because this file

--- a/Sources/OTel/OTelCore/Configuration/OTelEnvironment.swift
+++ b/Sources/OTel/OTelCore/Configuration/OTelEnvironment.swift
@@ -19,7 +19,11 @@ import Musl
 import Darwin.C
 #endif
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// A wrapper for reading environment values.
 struct OTelEnvironment: Sendable {

--- a/Tests/OTelTests/OTelCoreTests/Resource/OTelProcessResourceDetectorTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Resource/OTelProcessResourceDetectorTests.swift
@@ -11,7 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Logging
 @testable import OTel
 import XCTest

--- a/Tests/OTelTests/OTelTesting/OTelLogRecord+Stub.swift
+++ b/Tests/OTelTests/OTelTesting/OTelLogRecord+Stub.swift
@@ -11,7 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Logging
 @testable import OTel
 


### PR DESCRIPTION
## Motivation

On platforms that have FoundationEssentials, we can avoid linking full Foundation, which can result in a much smaller binary.

## Modifications
- Update Makefile to patch Foundation import in generated code
- Rerun code generation with patched Foundation import
- Update Foundation imports in hand-written code

## Result

On platforms with FoundationEssentials, we link that, instead of Foundation.