### PR TITLE
Add example package using Vapor

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -30,12 +30,8 @@ logs, metrics, and traces to file, Prometheus, and Jaeger, respectively, via an 
 - [hello-world-hummingbird-server-only-traces](./hello-world-hummingbird-server-only-traces) - HTTP server
   with instrumentation middleware, with metrics and logging backends disabled.
 
-## Pruning dependencies with traits
-
-- TODO: example building without the OTLPGRPC trait
-- TODO: example building without the OTLPHTTP trait
-
 ## Integrations
 
-- TODO: Vapor example
+- [hello-world-vapor-server-otlp-http-protobuf](./hello-world-vapor-server-otlp-http-protobuf) - HTTP server
+  with instrumentation middleware, exporting telemetry over OTLP/HTTP+Protobuf.
 - TODO: Grafana example

--- a/Examples/hello-world-vapor-server-otlp-http-protobuf/.gitignore
+++ b/Examples/hello-world-vapor-server-otlp-http-protobuf/.gitignore
@@ -1,0 +1,3 @@
+.build/
+.swiftpm/
+docker/logs/

--- a/Examples/hello-world-vapor-server-otlp-http-protobuf/Package.swift
+++ b/Examples/hello-world-vapor-server-otlp-http-protobuf/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "hello-world-vapor-server-otlp-http-protobuf",
+    platforms: [.macOS(.v13)],
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.115.0"),
+        // TODO: update this to `from: 1.0.0` when we release 1.0.
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.1", traits: ["OTLPHTTP"]),
+    ],
+    targets: [
+        .executableTarget(
+            name: "HelloWorldVaporServer",
+            dependencies: [
+                .product(name: "Vapor", package: "vapor"),
+                .product(name: "OTel", package: "swift-otel"),
+            ]
+        ),
+    ]
+)

--- a/Examples/hello-world-vapor-server-otlp-http-protobuf/README.md
+++ b/Examples/hello-world-vapor-server-otlp-http-protobuf/README.md
@@ -1,0 +1,126 @@
+# Hello World HTTP server with observability middleware (OTLP/HTTP+Protobuf)
+
+An HTTP server that uses middleware to emit telemetry for each HTTP request.
+
+> **Disclaimer:** This example is deliberately simplified and is intended for illustrative purposes only.
+
+## Overview
+
+This example bootstraps the logging, metrics, and tracing Swift subsystems to export
+logs, metrics, and traces to file, Prometheus, and Jaeger, respectively, via an OTel Collector.
+
+It then starts a Vapor HTTP server along with its associated middleware for instrumentation.
+
+Telemetry data is exported using OTLP/HTTP+Protobuf (the default serialization).
+
+## Package traits
+
+This example package depends on Swift OTel with only the `OTLPHTTP` trait enabled.
+
+This is not strictly necessary because the default traits include both `OTLPHTTP` and `OTLPGRPC`, but it will reduce
+ the dependency graph with a new enough Swift toolchain.
+
+To use the OTLP/gRPC exporter, enable the `OTLPGRPC` trait or remove the `traits:` parameter on the package dependency.
+
+## Testing
+
+The example uses [Docker Compose](https://docs.docker.com/compose) to run a set of containers to collect and
+visualize the telemetry from the server, which is running on your local machine.
+
+```none
+┌──────────────────────────────────────────────────────────────────────┐
+│                                                                  Host│
+│                       ┌────────────────────────────────────────────┐ │
+│                       │                              Docker Compose│ │
+│                       │ ┌───────────┐                              │ │
+│                       │ │           │   Logs        ┌────────────┐ │ │
+│                       │ │           ├──────────────▶│    File    │ │ │
+│                       │ │           │               └────────────┘ │ │
+│                       │ │           │   Traces      ┌────────────┐ │ │
+│ ┌────────┐            │ │   OTel    ├──────────────▶│   Jaeger   │ │ │
+│ │        │            │ │ Collector │               └────────────┘ │ │
+│ │  HTTP  │            │ │           │   Metrics     ┌────────────┐ │ │
+│ │ Server │────────────┼▶│           │◀──────────────│ Prometheus │ │ │
+│ │        │            │ │           │               └────────────┘ │ │
+│ └────────┘            │ │           │   Debug       ┌────────────┐ │ │
+│      ▲      ┌──────┐  │ │           ├──────────────▶│   stderr   │ │ │
+│      └──────│ curl │  │ └───────────┘               └────────────┘ │ │
+│  GET /hello └──────┘  └────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+The server sends requests to OTel Collector, which is configured with an OTLP receiver for logs, metrics, and traces;
+and exporters for Jaeger, Prometheus and file for traces, metrics, and logs, respectively. The Collector is also
+configured with a debug exporter so we can see the events it receives in the container logs.
+
+### Running the collector and visualization containers
+
+In one terminal window, run the following command:
+
+```console
+% docker compose -f docker/docker-compose.yaml up
+[+] Running 3/3
+ ✔ Container docker-jaeger-1          Created                       0.5s
+ ✔ Container docker-prometheus-1      Created                       0.4s
+ ✔ Container docker-otel-collector-1  Created                       0.5s
+...
+```
+
+At this point the tracing collector and visualization tools are running.
+
+### Running the server
+
+Now, in another terminal, run the server locally using the following command:
+
+```console
+% swift run
+```
+
+### Making some requests
+
+Finally, in a third terminal, make a few requests to the server:
+
+```console
+% for i in {1..5}; do curl localhost:8080/hello; done
+hello
+hello
+hello
+hello
+hello
+```
+
+In the output from the OTel Collector, you should see debug messages for the received OTLP events.
+
+### Viewing the log records
+
+The file the OTel Collector is using to export log records is mounted from the host. In another terminal window, you can
+watch the logging output using the following command:
+
+```console
+% tail -f docker/logs/logs.json
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"hello_world"}}]},"scopeLogs":[{"scope":{"name":"swift-otel","version":"1.0.0"},"logRecords":[{"timeUnixNano":"1754915066736223000","observedTimeUnixNano":"1754915066736223000","severityNumber":10,"severityText":"notice","body":{"stringValue":"Server started on http://127.0.0.1:8080"},"attributes":[{"key":"code.function","value":{"stringValue":"start(address:)"}},{"key":"code.filepath","value":{"stringValue":"Vapor/HTTPServer.swift"}},{"key":"code.lineno","value":{"stringValue":"357"}}],"traceId":"","spanId":""}]}]}]}
+
+{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"hello_world"}}]},"scopeLogs":[{"scope":{"name":"swift-otel","version":"1.0.0"},"logRecords":[{"timeUnixNano":"1754915087422729000","observedTimeUnixNano":"1754915087422729000","severityNumber":9,"severityText":"info","body":{"stringValue":"GET /hello"},"attributes":[{"key":"code.filepath","value":{"stringValue":"Vapor/RouteLoggingMiddleware.swift"}},{"key":"request-id","value":{"stringValue":"D526B4A1-82DE-4718-A1FA-2F415A0A0D02"}},{"key":"code.function","value":{"stringValue":"respond(to:chainingTo:)"}},{"key":"code.lineno","value":{"stringValue":"14"}}],"traceId":"","spanId":""},{"timeUnixNano":"1754915087423257000","observedTimeUnixNano":"1754915087423257000","severityNumber":9,"severityText":"info","body":{"stringValue":"GET /hello"},"attributes":[{"key":"code.lineno","value":{"stringValue":"14"}},{"key":"request-id","value":{"stringValue":"D526B4A1-82DE-4718-A1FA-2F415A0A0D02"}},{"key":"code.function","value":{"stringValue":"respond(to:chainingTo:)"}},{"key":"code.filepath","value":{"stringValue":"Vapor/RouteLoggingMiddleware.swift"}}],"traceId":"580497379a32db1685b54408d7372d22","spanId":"1c93217eb59b1ec3"}]}]}]}
+...
+```
+
+### Visualizing the metrics using Prometheus UI
+
+Now open the Prometheus UI in your web browser by visiting
+[localhost:9090](http://localhost:9090). Click the graph tab and update the
+query to `http_server_request_duration_bucket`, or use [this pre-canned
+link](http://localhost:9090/graph?g0.expr=http_request_duration_seconds_bucket).
+
+You should see the graph showing the recent request durations.
+
+### Visualizing the traces using Jaeger UI
+
+Visit Jaeger UI in your browser at [localhost:16686](http://localhost:16686).
+
+Select `hello_world` from the dropdown and click `Find Traces`, or use
+[this pre-canned link](http://localhost:16686/search?service=hello_world).
+
+See the traces for the recent requests and click to select a trace for a given request.
+
+Click to expand the trace, the metadata associated with the request and the
+process, and the events.

--- a/Examples/hello-world-vapor-server-otlp-http-protobuf/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
+++ b/Examples/hello-world-vapor-server-otlp-http-protobuf/Sources/HelloWorldVaporServer/HelloWorldVaporServer.swift
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import OTel
+import Vapor
+
+@main
+enum HelloWorldVaporServer {
+    static func main() async throws {
+        // Bootstrap observability backends (with short export intervals for demo purposes).
+        var config = OTel.Configuration.default
+        config.serviceName = "hello_world"
+        config.diagnosticLogLevel = .error
+        config.logs.batchLogRecordProcessor.scheduleDelay = .seconds(3)
+        config.metrics.exportInterval = .seconds(3)
+        config.traces.batchSpanProcessor.scheduleDelay = .seconds(3)
+        let observability = try OTel.bootstrap(configuration: config)
+
+        // Create an HTTP server with instrumentation middlewares added.
+        let app = try await Vapor.Application.make()
+        app.middleware.use(TracingMiddleware())
+        app.middleware.use(RouteLoggingMiddleware(logLevel: .info))
+        app.get("hello") { _ in "hello" }
+
+        // Run the observability service in a task group with the Vapor server.
+        try await withThrowingTaskGroup { group in
+            group.addTask { try await observability.run() }
+            group.addTask { try await app.execute() }
+            try await group.next()
+            group.cancelAll()
+            try await group.waitForAll()
+        }
+    }
+}

--- a/Examples/hello-world-vapor-server-otlp-http-protobuf/docker/docker-compose.yaml
+++ b/Examples/hello-world-vapor-server-otlp-http-protobuf/docker/docker-compose.yaml
@@ -1,0 +1,32 @@
+version: "3.5"
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+      - ./logs:/logs:rw
+    ports:
+      - "4317:4317"  # OTLP/gRPC receiver
+      - "4318:4318"  # OTLP/HTTP receiver
+
+  prometheus:
+    image: prom/prometheus:latest
+    entrypoint:
+      - "/bin/prometheus"
+      - "--log.level=debug"
+      - "--config.file=/etc/prometheus/prometheus.yaml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yaml
+    ports:
+      - "9090:9090"  # Prometheus web UI
+
+  jaeger:
+    image: jaegertracing/all-in-one
+    ports:
+      - "16686:16686"  # Jaeger Web UI
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/compose-spec/compose-spec/master/schema/compose-spec.json

--- a/Examples/hello-world-vapor-server-otlp-http-protobuf/docker/otel-collector-config.yaml
+++ b/Examples/hello-world-vapor-server-otlp-http-protobuf/docker/otel-collector-config.yaml
@@ -1,0 +1,36 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "otel-collector:4317"
+      http:
+        endpoint: "otel-collector:4318"
+
+exporters:
+  debug:  # Data sources: traces, metrics, logs
+    verbosity: basic
+
+  file:
+    path: /logs/logs.json
+
+  prometheus:  # Data sources: metrics
+    endpoint: "otel-collector:7070"
+
+  otlp/jaeger:  # Data sources: traces
+    endpoint: "jaeger:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [file, debug]
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus, debug]
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/jaeger, debug]
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/srikanthccv/otelcol-jsonschema/main/schema.json

--- a/Examples/hello-world-vapor-server-otlp-http-protobuf/docker/prometheus.yaml
+++ b/Examples/hello-world-vapor-server-otlp-http-protobuf/docker/prometheus.yaml
@@ -1,0 +1,7 @@
+scrape_configs:
+  - job_name: "otel-collector"
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["otel-collector:7070"]
+
+# yaml-language-server: $schema=http://json.schemastore.org/prometheus


### PR DESCRIPTION
## Motivation

As part of the next alpha, we're adding some more examples. 

## Modifications

Add example package using Vapor

## Result

Adopters can see a working example using a Vapor HTTP server.