### PR TITLE
Update GitHub Workflows to use a concurrency group per Git ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: "CI"
 on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-ci
+  cancel-in-progress: true
+
 jobs:
   soundness:
     name: Soundness Check


### PR DESCRIPTION
## Motivation

Usually projects define a concurrency group for each ref, which allows for better CI flows.

## Modifications

Use a concurrency group per Git ref

## Result

CI that queues less because new pushes to PR branches cancel current runs on the branch.