### PR TITLE
Also use conditional FoundationEssentials imports for typed imports

### DIFF
--- a/Sources/OTel/OTLPCore+Extensions/Tracing/OTelFinishedSpan+Proto.swift
+++ b/Sources/OTel/OTLPCore+Extensions/Tracing/OTelFinishedSpan+Proto.swift
@@ -14,7 +14,11 @@
 #if !(OTLPHTTP || OTLPGRPC)
 // Empty when above trait(s) are disabled.
 #else
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.Data
+#else
 import struct Foundation.Data
+#endif
 import Tracing
 import W3CTraceContext
 

--- a/Sources/OTel/OTLPCore+Extensions/Tracing/SpanID+Proto.swift
+++ b/Sources/OTel/OTLPCore+Extensions/Tracing/SpanID+Proto.swift
@@ -14,7 +14,11 @@
 #if !(OTLPHTTP || OTLPGRPC)
 // Empty when above trait(s) are disabled.
 #else
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.Data
+#else
 import struct Foundation.Data
+#endif
 import W3CTraceContext
 
 extension SpanID {

--- a/Sources/OTel/OTLPCore+Extensions/Tracing/SpanLink+Proto.swift
+++ b/Sources/OTel/OTLPCore+Extensions/Tracing/SpanLink+Proto.swift
@@ -14,7 +14,11 @@
 #if !(OTLPHTTP || OTLPGRPC)
 // Empty when above trait(s) are disabled.
 #else
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.Data
+#else
 import struct Foundation.Data
+#endif
 import Tracing
 
 extension Opentelemetry_Proto_Trace_V1_Span.Link {

--- a/Sources/OTel/OTLPCore+Extensions/Tracing/TraceID+Proto.swift
+++ b/Sources/OTel/OTLPCore+Extensions/Tracing/TraceID+Proto.swift
@@ -14,7 +14,11 @@
 #if !(OTLPHTTP || OTLPGRPC)
 // Empty when above trait(s) are disabled.
 #else
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.Data
+#else
 import struct Foundation.Data
+#endif
 import W3CTraceContext
 
 extension TraceID {

--- a/Sources/OTel/OTLPGRPC/OTLPGRPCExporter.swift
+++ b/Sources/OTel/OTLPGRPC/OTLPGRPCExporter.swift
@@ -14,7 +14,11 @@
 #if !OTLPGRPC
 // Empty when above trait(s) are disabled.
 #else
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.URLComponents
+#else
 import struct Foundation.URLComponents
+#endif
 import GRPCCore
 import GRPCNIOTransportHTTP2
 import Logging

--- a/Sources/OTel/OTLPHTTP/OTLPHTTPExporter.swift
+++ b/Sources/OTel/OTLPHTTP/OTLPHTTPExporter.swift
@@ -22,9 +22,15 @@ import NIOSSL
 import ServiceLifecycle
 import SwiftProtobuf
 
+#if canImport(FoundationEssentials)
+import class FoundationEssentials.FileManager
+import func FoundationEssentials.pow
+import struct FoundationEssentials.URL
+#else
 import class Foundation.FileManager
 import func Foundation.pow
 import struct Foundation.URL
+#endif
 import struct NIOCore.ByteBuffer
 import struct NIOCore.TimeAmount
 

--- a/Sources/OTel/OTLPHTTP/OTLPHTTPExporter.swift
+++ b/Sources/OTel/OTLPHTTP/OTLPHTTPExporter.swift
@@ -24,11 +24,9 @@ import SwiftProtobuf
 
 #if canImport(FoundationEssentials)
 import class FoundationEssentials.FileManager
-import func FoundationEssentials.pow
 import struct FoundationEssentials.URL
 #else
 import class Foundation.FileManager
-import func Foundation.pow
 import struct Foundation.URL
 #endif
 import struct NIOCore.ByteBuffer
@@ -233,10 +231,10 @@ extension HTTPClient {
             switch policy(response) {
             case .doNotRetry: return .doNotRetry
             case .retryWithBackoff:
-                let exponentialDelay = baseDelay * pow(2.0, Double(attempts - 1))
+                let exponentialDelay = baseDelay * (2 << (attempts - 2))
                 let cappedDelay = min(exponentialDelay, maxDelay)
                 let jitterAmount = cappedDelay * jitter * Double.random(in: -1 ... 1)
-                let delay = max(.zero, cappedDelay + jitterAmount)
+                let delay = max(Duration.zero, cappedDelay + jitterAmount)
                 return .retryAfter(delay)
             case .retryWithSpecificBackoff(let delay):
                 return .retryAfter(delay)

--- a/Sources/OTel/OTelAPI/OTel+Backends.swift
+++ b/Sources/OTel/OTelAPI/OTel+Backends.swift
@@ -11,7 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import class FoundationEssentials.ProcessInfo
+#else
 import class Foundation.ProcessInfo
+#endif
 public import CoreMetrics
 public import Logging
 public import ServiceLifecycle

--- a/Sources/OTel/OTelAPI/OTel+Bootstrap.swift
+++ b/Sources/OTel/OTelAPI/OTel+Bootstrap.swift
@@ -11,7 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import class FoundationEssentials.ProcessInfo
+#else
 import class Foundation.ProcessInfo
+#endif
 import Logging
 import Metrics
 public import ServiceLifecycle

--- a/Sources/OTel/OTelCore/Logging/Exporting/OTelConsoleLogRecordExporter.swift
+++ b/Sources/OTel/OTelCore/Logging/Exporting/OTelConsoleLogRecordExporter.swift
@@ -11,7 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.Date
+#else
 import struct Foundation.Date
+#endif
 import ServiceLifecycle
 
 struct OTelConsoleLogRecordExporter: OTelLogRecordExporter {

--- a/Sources/OTel/OTelCore/OTel+Configuration+DiagnosticLogger.swift
+++ b/Sources/OTel/OTelCore/OTel+Configuration+DiagnosticLogger.swift
@@ -11,7 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import class FoundationEssentials.ProcessInfo
+#else
 import class Foundation.ProcessInfo
+#endif
 import Logging
 
 extension OTel.Configuration {

--- a/Sources/OTel/OTelCore/Resource/OTelProcessResourceDetector.swift
+++ b/Sources/OTel/OTelCore/Resource/OTelProcessResourceDetector.swift
@@ -11,7 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import class FoundationEssentials.ProcessInfo
+#else
 import class Foundation.ProcessInfo
+#endif
 import Logging
 import Tracing
 

--- a/Tests/OTelTests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
+++ b/Tests/OTelTests/OTLPHTTPTests/OTLPHTTPExporterTests.swift
@@ -12,7 +12,11 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.Data
+#else
 import struct Foundation.Data
+#endif
 import Metrics
 import NIOConcurrencyHelpers
 import NIOHTTP1

--- a/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
+++ b/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
@@ -12,7 +12,11 @@
 //===----------------------------------------------------------------------===//
 
 #if compiler(>=6.2) // Swift Testing exit tests only added in 6.2
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.Data
+#else
 import struct Foundation.Data
+#endif
 import Logging
 import Metrics
 import NIOTestUtils

--- a/Tests/OTelTests/OTelAPITests/TestUtils.swift
+++ b/Tests/OTelTests/OTelAPITests/TestUtils.swift
@@ -23,7 +23,11 @@ import Musl
 #error("Unsupported runtime")
 #endif
 
+#if canImport(FoundationEssentials)
+import struct FoundationEssentials.URL
+#else
 import struct Foundation.URL
+#endif
 import ServiceLifecycle
 
 extension Testing.Test {

--- a/Tests/OTelTests/OTelCoreTests/Configuration/OTelEnvironmentTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Configuration/OTelEnvironmentTests.swift
@@ -11,7 +11,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import class FoundationEssentials.ProcessInfo
+#else
 import class Foundation.ProcessInfo
+#endif
 @testable import OTel
 import XCTest
 


### PR DESCRIPTION
## Motivation

On platforms that split Foundation into FoundationEssentials, we want to only require our users link the latter. We tried to do this in #314 but this missed "scoped imports", e.g. `import struct Foundation.Data`.

## Modifications

Also use conditional FoundationEssentials imports for typed imports

## Result

Remove requirement for full Foundation.

## Notes

I'll see if I can work on some CI for this too, in a followup PR.
