### PR TITLE
More consistent logging of lifecycle and errors

### DIFF
--- a/Sources/OTel/OTelCore/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReader.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReader.swift
@@ -57,10 +57,8 @@ struct OTelPeriodicExportingMetricsReader<Clock: _Concurrency.Clock> where Clock
             try await withTimeout(configuration.exportTimeout, clock: clock) {
                 try await exporter.export(batch)
             }
-        } catch is TimeoutError {
-            logger.warning("Timed out exporting metrics.", metadata: ["timeout": "\(configuration.exportTimeout)"])
         } catch {
-            logger.error("Failed to export metrics.", metadata: ["error": "\(error)"])
+            logger.log(level: .warning, error: error, message: "Failed to export metrics.")
         }
     }
 }
@@ -75,12 +73,12 @@ extension OTelPeriodicExportingMetricsReader: CustomStringConvertible, Service {
             logger.trace("Timer fired.", metadata: ["interval": "\(interval)"])
             await tick()
         }
-        logger.debug("Shutting down.")
+        logger.info("Shutting down.")
         // Unlike traces, force-flush is just a regular tick for metrics; no need for a different function.
         await tick()
         try await exporter.forceFlush()
         await exporter.shutdown()
-        logger.debug("Shut down.")
+        logger.info("Shut down.")
     }
 }
 

--- a/Sources/OTel/OTelCore/OTel+Configuration+DiagnosticLogger.swift
+++ b/Sources/OTel/OTelCore/OTel+Configuration+DiagnosticLogger.swift
@@ -52,3 +52,24 @@ extension Logger {
         return result
     }
 }
+
+extension Logger {
+    func log(
+        level: Logger.Level,
+        error: some Error,
+        message: @autoclosure () -> Logger.Message,
+        metadata: @autoclosure () -> Logger.Metadata? = nil,
+        file: String = #fileID,
+        function: String = #function,
+        line: UInt = #line
+    ) {
+        self.log(
+            level: level,
+            message(),
+            metadata: metadata()?.merging(["error": "\(error)", "error_type": "\(type(of: error))"], uniquingKeysWith: { _, new in new }),
+            file: file,
+            function: function,
+            line: line
+        )
+    }
+}

--- a/Sources/OTel/OTelCore/OTel+Configuration+DiagnosticLogger.swift
+++ b/Sources/OTel/OTelCore/OTel+Configuration+DiagnosticLogger.swift
@@ -66,7 +66,7 @@ extension Logger {
         self.log(
             level: level,
             message(),
-            metadata: metadata()?.merging(["error": "\(error)", "error_type": "\(type(of: error))"], uniquingKeysWith: { _, new in new }),
+            metadata: (metadata() ?? [:]).merging(["error": "\(error)", "error_type": "\(type(of: error))"]) { $1 },
             file: file,
             function: function,
             line: line

--- a/Sources/OTel/OTelCore/Resource/OTelResourceDetection.swift
+++ b/Sources/OTel/OTelCore/Resource/OTelResourceDetection.swift
@@ -88,11 +88,7 @@ struct OTelResourceDetection<Clock: _Concurrency.Clock>: Sendable where Clock.Du
                         logger.trace("Detected resource.", metadata: ["detector": "\(detector)"])
                         return (index, resource)
                     } catch {
-                        logger.error("Failed to detect resource.", metadata: [
-                            "detector": "\(detector)",
-                            "error_type": "\(type(of: error))",
-                            "error_description": "\(error)",
-                        ])
+                        logger.log(level: .warning, error: error, message: "Failed to detect resource.", metadata: ["detector": "\(detector)"])
                         return (index, OTelResource())
                     }
                 }

--- a/Sources/OTel/OTelCore/Tracing/OTelTracer.swift
+++ b/Sources/OTel/OTelCore/Tracing/OTelTracer.swift
@@ -98,6 +98,7 @@ extension OTelTracer where Clock == ContinuousClock {
 
 extension OTelTracer: Service {
     func run() async throws {
+        logger.info("Starting.")
         await withGracefulShutdownHandler {
             for await event in eventStream {
                 // We don't want to propagate the current span's service context into
@@ -114,10 +115,10 @@ extension OTelTracer: Service {
                 }
             }
         } onGracefulShutdown: {
-            self.logger.debug("Shutting down.")
+            self.logger.info("Shutting down.")
             self.eventStreamContinuation.finish()
         }
-        logger.debug("Shut down.")
+        logger.info("Shut down.")
     }
 }
 
@@ -236,11 +237,7 @@ extension OTelTracer: Instrument {
         do {
             context.spanContext = try propagator.extractSpanContext(from: carrier, using: extractor)
         } catch {
-            logger.debug("Failed to extract span context.", metadata: [
-                "carrier": "\(carrier)",
-                "error_type": "\(type(of: error))",
-                "error_description": "\(error)",
-            ])
+            logger.log(level: .warning, error: error, message: "Failed to extract span context.", metadata: ["carrier": "\(carrier)"])
         }
     }
 }

--- a/Sources/OTel/OTelCore/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
+++ b/Sources/OTel/OTelCore/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
@@ -90,13 +90,13 @@ actor OTelBatchSpanProcessor<Exporter: OTelSpanExporter, Clock: _Concurrency.Clo
                 }
                 await taskGroup.waitForAll()
             } onGracefulShutdown: {
-                self.logger.debug("Shutting down.")
+                self.logger.info("Shutting down.")
                 self.spanContinuation.finish()
                 self.explicitTick.finish()
             }
             try? await self.forceFlush()
             await self.exporter.shutdown()
-            self.logger.debug("Shut down.")
+            self.logger.info("Shut down.")
         }
     }
 
@@ -118,7 +118,7 @@ actor OTelBatchSpanProcessor<Exporter: OTelSpanExporter, Clock: _Concurrency.Clo
                 do {
                     try await self.exporter.forceFlush()
                 } catch {
-                    self.logger.error("Force flush failed", metadata: ["error": "\(error)"])
+                    self.logger.log(level: .warning, error: error, message: "Force flush failed.")
                 }
             }
         }
@@ -151,10 +151,7 @@ actor OTelBatchSpanProcessor<Exporter: OTelSpanExporter, Clock: _Concurrency.Clo
                 logger.debug("Exported batch.")
             }
         } catch {
-            logger.warning("Failed to export batch.", metadata: [
-                "error": "\(String(describing: type(of: error)))",
-                "error_description": "\(error)",
-            ])
+            logger.log(level: .warning, error: error, message: "Failed to export batch.")
         }
     }
 }

--- a/Sources/OTel/OTelCore/Tracing/Processing/OTelSimpleSpanProcessor.swift
+++ b/Sources/OTel/OTelCore/Tracing/Processing/OTelSimpleSpanProcessor.swift
@@ -45,7 +45,7 @@ struct OTelSimpleSpanProcessor<Exporter: OTelSpanExporter>: OTelSpanProcessor {
                     logger.trace("Received ended span.", metadata: ["span_id": "\(span.spanContext.spanID)"])
                     try await exporter.export([span])
                 } catch {
-                    logger.warning("Exporting log record failed", metadata: ["error": "\(error)"])
+                    logger.log(level: .warning, error: error, message: "Failed to export log record.")
                     // simple log processor does not attempt retries
                 }
             }

--- a/Tests/OTelTests/OTelCoreTests/Logging/DiagnosticLoggingTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Logging/DiagnosticLoggingTests.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+@testable import OTel
+import Testing
+
+@Suite struct DiagnosticLoggingTests {
+    @Test func testLogErrorHelper() async throws {
+        let recordingHandler = RecordingLogHandler()
+        var logMessages = recordingHandler.recordedLogMessageStream.makeAsyncIterator()
+        let logger = Logger(label: "test") { _ in recordingHandler }
+        struct TestError: Error, CustomStringConvertible {
+            var description: String { "custom description" }
+        }
+
+        for level in [Logger.Level.trace, .trace, .info, .warning, .error] {
+            logger.log(level: level, error: TestError(), message: "Thing failed.")
+            let message = await logMessages.next()
+            #expect(message?.level == level)
+            #expect(message?.message == "Thing failed.")
+            #expect(message?.metadata?["error"] == "custom description")
+            #expect(message?.metadata?["error_type"] == "TestError")
+        }
+    }
+}

--- a/Tests/OTelTests/OTelCoreTests/Logging/DiagnosticLoggingTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Logging/DiagnosticLoggingTests.swift
@@ -16,7 +16,7 @@ import Logging
 import Testing
 
 @Suite struct DiagnosticLoggingTests {
-    @Test func testLogErrorHelper() async throws {
+    @Test(arguments: Logger.Level.allCases) func testLogErrorHelper(level: Logger.Level) async throws {
         let recordingHandler = RecordingLogHandler()
         var logMessages = recordingHandler.recordedLogMessageStream.makeAsyncIterator()
         let logger = Logger(label: "test") { _ in recordingHandler }
@@ -24,13 +24,11 @@ import Testing
             var description: String { "custom description" }
         }
 
-        for level in [Logger.Level.trace, .trace, .info, .warning, .error] {
-            logger.log(level: level, error: TestError(), message: "Thing failed.")
-            let message = await logMessages.next()
-            #expect(message?.level == level)
-            #expect(message?.message == "Thing failed.")
-            #expect(message?.metadata?["error"] == "custom description")
-            #expect(message?.metadata?["error_type"] == "TestError")
-        }
+        logger.log(level: level, error: TestError(), message: "Thing failed.")
+        let message = await logMessages.next()
+        #expect(message?.level == level)
+        #expect(message?.message == "Thing failed.")
+        #expect(message?.metadata?["error"] == "custom description")
+        #expect(message?.metadata?["error_type"] == "TestError")
     }
 }

--- a/Tests/OTelTests/OTelCoreTests/Logging/DiagnosticLoggingTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Logging/DiagnosticLoggingTests.swift
@@ -24,10 +24,11 @@ import Testing
             var description: String { "custom description" }
         }
 
-        logger.log(level: level, error: TestError(), message: "Thing failed.")
+        logger.log(level: level, error: TestError(), message: "Thing failed.", metadata: ["foo": "bar"])
         let message = await logMessages.next()
         #expect(message?.level == level)
         #expect(message?.message == "Thing failed.")
+        #expect(message?.metadata?["foo"] == "bar")
         #expect(message?.metadata?["error"] == "custom description")
         #expect(message?.metadata?["error_type"] == "TestError")
     }

--- a/Tests/OTelTests/OTelTesting/RecordingLogHandler.swift
+++ b/Tests/OTelTests/OTelTesting/RecordingLogHandler.swift
@@ -37,6 +37,7 @@ struct RecordingLogHandler: LogHandler {
         function: String,
         line: UInt
     ) {
+        let metadata = self.metadata.merging(metadata ?? [:], uniquingKeysWith: { _, new in new })
         recordedLogMessages.withLockedValue { $0.append((level, message, metadata)) }
         counts.withLockedValue { $0[level] = $0[level, default: 0] + 1 }
         recordedLogMessageContinuation.yield((level, message, metadata))


### PR DESCRIPTION
## Motivation

We currently log various information but inconsistently. For example, errors are logged, but with different structured metadata and log levels across the codebase. Similarly the lifecycle events on Service Lifecycle services are inconsistently levelled.

## Modifications

- Use a helper that uses consistent metadata for logging errors.
- Try and align the other logging a little more.

## Result

More consistent diagnostic logging.