### PR TITLE
Remove unused import of NIOFoundationCompat

### DIFF
--- a/Sources/OTel/OTLPHTTP/OTLPHTTPExporter.swift
+++ b/Sources/OTel/OTLPHTTP/OTLPHTTPExporter.swift
@@ -16,7 +16,6 @@
 #else
 import AsyncHTTPClient
 import Logging
-import NIOFoundationCompat
 import NIOHTTP1
 import NIOSSL
 import ServiceLifecycle


### PR DESCRIPTION
## Motivation

Scouring for unused imports, I found we no longer need NIOFoundationCompat.

## Modifications

Remove import.

## Result

No dependency on NIOFoundationCompat.