### PR TITLE
Simplify in-memory processors by removing unnecessary AsyncStream

### DIFF
--- a/Tests/OTelTests/OTelTesting/OTelInMemoryLogRecordProcessor.swift
+++ b/Tests/OTelTests/OTelTesting/OTelInMemoryLogRecordProcessor.swift
@@ -26,20 +26,14 @@ final class OTelInMemoryLogRecordProcessor: OTelLogRecordProcessor {
     var numberOfForceFlushes: Int { _numberOfForceFlushes.withLockedValue { $0 } }
     private let _numberOfForceFlushes = NIOLockedValueBox<Int>(0)
 
-    private let stream: AsyncStream<Void>
-    private let continuation: AsyncStream<Void>.Continuation
-
-    init() {
-        (stream, continuation) = AsyncStream.makeStream()
-    }
+    init() {}
 
     func run() async throws {
-        await withGracefulShutdownHandler {
-            for await _ in stream.cancelOnGracefulShutdown() {}
+        try await withGracefulShutdownHandler {
+            try await gracefulShutdown()
         } onGracefulShutdown: {
-            self.continuation.finish()
+            self._numberOfShutdowns.withLockedValue { $0 += 1 }
         }
-        _numberOfShutdowns.withLockedValue { $0 += 1 }
     }
 
     nonisolated func onEmit(_ record: inout OTelLogRecord) {


### PR DESCRIPTION
## Motivation

The internal in-memory processors had an unnecessary AsyncStream purely to keep the service running until graceful shutdown. This isn't necessary since Service Lifecycle provides a utility for waiting for graceful shutdown.

## Modifications

- Simplify in-memory processors by removing unnecessary AsyncStream

## Result

In-memory processors use simplified graceful shutdown logic.
