### PR TITLE
Remove configuration of gRPC transport which is covered by CallOptions

### DIFF
--- a/Sources/OTel/OTLPGRPC/OTLPGRPCExporter.swift
+++ b/Sources/OTel/OTLPGRPC/OTLPGRPCExporter.swift
@@ -101,22 +101,10 @@ enum OTLPGRPCExporterError: Swift.Error {
 }
 
 @available(gRPCSwift, *)
-extension HTTP2ClientTransport.Posix.Config {
-    init(_ configuration: OTel.Configuration.OTLPExporterConfiguration) {
-        self = .defaults
-        switch configuration.compression.backing {
-        case .gzip: self.compression = .init(algorithm: .gzip, enabledAlgorithms: [.gzip])
-        case .none: self.compression = .init(algorithm: .none, enabledAlgorithms: [.none])
-        }
-    }
-}
-
-@available(gRPCSwift, *)
 extension CallOptions {
     init(_ configuration: OTel.Configuration.OTLPExporterConfiguration) {
         self = .defaults
         self.timeout = configuration.timeout
-        // TODO: we're setting compression here and in the transport config; do we need both?
         self.compression = switch configuration.compression.backing {
         case .gzip: .gzip
         case .none: CompressionAlgorithm.none
@@ -193,7 +181,7 @@ extension HTTP2ClientTransport.Posix {
         try self.init(
             target: .dns(host: host, port: port),
             transportSecurity: security,
-            config: Config(configuration)
+            config: .defaults
         )
     }
 }


### PR DESCRIPTION
## Motivation

In the OTLP/gRPC exporter we were setting the `compression` on both the transport level and the call options level. This is unnecessary and we can use just one.

## Modifications

Remove configuration of gRPC transport which is covered by CallOptions

## Result

- No adopter impact.
- Codebase cleanup.