### PR TITLE
Add environment variable override for logging backend level

### DIFF
--- a/Sources/OTel/OTelAPI/OTel+Configuration.swift
+++ b/Sources/OTel/OTelAPI/OTel+Configuration.swift
@@ -375,6 +375,7 @@ extension OTel.Configuration {
 
         /// Default log level for loggers returned by the logging backend factory.
         ///
+        /// - Environment variable(s): `OTEL_SWIFT_LOG_LEVEL` (SDK-specific)
         /// - Default value: `.info`
         public var level: LogLevel
 

--- a/Sources/OTel/OTelCore/OTel+Configuration+Environment.swift
+++ b/Sources/OTel/OTelCore/OTel+Configuration+Environment.swift
@@ -58,6 +58,7 @@ extension OTel.Configuration.Key.GeneralKey {
     static let metricExportInterval = Self(key: "OTEL_METRIC_EXPORT_INTERVAL")
     static let metricExportTimeout = Self(key: "OTEL_METRIC_EXPORT_TIMEOUT")
     static let logsExporter = Self(key: "OTEL_LOGS_EXPORTER")
+    static let logsLevel = Self(key: "OTEL_SWIFT_LOG_LEVEL") // SDK-specific => different format.
     static let propagators = Self(key: "OTEL_PROPAGATORS")
     static let sampler = Self(key: "OTEL_TRACES_SAMPLER")
     static let samplerArgument = Self(key: "OTEL_TRACES_SAMPLER_ARG")

--- a/Sources/OTel/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
+++ b/Sources/OTel/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
@@ -50,6 +50,7 @@ extension OTel.Configuration.LogsConfiguration {
         batchLogRecordProcessor.applyEnvironmentOverrides(environment: environment, logger: logger)
         exporter.override(using: .logsExporter, from: environment, logger: logger)
         otlpExporter.applyEnvironmentOverrides(environment: environment, signal: .logs, logger: logger)
+        level.override(using: .logsLevel, from: environment, logger: logger)
     }
 }
 

--- a/Tests/OTelTests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
@@ -511,6 +511,32 @@ import Testing
         }
     }
 
+    // OTEL_SWIFT_LOG_LEVEL
+    // SDK-specific environment variable for configuring the default log level of the bootstrapped Swift Log backend.
+    @Test func testLogsLevel() {
+        #expect(OTel.Configuration.default.logs.level.backing == .info)
+
+        #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_SWIFT_LOG_LEVEL": "trace",
+        ]).logs.level.backing == .trace)
+
+        #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_SWIFT_LOG_LEVEL": "debug",
+        ]).logs.level.backing == .debug)
+
+        #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_SWIFT_LOG_LEVEL": "info",
+        ]).logs.level.backing == .info)
+
+        #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_SWIFT_LOG_LEVEL": "warning",
+        ]).logs.level.backing == .warning)
+
+        #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_SWIFT_LOG_LEVEL": "error",
+        ]).logs.level.backing == .error)
+    }
+
     // OTEL_EXPORTER_OTLP_ENDPOINT (OTLP/HTTP edition).
     // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
     // https://opentelemetry.io/docs/specs/otel/protocol/exporter/#configuration-options


### PR DESCRIPTION
## Motivation

The OTel spec doesn't define an environment variable for setting the default level on the OTLP logging backend (it does define `OTEL_LOG_LEVEL`, but this is for the diagnostic log level for the SDK itself, which confuses many people in most SDKs).

However, the spec states that SDKs can add their own variables if they prefix them with `OTEL_<LANGUAGE>_`.

## Modification

Add configuration environment override for logging level: `OTEL_SWIFT_LOG_LEVEL`.

## Result

Adopters can override the level used by the logging factory created using `bootstrap` or `makeLoggingBackend` by setting `OTEL_SWIFT_LOG_LEVEL`. This in addition to the existing functionality for configuring the log level, provided by `Configuration.logs.level`.

[^1]: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/