### PR TITLE
Use defer to cleanly shutdown HTTPClient in HTTP retry tests

### DIFF
--- a/Tests/OTelTests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
+++ b/Tests/OTelTests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
@@ -385,7 +385,7 @@ import Tracing
 
     @Test func testHTTPClientWithRetryPolicyMaxAttempts() async throws {
         let testServer = NIOHTTP1TestServer(group: .singletonMultiThreadedEventLoopGroup)
-        defer { #expect(throws: Never.self) { try? testServer.stop() } }
+        defer { try? testServer.stop() }
 
         let clock = TestClock()
         let numRequestsReceivedByServer = NIOLockedValueBox(0)
@@ -447,7 +447,7 @@ import Tracing
 
     @Test func testHTTPClientWithRetryPolicyFirstRequestSucceeds() async throws {
         let testServer = NIOHTTP1TestServer(group: .singletonMultiThreadedEventLoopGroup)
-        defer { #expect(throws: Never.self) { try? testServer.stop() } }
+        defer { try? testServer.stop() }
 
         let clock = TestClock()
         let numRequestsReceivedByServer = NIOLockedValueBox(0)
@@ -498,7 +498,7 @@ import Tracing
 
     @Test func testHTTPClientWithRetryPolicyRetrySucceeds() async throws {
         let testServer = NIOHTTP1TestServer(group: .singletonMultiThreadedEventLoopGroup)
-        defer { #expect(throws: Never.self) { try? testServer.stop() } }
+        defer { try? testServer.stop() }
 
         let clock = TestClock()
         let numRequestsReceivedByServer = NIOLockedValueBox(0)

--- a/Tests/OTelTests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
+++ b/Tests/OTelTests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
@@ -392,37 +392,36 @@ import Tracing
 
         try await withThrowingTaskGroup { group in
             group.addTask { // client
-                try await HTTPClient.withHTTPClient { client in
-                    var request = HTTPClientRequest(url: "http://127.0.0.1:\(testServer.serverPort)/some/path")
-                    request.method = .POST
-                    request.body = .init(.bytes(.init(string: "hello")))
-                    let retryPolicy = HTTPClient.RetryPolicy(
-                        maxAttempts: 3,
-                        baseDelay: .seconds(1),
-                        maxDelay: .seconds(10),
-                        jitter: 0.0
-                    ) { response in
-                        switch response.status {
-                        case .tooManyRequests:
-                            if let retryAfter = response.headers["Retry-After"].last.flatMap(Int.init) {
-                                .retryWithSpecificBackoff(.seconds(retryAfter))
-                            } else {
-                                .retryWithBackoff
-                            }
-                        default: .doNotRetry
+                let client = HTTPClient(eventLoopGroup: .singletonMultiThreadedEventLoopGroup)
+                defer { #expect(throws: Never.self) { try client.syncShutdown() }}
+                var request = HTTPClientRequest(url: "http://127.0.0.1:\(testServer.serverPort)/some/path")
+                request.method = .POST
+                request.body = .init(.bytes(.init(string: "hello")))
+                let retryPolicy = HTTPClient.RetryPolicy(
+                    maxAttempts: 3,
+                    baseDelay: .seconds(1),
+                    maxDelay: .seconds(10),
+                    jitter: 0.0
+                ) { response in
+                    switch response.status {
+                    case .tooManyRequests:
+                        if let retryAfter = response.headers["Retry-After"].last.flatMap(Int.init) {
+                            .retryWithSpecificBackoff(.seconds(retryAfter))
+                        } else {
+                            .retryWithBackoff
                         }
+                    default: .doNotRetry
                     }
-                    let response = try await client.execute(
-                        request,
-                        timeout: .seconds(60),
-                        logger: ._otelDebug,
-                        clock: clock,
-                        retryPolicy: retryPolicy
-                    )
-                    #expect(response.status == .tooManyRequests)
-                    #expect(numRequestsReceivedByServer.withLockedValue { $0 } == 3)
                 }
-                print("client task done")
+                let response = try await client.execute(
+                    request,
+                    timeout: .seconds(60),
+                    logger: ._otelDebug,
+                    clock: clock,
+                    retryPolicy: retryPolicy
+                )
+                #expect(response.status == .tooManyRequests)
+                #expect(numRequestsReceivedByServer.withLockedValue { $0 } == 3)
             }
             group.addTask { // server
                 var sleepCalls = clock.sleepCalls.makeAsyncIterator()
@@ -454,30 +453,30 @@ import Tracing
 
         try await withThrowingTaskGroup { group in
             group.addTask { // client
-                try await HTTPClient.withHTTPClient { client in
-                    var request = HTTPClientRequest(url: "http://127.0.0.1:\(testServer.serverPort)/some/path")
-                    request.method = .POST
-                    request.body = .init(.bytes(.init(string: "hello")))
-                    let retryPolicy = HTTPClient.RetryPolicy(
-                        maxAttempts: 3,
-                        baseDelay: .seconds(1),
-                        maxDelay: .seconds(10),
-                        jitter: 0.0
-                    ) { response in
-                        switch response.status {
-                        case .tooManyRequests:
-                            if let retryAfter = response.headers["Retry-After"].last.flatMap(Int.init) {
-                                .retryWithSpecificBackoff(.seconds(retryAfter))
-                            } else {
-                                .retryWithBackoff
-                            }
-                        default: .doNotRetry
+                let client = HTTPClient(eventLoopGroup: .singletonMultiThreadedEventLoopGroup)
+                defer { #expect(throws: Never.self) { try client.syncShutdown() }}
+                var request = HTTPClientRequest(url: "http://127.0.0.1:\(testServer.serverPort)/some/path")
+                request.method = .POST
+                request.body = .init(.bytes(.init(string: "hello")))
+                let retryPolicy = HTTPClient.RetryPolicy(
+                    maxAttempts: 3,
+                    baseDelay: .seconds(1),
+                    maxDelay: .seconds(10),
+                    jitter: 0.0
+                ) { response in
+                    switch response.status {
+                    case .tooManyRequests:
+                        if let retryAfter = response.headers["Retry-After"].last.flatMap(Int.init) {
+                            .retryWithSpecificBackoff(.seconds(retryAfter))
+                        } else {
+                            .retryWithBackoff
                         }
+                    default: .doNotRetry
                     }
-                    let response = try await client.execute(request, timeout: .seconds(60), clock: clock, retryPolicy: retryPolicy)
-                    #expect(response.status == .ok)
-                    #expect(numRequestsReceivedByServer.withLockedValue { $0 } == 1)
                 }
+                let response = try await client.execute(request, timeout: .seconds(60), clock: clock, retryPolicy: retryPolicy)
+                #expect(response.status == .ok)
+                #expect(numRequestsReceivedByServer.withLockedValue { $0 } == 1)
             }
             group.addTask { // server
                 // Return OK.
@@ -502,30 +501,30 @@ import Tracing
 
         try await withThrowingTaskGroup { group in
             group.addTask { // client
-                try await HTTPClient.withHTTPClient { client in
-                    var request = HTTPClientRequest(url: "http://127.0.0.1:\(testServer.serverPort)/some/path")
-                    request.method = .POST
-                    request.body = .init(.bytes(.init(string: "hello")))
-                    let retryPolicy = HTTPClient.RetryPolicy(
-                        maxAttempts: 3,
-                        baseDelay: .seconds(1),
-                        maxDelay: .seconds(10),
-                        jitter: 0.0
-                    ) { response in
-                        switch response.status {
-                        case .tooManyRequests:
-                            if let retryAfter = response.headers["Retry-After"].last.flatMap(Int.init) {
-                                .retryWithSpecificBackoff(.seconds(retryAfter))
-                            } else {
-                                .retryWithBackoff
-                            }
-                        default: .doNotRetry
+                let client = HTTPClient(eventLoopGroup: .singletonMultiThreadedEventLoopGroup)
+                defer { #expect(throws: Never.self) { try client.syncShutdown() }}
+                var request = HTTPClientRequest(url: "http://127.0.0.1:\(testServer.serverPort)/some/path")
+                request.method = .POST
+                request.body = .init(.bytes(.init(string: "hello")))
+                let retryPolicy = HTTPClient.RetryPolicy(
+                    maxAttempts: 3,
+                    baseDelay: .seconds(1),
+                    maxDelay: .seconds(10),
+                    jitter: 0.0
+                ) { response in
+                    switch response.status {
+                    case .tooManyRequests:
+                        if let retryAfter = response.headers["Retry-After"].last.flatMap(Int.init) {
+                            .retryWithSpecificBackoff(.seconds(retryAfter))
+                        } else {
+                            .retryWithBackoff
                         }
+                    default: .doNotRetry
                     }
-                    let response = try await client.execute(request, timeout: .seconds(60), clock: clock, retryPolicy: retryPolicy)
-                    #expect(response.status == .ok)
-                    #expect(numRequestsReceivedByServer.withLockedValue { $0 } == 2)
                 }
+                let response = try await client.execute(request, timeout: .seconds(60), clock: clock, retryPolicy: retryPolicy)
+                #expect(response.status == .ok)
+                #expect(numRequestsReceivedByServer.withLockedValue { $0 } == 2)
             }
             group.addTask { // server
                 var sleepCalls = clock.sleepCalls.makeAsyncIterator()

--- a/Tests/OTelTests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
+++ b/Tests/OTelTests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
@@ -385,7 +385,7 @@ import Tracing
 
     @Test func testHTTPClientWithRetryPolicyMaxAttempts() async throws {
         let testServer = NIOHTTP1TestServer(group: .singletonMultiThreadedEventLoopGroup)
-        defer { #expect(throws: Never.self) { try testServer.stop() } }
+        defer { #expect(throws: Never.self) { try? testServer.stop() } }
 
         let clock = TestClock()
         let numRequestsReceivedByServer = NIOLockedValueBox(0)
@@ -447,7 +447,7 @@ import Tracing
 
     @Test func testHTTPClientWithRetryPolicyFirstRequestSucceeds() async throws {
         let testServer = NIOHTTP1TestServer(group: .singletonMultiThreadedEventLoopGroup)
-        defer { #expect(throws: Never.self) { try testServer.stop() } }
+        defer { #expect(throws: Never.self) { try? testServer.stop() } }
 
         let clock = TestClock()
         let numRequestsReceivedByServer = NIOLockedValueBox(0)
@@ -498,7 +498,7 @@ import Tracing
 
     @Test func testHTTPClientWithRetryPolicyRetrySucceeds() async throws {
         let testServer = NIOHTTP1TestServer(group: .singletonMultiThreadedEventLoopGroup)
-        defer { #expect(throws: Never.self) { try testServer.stop() } }
+        defer { #expect(throws: Never.self) { try? testServer.stop() } }
 
         let clock = TestClock()
         let numRequestsReceivedByServer = NIOLockedValueBox(0)


### PR DESCRIPTION
## Motivation

Once the retry test is done, we just want to tear down the mock server.

## Modifications

- Ignore errors shutting down the NIO test HTTP server

## Result

Less flaky test.