### PR TITLE
Add a Grafana LGTM example

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -37,5 +37,8 @@ logs, metrics, and traces to file, Prometheus, and Jaeger, respectively, via an 
 
 ## Integrations
 
+- [hello-world-grafana-lgtm](./hello-world-grafana-lgtm) - HTTP server with instrumentation middleware,
+  exporting telemetry over OTLP/gRPC, sending all three signals to a local deployment of Grafana LGTM.
+
 - TODO: Vapor example
 - TODO: Grafana example

--- a/Examples/hello-world-grafana-lgtm/.gitignore
+++ b/Examples/hello-world-grafana-lgtm/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+docker/logs/

--- a/Examples/hello-world-grafana-lgtm/Package.swift
+++ b/Examples/hello-world-grafana-lgtm/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "hello-world-grafana-lgtm",
+    platforms: [.macOS(.v15)],
+    dependencies: [
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
+        // TODO: update this to `from: 1.0.0` when we release 1.0.
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.1", traits: ["OTLPGRPC"]),
+    ],
+    targets: [
+        .executableTarget(
+            name: "HelloWorldHummingbirdServer",
+            dependencies: [
+                .product(name: "Hummingbird", package: "hummingbird"),
+                .product(name: "OTel", package: "swift-otel"),
+            ]
+        ),
+    ]
+)

--- a/Examples/hello-world-grafana-lgtm/README.md
+++ b/Examples/hello-world-grafana-lgtm/README.md
@@ -1,0 +1,138 @@
+# Hello World HTTP server with a local Grafana LGTM deployment
+
+An HTTP server that uses middleware to emit telemetry for each HTTP request.
+
+Local collector is the [Grafana LGTM](https://github.com/grafana/docker-otel-lgtm) package, containing support for logs, metrics, and distributed tracing in a single container.
+
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
+## Overview
+
+This example bootstraps the logging, metrics, and tracing Swift subsystems to export
+logs, metrics, and traces to a local Grafana instance.
+
+It then starts a Hummingbird HTTP server along with its associated middleware for instrumentation.
+
+Telemetry data is exported using OTLP/gRPC.
+
+## Package traits
+
+This example package depends on Swift OTel with only the `OTLPGRPC` trait enabled.
+
+This is not strictly necessary because the default traits include both `OTLPHTTP` and `OTLPGRPC`, but it will reduce
+ the dependency graph with a new enough Swift toolchain.
+
+To use the OTLP/HTTP exporter, enable the `OTLPHTTP` trait or remove the `traits:` parameter on the package dependency.
+
+## Notable Configuration
+
+```swift
+// Configure the exporters to use OTLP/gRPC.
+config.logs.otlpExporter.protocol = .grpc
+config.metrics.otlpExporter.protocol = .grpc
+config.traces.otlpExporter.protocol = .grpc
+```
+
+## Testing
+
+The example uses [Docker Compose](https://docs.docker.com/compose) to run a single container to collect and
+visualize the telemetry from the server, which is running on your local machine.
+
+```none
+┌─────────────────────────────────────────────────────────────────────────────────────────────┐
+│                                                                                       Host  │
+│                              ┌──────────────────────────────────────────────────────────┐   │
+│                              │                                          Docker Compose  │   │
+│                              │   ┌──────────────────────────────────────────────────┐   │   │
+│                              │   │                                    Grafana LGTM  │   │   │
+│                              │   │                                                  │   │   │
+│                              │   │  ┌─────────────┐                                 │   │   │
+│                              │   │  │             │                                 │   │   │
+│                              │   │  │             │   Logs        ┌─────────────┐   │   │   │
+│ ┌────────────┐               │   │  │             ├──────────────▶│    Loki     │   │   │   │
+│ │            │               │   │  │             │               └─────────────┘   │   │   │
+│ │            │               │   │  │             │   Metrics     ┌─────────────┐   │   │   │
+│ │    HTTP    │               │   │  │    OTel     ├──────────────▶│  Prometheus │   │   │   │
+│ │   Server   │───────────────┼───┼─▶│  Collector  │               └─────────────┘   │   │   │
+│ │            │               │   │  │             │   Traces      ┌─────────────┐   │   │   │
+│ │            │               │   │  │             ├──────────────▶│    Tempo    │   │   │   │
+│ └────────────┘               │   │  │             │               └─────────────┘   │   │   │
+│        ▲                     │   │  │             │                                 │   │   │
+│        │                     │   │  │             │                                 │   │   │
+│        │                     │   │  └─────────────┘                                 │   │   │
+│        │        ┌──────┐     │   └──────────────────────────────────────────────────┘   │   │
+│        └────────│ curl │     │                                                          │   │
+│    GET /hello   └──────┘     └──────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+The server sends requests to Grafana LGTM, which internally runs OTel Collector, which in turn is configured with an OTLP receiver for logs, metrics, and traces; and exporters for Loki, Prometheus, and Tempo for logs, metrics, and traces, respectively.
+
+### Running the collector and visualization containers
+
+In one terminal window, run the following command:
+
+```console
+% docker compose -f docker/docker-compose.yaml up
+[+] Running 1/1
+ ✔ Container docker-grafana-1          Created                       0.5s
+...
+docker-grafana-1  | Running Grafana v12.0.2 logging=false
+docker-grafana-1  | Running OpenTelemetry Collector v0.130.0 logging=false
+docker-grafana-1  | Running Prometheus v3.5.0 logging=false
+docker-grafana-1  | Waiting for the OpenTelemetry collector and the Grafana LGTM stack to start up...
+docker-grafana-1  | Running Tempo v2.8.1 logging=false
+docker-grafana-1  | Running Loki v3.5.2 logging=false
+docker-grafana-1  | Running Pyroscope v1.14.0 logging=false
+docker-grafana-1  | Prometheus is up and running. Startup time: 2 seconds
+docker-grafana-1  | Otelcol is up and running. Startup time: 2 seconds
+docker-grafana-1  | Pyroscope is up and running. Startup time: 3 seconds
+docker-grafana-1  | Loki is up and running. Startup time: 3 seconds
+docker-grafana-1  | Tempo is up and running. Startup time: 3 seconds
+docker-grafana-1  | Grafana is up and running. Startup time: 7 seconds
+docker-grafana-1  | Total startup time: 7 seconds
+docker-grafana-1  | 
+docker-grafana-1  | Startup Time Summary:
+docker-grafana-1  | ---------------------
+docker-grafana-1  | Grafana: 7 seconds
+docker-grafana-1  | Loki: 3 seconds
+docker-grafana-1  | Prometheus: 2 seconds
+docker-grafana-1  | Tempo: 3 seconds
+docker-grafana-1  | Pyroscope: 3 seconds
+docker-grafana-1  | OpenTelemetry collector: 2 seconds
+docker-grafana-1  | Total: 7 seconds
+docker-grafana-1  | The OpenTelemetry collector and the Grafana LGTM stack are up and running. (created /tmp/ready)
+docker-grafana-1  | Open ports:
+docker-grafana-1  |  - 4317: OpenTelemetry GRPC endpoint
+docker-grafana-1  |  - 4318: OpenTelemetry HTTP endpoint
+docker-grafana-1  |  - 3000: Grafana. User: admin, password: admin
+```
+
+At this point the tracing collector and visualization tools are running.
+
+### Running the server
+
+Now, in another terminal, run the server locally using the following command:
+
+```console
+% swift run
+```
+
+### Making some requests
+
+Finally, in a third terminal, make a few requests to the server:
+
+```console
+% for i in {1..5}; do curl localhost:8080/hello; done
+hello
+hello
+hello
+hello
+hello
+```
+
+### Viewing logs, metrics, and traces
+
+Open the local Grafana viewer at `http://localhost:3000` and in the left bar, click on Drilldown.
+
+There, under Logs, Metrics, and Traces, you can browse the telemetry coming from the local test server as you run local requests.

--- a/Examples/hello-world-grafana-lgtm/Sources/HelloWorldHummingbirdServer/HelloWorldHummingbirdServer.swift
+++ b/Examples/hello-world-grafana-lgtm/Sources/HelloWorldHummingbirdServer/HelloWorldHummingbirdServer.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Hummingbird
+import OTel
+
+@main
+enum HelloWorldHummingbirdServer {
+    static func main() async throws {
+        // Bootstrap observability backends (with short export intervals for demo purposes).
+        var config = OTel.Configuration.default
+        config.serviceName = "hello_world"
+        config.diagnosticLogLevel = .error
+        config.logs.batchLogRecordProcessor.scheduleDelay = .seconds(3)
+        config.metrics.exportInterval = .seconds(3)
+        config.traces.batchSpanProcessor.scheduleDelay = .seconds(3)
+        config.logs.otlpExporter.protocol = .grpc
+        config.metrics.otlpExporter.protocol = .grpc
+        config.traces.otlpExporter.protocol = .grpc
+        let observability = try OTel.bootstrap(configuration: config)
+
+        // Create an HTTP server with instrumentation middlewares added.
+        let router = Router()
+        router.middlewares.add(TracingMiddleware())
+        router.middlewares.add(MetricsMiddleware())
+        router.middlewares.add(LogRequestsMiddleware(.info))
+        router.get("hello") { _, _ in "hello" }
+        var app = Application(router: router)
+
+        // Add the observability service to the Hummingbird service group and run the server.
+        app.addServices(observability)
+        try await app.runService()
+    }
+}

--- a/Examples/hello-world-grafana-lgtm/docker/.gitignore
+++ b/Examples/hello-world-grafana-lgtm/docker/.gitignore
@@ -1,0 +1,1 @@
+container

--- a/Examples/hello-world-grafana-lgtm/docker/docker-compose.yaml
+++ b/Examples/hello-world-grafana-lgtm/docker/docker-compose.yaml
@@ -1,0 +1,16 @@
+version: "3.5"
+services:
+  grafana:
+    image: docker-upstream.apple.com/grafana/otel-lgtm:latest
+    environment:
+      - GF_PATHS_DATA=/data/grafana
+    volumes:
+      - ./container/grafana:/data/grafana
+      - ./container/prometheus:/data/prometheus
+      - ./container/loki:/data/loki
+    ports:
+      - "3000:3000"
+      - "4317:4317"
+      - "4318:4318"
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json


### PR DESCRIPTION
## Summary

Adds an example using Grafana LGTM.

Started as a duplicate of `hello-world-hummingbird-server-otlp-grpc`, so is mostly the same.

## Test Plan

Verified the steps manually locally, was able to see logs, metrics, and traces in the local Grafana instance.
