### PR TITLE
Add CI for API breakage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,3 +143,17 @@ jobs:
             exit 1
           fi
           echo "All example matrix jobs succeeded."
+
+  api-breakage:
+    name: API breakage check
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Mark the workspace as safe
+      run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+    - name: API breaking changes
+      run: |
+        swift package diagnose-api-breaking-changes origin/${GITHUB_BASE_REF}


### PR DESCRIPTION
## Motivation

Now that we have a stable API it would be good to check that we don't accidentally break it.

## Modifications

Add CI for API breakage

## Result

Another CI pipeline that checks for accidental API breakage.