### PR TITLE
Remove outdated TODO comments and update others with more context

### DIFF
--- a/Sources/OTel/OTLPCore+Extensions/Logging/OTelLogRecord+Proto.swift
+++ b/Sources/OTel/OTLPCore+Extensions/Logging/OTelLogRecord+Proto.swift
@@ -28,9 +28,13 @@ extension Opentelemetry_Proto_Logs_V1_LogRecord {
         body = .init(logRecord.body.description)
 
         attributes = .init(logRecord.metadata)
-        droppedAttributesCount = 0 // TODO: do we need this?
+        // TODO: We should be setting dropped counts here.
+        //       see: https://opentelemetry.io/docs/specs/otel/logs/sdk/#logrecord-limits
+        droppedAttributesCount = 0
 
-        flags = 0 // TODO: do we need this?
+        // TODO: This should be set to the trace flag in the W3C trace context.
+        //       see: https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-traceflags
+        flags = 0
 
         if let spanContext = logRecord.spanContext {
             traceID = spanContext.traceID.data

--- a/Sources/OTel/OTLPCore+Extensions/Tracing/OTelFinishedSpan+Proto.swift
+++ b/Sources/OTel/OTLPCore+Extensions/Tracing/OTelFinishedSpan+Proto.swift
@@ -48,6 +48,9 @@ extension Opentelemetry_Proto_Trace_V1_Span {
         attributes = .init(finishedSpan.attributes)
         events = finishedSpan.events.map(Opentelemetry_Proto_Trace_V1_Span.Event.init)
         links = finishedSpan.links.compactMap(Opentelemetry_Proto_Trace_V1_Span.Link.init)
+
+        // TODO: We should be setting dropped counts here.
+        //       see: https://opentelemetry.io/docs/specs/otel/trace/sdk/#span-limits
     }
 }
 

--- a/Sources/OTel/OTLPHTTP/OTLPHTTPExporter.swift
+++ b/Sources/OTel/OTLPHTTP/OTLPHTTPExporter.swift
@@ -70,7 +70,6 @@ final class OTLPHTTPExporter<Request: Message, Response: Message>: Sendable {
             request.headers.replaceOrAdd(name: "Content-Type", value: "application/x-protobuf")
         case .httpJSON:
             // https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding
-            // TODO: Double check the spec for any missing JSON transformation and whether Swift Protobuf supports them.
             var encodingOptions = JSONEncodingOptions()
             encodingOptions.alwaysPrintInt64sAsNumbers = false
             encodingOptions.alwaysPrintEnumsAsInts = true

--- a/Sources/OTel/OTelCore/OTel+Configuration+DiagnosticLogger.swift
+++ b/Sources/OTel/OTelCore/OTel+Configuration+DiagnosticLogger.swift
@@ -20,7 +20,6 @@ extension OTel.Configuration {
         case .console:
             Logger(label: "swift-otel", factory: { label in StreamLogHandler.standardError(label: label) })
         case .custom(let logger):
-            // TODO: would a better configuration API accept a custom factory, which would allow per-logger labels?
             logger
         }
         // Environment variable overrides may not have been applied, so we explicitly check here.

--- a/Tests/OTelTests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
+++ b/Tests/OTelTests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
@@ -350,7 +350,6 @@ import Tracing
     }
 
     @Test func testRetryCustomPolicyStillBacksOffBasedOnAttempts() async throws {
-        // TODO: use an extension on tooManyRequests response
         var retryPolicy = HTTPClient.RetryPolicy(
             maxAttempts: 8,
             baseDelay: .seconds(1),

--- a/Tests/OTelTests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
@@ -792,7 +792,6 @@ import Testing
     // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#boolean
     // https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options
     @Test func testOTLPExporterInsecure() {
-        // TODO: this should be the default check for each of the tests
         #expect(OTel.Configuration.OTLPExporterConfiguration.default.insecure == false)
 
         #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [


### PR DESCRIPTION
## Motivation

There are a number of `TODO` comments in the repo. Several are outdated and have been resolved. Some remain, but had incomplete action statements.

## Modifications

Remove outdated TODO comments and update others with more context

## Result

- No adopter impact.
- Cleaner codebase.