### PR TITLE
Remove empty conditional compiler branches

### DIFF
--- a/Sources/OTel/OTelAPI/OTel+Backends.swift
+++ b/Sources/OTel/OTelAPI/OTel+Backends.swift
@@ -15,8 +15,6 @@ public import CoreMetrics
 public import Logging
 public import ServiceLifecycle
 public import Tracing
-#if OTLPGRPC
-#endif
 
 extension OTel {
     /// Create a logging backend with an OTLP exporter.

--- a/Sources/OTel/OTelCore/OTelCore+GenericWrappers.swift
+++ b/Sources/OTel/OTelCore/OTelCore+GenericWrappers.swift
@@ -11,8 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if OTLPGRPC
-#endif
 import Logging
 import Tracing
 import W3CTraceContext


### PR DESCRIPTION
## Motivation

When we squished the modules into one, we removed some imports. As a result a couple of `#if-#endif` branches had no content at all.

## Modifications

Remove empty conditional compiler branches

## Result

- No adopter impact.
- Cleaning up codebase.
