### PR TITLE
Add CI for Foundation imports without FoundationEssentials equivalent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,14 @@ jobs:
           which curl yq || (apt -q update && apt -yq install curl yq)
           scripts/check-docs.sh
 
+  check-foundation-imports:
+    name: Foundation Imports Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.3.0
+      - name: Run Foundation imports check
+        run: scripts/check-foundation-imports.sh
+
   construct-examples-matrix:
     name: Example Package (Construct Matrix)
     runs-on: ubuntu-latest

--- a/scripts/check-foundation-imports.sh
+++ b/scripts/check-foundation-imports.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the Swift OTel open source project
+##
+## Copyright (c) 2025 the Swift OTel project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -euo pipefail
+
+log() { printf -- "** %s\n" "$*" >&2; }
+error() { printf -- "** ERROR: %s\n" "$*" >&2; }
+fatal() { error "$@"; exit 1; }
+
+num_errors=0
+while IFS= read -r file; do
+  imports=$(grep "import.*Foundation" "${file}" | grep -v "FoundationEssentials" || true)
+  if [ -n "${imports}" ]; then
+    while read -r import; do
+      if ! grep -q "${import/Foundation/FoundationEssentials}" "${file}"; then
+        error "${file}: import has no FoundationEssentials equivalent: ${import}"
+        ((num_errors++))
+      fi
+    done <<<"${imports}"
+  fi
+done < <(find Sources -type f -name '*.swift')
+
+
+if [ "${num_errors}" -gt 0 ]; then
+  fatal "❌ Found ${num_errors} errors."
+fi
+
+log "✅ Found no errors."


### PR DESCRIPTION
## Motivation

Even though some of our dependencies are not yet `FoundationEssentials`-clean, we don't want to regress the fact that this repo does not force the full Foundation dependency on downstream packages itself.

## Modifications

Add CI for Foundation imports without FoundationEssentials equivalent.

## Result

CI will catch if we have a Foundation import without an equivalent FoundationEssentials import.

## Notes

Here's an example of this failing if I add an `import struct Foundation.Data` locally:

```console
% scripts/check-foundation-essentials-dependency.sh
** ERROR: Sources/OTel/OTLPHTTP/OTLPHTTPExporter.swift: import has no FoundationEssentials equivalent: import struct Foundation.Data
** ERROR: ❌ Found 1 errors.
```