### PR TITLE
Do not trigger extra export when BatchLogRecordProcessor queue is full

### DIFF
--- a/Sources/OTel/OTelCore/Logging/Processing/Batch/OTelBatchLogRecordProcessor.swift
+++ b/Sources/OTel/OTelCore/Logging/Processing/Batch/OTelBatchLogRecordProcessor.swift
@@ -56,10 +56,8 @@ actor OTelBatchLogRecordProcessor<Exporter: OTelLogRecordExporter, Clock: _Concu
 
     private func _onLog(_ log: OTelLogRecord) {
         buffer.append(log)
-
-        if buffer.count == configuration.maximumQueueSize {
-            explicitTick.yield()
-        }
+        // NOTE: Unlike the BatchSpanProcessor, the spec does _not_ say the BatchLogRecordProcessor should trigger an
+        // export when the queue size is reached.
     }
 
     func run() async throws {


### PR DESCRIPTION
## Motivation

The OTel spec says that the Batch Span Processor should trigger an additional export when it's queue reaches maximum capacity[^1]. However, the Batch Log Record Processor does _not_ state this[^2]. Our Batch Log Record Processor does do this—presumably because it was copied from the span processor.

## Modification

- Remove yield of explicit tick when consuming log stream if buffer is full.

## Result

Batch Log Record Processor no longer triggers an additional export when the queue size is reached.

[^1]: https://opentelemetry.io/docs/specs/otel/trace/sdk/#batching-processor
[^2]: https://opentelemetry.io/docs/specs/otel/logs/sdk/#batching-processor