### PR TITLE
Update examples to depend on exact: 1.0.0-alpha.2

### DIFF
--- a/Examples/hello-world-grafana-lgtm/Package.swift
+++ b/Examples/hello-world-grafana-lgtm/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.1", traits: ["OTLPGRPC"]),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2", traits: ["OTLPGRPC"]),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-logging-metadata-provider/Package.swift
+++ b/Examples/hello-world-hummingbird-server-logging-metadata-provider/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-mtls/Package.swift
+++ b/Examples/hello-world-hummingbird-server-mtls/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-only-traces/Package.swift
+++ b/Examples/hello-world-hummingbird-server-only-traces/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-otlp-grpc/Package.swift
+++ b/Examples/hello-world-hummingbird-server-otlp-grpc/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.1", traits: ["OTLPGRPC"]),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2", traits: ["OTLPGRPC"]),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-otlp-http-json/Package.swift
+++ b/Examples/hello-world-hummingbird-server-otlp-http-json/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.1", traits: ["OTLPHTTP"]),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2", traits: ["OTLPHTTP"]),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-otlp-http-protobuf/Package.swift
+++ b/Examples/hello-world-hummingbird-server-otlp-http-protobuf/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.1", traits: ["OTLPHTTP"]),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2", traits: ["OTLPHTTP"]),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-tls/Package.swift
+++ b/Examples/hello-world-hummingbird-server-tls/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-vapor-server-otlp-http-protobuf/Package.swift
+++ b/Examples/hello-world-vapor-server-otlp-http-protobuf/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.115.0"),
         // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.1", traits: ["OTLPHTTP"]),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2", traits: ["OTLPHTTP"]),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
## Motivation

Once 1.0.0-alpha.2 is tagged, our examples should resolve to this.

## Modifications

Update examples to depend on exact: 1.0.0-alpha.2

## Result

Adopters checking out examples on the repo will use the latest alpha release.