### PR TITLE
Re-generate files with swift-protobuf 1.31.0

### DIFF
--- a/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/collector/logs/v1/logs_service.pb.swift
+++ b/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/collector/logs/v1/logs_service.pb.swift
@@ -121,9 +121,7 @@ fileprivate let _protobuf_package = "opentelemetry.proto.collector.logs.v1"
 
 extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ExportLogsServiceRequest"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "resource_logs"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_logs\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -153,9 +151,7 @@ extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceRequest: SwiftP
 
 extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ExportLogsServiceResponse"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "partial_success"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}partial_success\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -189,10 +185,7 @@ extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsServiceResponse: Swift
 
 extension Opentelemetry_Proto_Collector_Logs_V1_ExportLogsPartialSuccess: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ExportLogsPartialSuccess"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "rejected_log_records"),
-    2: .standard(proto: "error_message"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}rejected_log_records\0\u{3}error_message\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/collector/metrics/v1/metrics_service.pb.swift
+++ b/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/collector/metrics/v1/metrics_service.pb.swift
@@ -121,9 +121,7 @@ fileprivate let _protobuf_package = "opentelemetry.proto.collector.metrics.v1"
 
 extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ExportMetricsServiceRequest"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "resource_metrics"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_metrics\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -153,9 +151,7 @@ extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceRequest: 
 
 extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ExportMetricsServiceResponse"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "partial_success"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}partial_success\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -189,10 +185,7 @@ extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsServiceResponse:
 
 extension Opentelemetry_Proto_Collector_Metrics_V1_ExportMetricsPartialSuccess: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ExportMetricsPartialSuccess"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "rejected_data_points"),
-    2: .standard(proto: "error_message"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}rejected_data_points\0\u{3}error_message\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/collector/trace/v1/trace_service.pb.swift
+++ b/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/collector/trace/v1/trace_service.pb.swift
@@ -121,9 +121,7 @@ fileprivate let _protobuf_package = "opentelemetry.proto.collector.trace.v1"
 
 extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ExportTraceServiceRequest"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "resource_spans"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_spans\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -153,9 +151,7 @@ extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceRequest: Swif
 
 extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ExportTraceServiceResponse"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "partial_success"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}partial_success\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -189,10 +185,7 @@ extension Opentelemetry_Proto_Collector_Trace_V1_ExportTraceServiceResponse: Swi
 
 extension Opentelemetry_Proto_Collector_Trace_V1_ExportTracePartialSuccess: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ExportTracePartialSuccess"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "rejected_spans"),
-    2: .standard(proto: "error_message"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}rejected_spans\0\u{3}error_message\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/common/v1/common.pb.swift
+++ b/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/common/v1/common.pb.swift
@@ -45,7 +45,7 @@ fileprivate struct _GeneratedWithProtocGenSwiftVersion: SwiftProtobuf.ProtobufAP
 /// AnyValue is used to represent any type of attribute value. AnyValue may contain a
 /// primitive value such as a string or integer or it may contain an arbitrary nested
 /// object containing arrays, key-value lists and primitives.
-package struct Opentelemetry_Proto_Common_V1_AnyValue: @unchecked Sendable {
+package struct Opentelemetry_Proto_Common_V1_AnyValue: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -114,7 +114,7 @@ package struct Opentelemetry_Proto_Common_V1_AnyValue: @unchecked Sendable {
 
   /// The value is one of the listed fields. It is valid for all values to be unspecified
   /// in which case this AnyValue is considered to be "empty".
-  package enum OneOf_Value: Equatable, @unchecked Sendable {
+  package enum OneOf_Value: Equatable, Sendable {
     case stringValue(String)
     case boolValue(Bool)
     case intValue(Int64)
@@ -219,15 +219,7 @@ fileprivate let _protobuf_package = "opentelemetry.proto.common.v1"
 
 extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".AnyValue"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "string_value"),
-    2: .standard(proto: "bool_value"),
-    3: .standard(proto: "int_value"),
-    4: .standard(proto: "double_value"),
-    5: .standard(proto: "array_value"),
-    6: .standard(proto: "kvlist_value"),
-    7: .standard(proto: "bytes_value"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}string_value\0\u{3}bool_value\0\u{3}int_value\0\u{3}double_value\0\u{3}array_value\0\u{3}kvlist_value\0\u{3}bytes_value\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -354,9 +346,7 @@ extension Opentelemetry_Proto_Common_V1_AnyValue: SwiftProtobuf.Message, SwiftPr
 
 extension Opentelemetry_Proto_Common_V1_ArrayValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ArrayValue"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "values"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}values\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -386,9 +376,7 @@ extension Opentelemetry_Proto_Common_V1_ArrayValue: SwiftProtobuf.Message, Swift
 
 extension Opentelemetry_Proto_Common_V1_KeyValueList: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".KeyValueList"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "values"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}values\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -418,10 +406,7 @@ extension Opentelemetry_Proto_Common_V1_KeyValueList: SwiftProtobuf.Message, Swi
 
 extension Opentelemetry_Proto_Common_V1_KeyValue: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".KeyValue"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "key"),
-    2: .same(proto: "value"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}key\0\u{1}value\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -460,12 +445,7 @@ extension Opentelemetry_Proto_Common_V1_KeyValue: SwiftProtobuf.Message, SwiftPr
 
 extension Opentelemetry_Proto_Common_V1_InstrumentationScope: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".InstrumentationScope"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "name"),
-    2: .same(proto: "version"),
-    3: .same(proto: "attributes"),
-    4: .standard(proto: "dropped_attributes_count"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}version\0\u{1}attributes\0\u{3}dropped_attributes_count\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/logs/v1/logs.pb.swift
+++ b/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/logs/v1/logs.pb.swift
@@ -306,7 +306,7 @@ package struct Opentelemetry_Proto_Logs_V1_ScopeLogs: Sendable {
 
 /// A log record according to OpenTelemetry Log Data Model:
 /// https://github.com/open-telemetry/oteps/blob/main/text/logs/0097-log-data-model.md
-package struct Opentelemetry_Proto_Logs_V1_LogRecord: @unchecked Sendable {
+package struct Opentelemetry_Proto_Logs_V1_LogRecord: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -406,47 +406,16 @@ package struct Opentelemetry_Proto_Logs_V1_LogRecord: @unchecked Sendable {
 fileprivate let _protobuf_package = "opentelemetry.proto.logs.v1"
 
 extension Opentelemetry_Proto_Logs_V1_SeverityNumber: SwiftProtobuf._ProtoNameProviding {
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "SEVERITY_NUMBER_UNSPECIFIED"),
-    1: .same(proto: "SEVERITY_NUMBER_TRACE"),
-    2: .same(proto: "SEVERITY_NUMBER_TRACE2"),
-    3: .same(proto: "SEVERITY_NUMBER_TRACE3"),
-    4: .same(proto: "SEVERITY_NUMBER_TRACE4"),
-    5: .same(proto: "SEVERITY_NUMBER_DEBUG"),
-    6: .same(proto: "SEVERITY_NUMBER_DEBUG2"),
-    7: .same(proto: "SEVERITY_NUMBER_DEBUG3"),
-    8: .same(proto: "SEVERITY_NUMBER_DEBUG4"),
-    9: .same(proto: "SEVERITY_NUMBER_INFO"),
-    10: .same(proto: "SEVERITY_NUMBER_INFO2"),
-    11: .same(proto: "SEVERITY_NUMBER_INFO3"),
-    12: .same(proto: "SEVERITY_NUMBER_INFO4"),
-    13: .same(proto: "SEVERITY_NUMBER_WARN"),
-    14: .same(proto: "SEVERITY_NUMBER_WARN2"),
-    15: .same(proto: "SEVERITY_NUMBER_WARN3"),
-    16: .same(proto: "SEVERITY_NUMBER_WARN4"),
-    17: .same(proto: "SEVERITY_NUMBER_ERROR"),
-    18: .same(proto: "SEVERITY_NUMBER_ERROR2"),
-    19: .same(proto: "SEVERITY_NUMBER_ERROR3"),
-    20: .same(proto: "SEVERITY_NUMBER_ERROR4"),
-    21: .same(proto: "SEVERITY_NUMBER_FATAL"),
-    22: .same(proto: "SEVERITY_NUMBER_FATAL2"),
-    23: .same(proto: "SEVERITY_NUMBER_FATAL3"),
-    24: .same(proto: "SEVERITY_NUMBER_FATAL4"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SEVERITY_NUMBER_UNSPECIFIED\0\u{1}SEVERITY_NUMBER_TRACE\0\u{1}SEVERITY_NUMBER_TRACE2\0\u{1}SEVERITY_NUMBER_TRACE3\0\u{1}SEVERITY_NUMBER_TRACE4\0\u{1}SEVERITY_NUMBER_DEBUG\0\u{1}SEVERITY_NUMBER_DEBUG2\0\u{1}SEVERITY_NUMBER_DEBUG3\0\u{1}SEVERITY_NUMBER_DEBUG4\0\u{1}SEVERITY_NUMBER_INFO\0\u{1}SEVERITY_NUMBER_INFO2\0\u{1}SEVERITY_NUMBER_INFO3\0\u{1}SEVERITY_NUMBER_INFO4\0\u{1}SEVERITY_NUMBER_WARN\0\u{1}SEVERITY_NUMBER_WARN2\0\u{1}SEVERITY_NUMBER_WARN3\0\u{1}SEVERITY_NUMBER_WARN4\0\u{1}SEVERITY_NUMBER_ERROR\0\u{1}SEVERITY_NUMBER_ERROR2\0\u{1}SEVERITY_NUMBER_ERROR3\0\u{1}SEVERITY_NUMBER_ERROR4\0\u{1}SEVERITY_NUMBER_FATAL\0\u{1}SEVERITY_NUMBER_FATAL2\0\u{1}SEVERITY_NUMBER_FATAL3\0\u{1}SEVERITY_NUMBER_FATAL4\0")
 }
 
 extension Opentelemetry_Proto_Logs_V1_LogRecordFlags: SwiftProtobuf._ProtoNameProviding {
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "LOG_RECORD_FLAGS_DO_NOT_USE"),
-    255: .same(proto: "LOG_RECORD_FLAGS_TRACE_FLAGS_MASK"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0LOG_RECORD_FLAGS_DO_NOT_USE\0\u{2}\u{7f}\u{3}LOG_RECORD_FLAGS_TRACE_FLAGS_MASK\0")
 }
 
 extension Opentelemetry_Proto_Logs_V1_LogsData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".LogsData"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "resource_logs"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_logs\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -476,14 +445,7 @@ extension Opentelemetry_Proto_Logs_V1_LogsData: SwiftProtobuf.Message, SwiftProt
 
 extension Opentelemetry_Proto_Logs_V1_ResourceLogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ResourceLogs"
-  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(
-      reservedNames: [],
-      reservedRanges: [1000..<1001],
-      numberNameMappings: [
-        1: .same(proto: "resource"),
-        2: .standard(proto: "scope_logs"),
-        3: .standard(proto: "schema_url"),
-  ])
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}resource\0\u{3}scope_logs\0\u{3}schema_url\0\u{c}h\u{f}\u{1}")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -527,11 +489,7 @@ extension Opentelemetry_Proto_Logs_V1_ResourceLogs: SwiftProtobuf.Message, Swift
 
 extension Opentelemetry_Proto_Logs_V1_ScopeLogs: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ScopeLogs"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "scope"),
-    2: .standard(proto: "log_records"),
-    3: .standard(proto: "schema_url"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}scope\0\u{3}log_records\0\u{3}schema_url\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -575,21 +533,7 @@ extension Opentelemetry_Proto_Logs_V1_ScopeLogs: SwiftProtobuf.Message, SwiftPro
 
 extension Opentelemetry_Proto_Logs_V1_LogRecord: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".LogRecord"
-  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(
-      reservedNames: [],
-      reservedRanges: [4..<5],
-      numberNameMappings: [
-        1: .standard(proto: "time_unix_nano"),
-        11: .standard(proto: "observed_time_unix_nano"),
-        2: .standard(proto: "severity_number"),
-        3: .standard(proto: "severity_text"),
-        5: .same(proto: "body"),
-        6: .same(proto: "attributes"),
-        7: .standard(proto: "dropped_attributes_count"),
-        8: .same(proto: "flags"),
-        9: .standard(proto: "trace_id"),
-        10: .standard(proto: "span_id"),
-  ])
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}time_unix_nano\0\u{3}severity_number\0\u{3}severity_text\0\u{2}\u{2}body\0\u{1}attributes\0\u{3}dropped_attributes_count\0\u{1}flags\0\u{3}trace_id\0\u{3}span_id\0\u{3}observed_time_unix_nano\0\u{c}\u{4}\u{1}")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/metrics/v1/metrics.pb.swift
+++ b/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/metrics/v1/metrics.pb.swift
@@ -979,7 +979,7 @@ package struct Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: Sendable {
 /// Exemplars also hold information about the environment when the measurement
 /// was recorded, for example the span and trace ID of the active span when the
 /// exemplar was recorded.
-package struct Opentelemetry_Proto_Metrics_V1_Exemplar: @unchecked Sendable {
+package struct Opentelemetry_Proto_Metrics_V1_Exemplar: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -1045,25 +1045,16 @@ package struct Opentelemetry_Proto_Metrics_V1_Exemplar: @unchecked Sendable {
 fileprivate let _protobuf_package = "opentelemetry.proto.metrics.v1"
 
 extension Opentelemetry_Proto_Metrics_V1_AggregationTemporality: SwiftProtobuf._ProtoNameProviding {
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "AGGREGATION_TEMPORALITY_UNSPECIFIED"),
-    1: .same(proto: "AGGREGATION_TEMPORALITY_DELTA"),
-    2: .same(proto: "AGGREGATION_TEMPORALITY_CUMULATIVE"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0AGGREGATION_TEMPORALITY_UNSPECIFIED\0\u{1}AGGREGATION_TEMPORALITY_DELTA\0\u{1}AGGREGATION_TEMPORALITY_CUMULATIVE\0")
 }
 
 extension Opentelemetry_Proto_Metrics_V1_DataPointFlags: SwiftProtobuf._ProtoNameProviding {
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "DATA_POINT_FLAGS_DO_NOT_USE"),
-    1: .same(proto: "DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0DATA_POINT_FLAGS_DO_NOT_USE\0\u{1}DATA_POINT_FLAGS_NO_RECORDED_VALUE_MASK\0")
 }
 
 extension Opentelemetry_Proto_Metrics_V1_MetricsData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".MetricsData"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "resource_metrics"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_metrics\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1093,14 +1084,7 @@ extension Opentelemetry_Proto_Metrics_V1_MetricsData: SwiftProtobuf.Message, Swi
 
 extension Opentelemetry_Proto_Metrics_V1_ResourceMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ResourceMetrics"
-  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(
-      reservedNames: [],
-      reservedRanges: [1000..<1001],
-      numberNameMappings: [
-        1: .same(proto: "resource"),
-        2: .standard(proto: "scope_metrics"),
-        3: .standard(proto: "schema_url"),
-  ])
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}resource\0\u{3}scope_metrics\0\u{3}schema_url\0\u{c}h\u{f}\u{1}")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1144,11 +1128,7 @@ extension Opentelemetry_Proto_Metrics_V1_ResourceMetrics: SwiftProtobuf.Message,
 
 extension Opentelemetry_Proto_Metrics_V1_ScopeMetrics: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ScopeMetrics"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "scope"),
-    2: .same(proto: "metrics"),
-    3: .standard(proto: "schema_url"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}scope\0\u{1}metrics\0\u{3}schema_url\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1192,19 +1172,7 @@ extension Opentelemetry_Proto_Metrics_V1_ScopeMetrics: SwiftProtobuf.Message, Sw
 
 extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Metric"
-  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(
-      reservedNames: [],
-      reservedRanges: [4..<5, 6..<7, 8..<9],
-      numberNameMappings: [
-        1: .same(proto: "name"),
-        2: .same(proto: "description"),
-        3: .same(proto: "unit"),
-        5: .same(proto: "gauge"),
-        7: .same(proto: "sum"),
-        9: .same(proto: "histogram"),
-        10: .standard(proto: "exponential_histogram"),
-        11: .same(proto: "summary"),
-  ])
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}name\0\u{1}description\0\u{1}unit\0\u{2}\u{2}gauge\0\u{2}\u{2}sum\0\u{2}\u{2}histogram\0\u{3}exponential_histogram\0\u{1}summary\0\u{c}\u{4}\u{1}\u{c}\u{6}\u{1}\u{c}\u{8}\u{1}")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1337,9 +1305,7 @@ extension Opentelemetry_Proto_Metrics_V1_Metric: SwiftProtobuf.Message, SwiftPro
 
 extension Opentelemetry_Proto_Metrics_V1_Gauge: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Gauge"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "data_points"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}data_points\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1369,11 +1335,7 @@ extension Opentelemetry_Proto_Metrics_V1_Gauge: SwiftProtobuf.Message, SwiftProt
 
 extension Opentelemetry_Proto_Metrics_V1_Sum: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Sum"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "data_points"),
-    2: .standard(proto: "aggregation_temporality"),
-    3: .standard(proto: "is_monotonic"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}data_points\0\u{3}aggregation_temporality\0\u{3}is_monotonic\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1413,10 +1375,7 @@ extension Opentelemetry_Proto_Metrics_V1_Sum: SwiftProtobuf.Message, SwiftProtob
 
 extension Opentelemetry_Proto_Metrics_V1_Histogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Histogram"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "data_points"),
-    2: .standard(proto: "aggregation_temporality"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}data_points\0\u{3}aggregation_temporality\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1451,10 +1410,7 @@ extension Opentelemetry_Proto_Metrics_V1_Histogram: SwiftProtobuf.Message, Swift
 
 extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ExponentialHistogram"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "data_points"),
-    2: .standard(proto: "aggregation_temporality"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}data_points\0\u{3}aggregation_temporality\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1489,9 +1445,7 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogram: SwiftProtobuf.Mes
 
 extension Opentelemetry_Proto_Metrics_V1_Summary: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Summary"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "data_points"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}data_points\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1521,18 +1475,7 @@ extension Opentelemetry_Proto_Metrics_V1_Summary: SwiftProtobuf.Message, SwiftPr
 
 extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".NumberDataPoint"
-  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(
-      reservedNames: [],
-      reservedRanges: [1..<2],
-      numberNameMappings: [
-        7: .same(proto: "attributes"),
-        2: .standard(proto: "start_time_unix_nano"),
-        3: .standard(proto: "time_unix_nano"),
-        4: .standard(proto: "as_double"),
-        6: .standard(proto: "as_int"),
-        5: .same(proto: "exemplars"),
-        8: .same(proto: "flags"),
-  ])
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{2}start_time_unix_nano\0\u{3}time_unix_nano\0\u{3}as_double\0\u{1}exemplars\0\u{3}as_int\0\u{1}attributes\0\u{1}flags\0\u{c}\u{1}\u{1}")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1609,22 +1552,7 @@ extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint: SwiftProtobuf.Message,
 
 extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".HistogramDataPoint"
-  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(
-      reservedNames: [],
-      reservedRanges: [1..<2],
-      numberNameMappings: [
-        9: .same(proto: "attributes"),
-        2: .standard(proto: "start_time_unix_nano"),
-        3: .standard(proto: "time_unix_nano"),
-        4: .same(proto: "count"),
-        5: .same(proto: "sum"),
-        6: .standard(proto: "bucket_counts"),
-        7: .standard(proto: "explicit_bounds"),
-        8: .same(proto: "exemplars"),
-        10: .same(proto: "flags"),
-        11: .same(proto: "min"),
-        12: .same(proto: "max"),
-  ])
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{2}start_time_unix_nano\0\u{3}time_unix_nano\0\u{1}count\0\u{1}sum\0\u{3}bucket_counts\0\u{3}explicit_bounds\0\u{1}exemplars\0\u{1}attributes\0\u{1}flags\0\u{1}min\0\u{1}max\0\u{c}\u{1}\u{1}")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1708,22 +1636,7 @@ extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint: SwiftProtobuf.Messa
 
 extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ExponentialHistogramDataPoint"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "attributes"),
-    2: .standard(proto: "start_time_unix_nano"),
-    3: .standard(proto: "time_unix_nano"),
-    4: .same(proto: "count"),
-    5: .same(proto: "sum"),
-    6: .same(proto: "scale"),
-    7: .standard(proto: "zero_count"),
-    8: .same(proto: "positive"),
-    9: .same(proto: "negative"),
-    10: .same(proto: "flags"),
-    11: .same(proto: "exemplars"),
-    12: .same(proto: "min"),
-    13: .same(proto: "max"),
-    14: .standard(proto: "zero_threshold"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}attributes\0\u{3}start_time_unix_nano\0\u{3}time_unix_nano\0\u{1}count\0\u{1}sum\0\u{1}scale\0\u{3}zero_count\0\u{1}positive\0\u{1}negative\0\u{1}flags\0\u{1}exemplars\0\u{1}min\0\u{1}max\0\u{3}zero_threshold\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1822,10 +1735,7 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint: SwiftPro
 
 extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.protoMessageName + ".Buckets"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "offset"),
-    2: .standard(proto: "bucket_counts"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}offset\0\u{3}bucket_counts\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1860,18 +1770,7 @@ extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets: 
 
 extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".SummaryDataPoint"
-  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(
-      reservedNames: [],
-      reservedRanges: [1..<2],
-      numberNameMappings: [
-        7: .same(proto: "attributes"),
-        2: .standard(proto: "start_time_unix_nano"),
-        3: .standard(proto: "time_unix_nano"),
-        4: .same(proto: "count"),
-        5: .same(proto: "sum"),
-        6: .standard(proto: "quantile_values"),
-        8: .same(proto: "flags"),
-  ])
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{2}start_time_unix_nano\0\u{3}time_unix_nano\0\u{1}count\0\u{1}sum\0\u{3}quantile_values\0\u{1}attributes\0\u{1}flags\0\u{c}\u{1}\u{1}")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1931,10 +1830,7 @@ extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint: SwiftProtobuf.Message
 
 extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.protoMessageName + ".ValueAtQuantile"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "quantile"),
-    2: .same(proto: "value"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}quantile\0\u{1}value\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1969,17 +1865,7 @@ extension Opentelemetry_Proto_Metrics_V1_SummaryDataPoint.ValueAtQuantile: Swift
 
 extension Opentelemetry_Proto_Metrics_V1_Exemplar: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Exemplar"
-  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(
-      reservedNames: [],
-      reservedRanges: [1..<2],
-      numberNameMappings: [
-        7: .standard(proto: "filtered_attributes"),
-        2: .standard(proto: "time_unix_nano"),
-        3: .standard(proto: "as_double"),
-        6: .standard(proto: "as_int"),
-        4: .standard(proto: "span_id"),
-        5: .standard(proto: "trace_id"),
-  ])
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{4}\u{2}time_unix_nano\0\u{3}as_double\0\u{3}span_id\0\u{3}trace_id\0\u{3}as_int\0\u{3}filtered_attributes\0\u{c}\u{1}\u{1}")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/resource/v1/resource.pb.swift
+++ b/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/resource/v1/resource.pb.swift
@@ -63,10 +63,7 @@ fileprivate let _protobuf_package = "opentelemetry.proto.resource.v1"
 
 extension Opentelemetry_Proto_Resource_V1_Resource: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Resource"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "attributes"),
-    2: .standard(proto: "dropped_attributes_count"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}attributes\0\u{3}dropped_attributes_count\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {

--- a/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/trace/v1/trace.pb.swift
+++ b/Sources/OTel/OTLPCore/Generated/opentelemetry/proto/trace/v1/trace.pb.swift
@@ -134,7 +134,7 @@ package struct Opentelemetry_Proto_Trace_V1_ScopeSpans: Sendable {
 /// A Span represents a single operation performed by a single component of the system.
 ///
 /// The next available field id is 17.
-package struct Opentelemetry_Proto_Trace_V1_Span: @unchecked Sendable {
+package struct Opentelemetry_Proto_Trace_V1_Span: Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
@@ -349,7 +349,7 @@ package struct Opentelemetry_Proto_Trace_V1_Span: @unchecked Sendable {
   /// different trace. For example, this can be used in batching operations,
   /// where a single batch handler processes multiple requests from different
   /// traces or when the handler receives a request from a different project.
-  package struct Link: @unchecked Sendable {
+  package struct Link: Sendable {
     // SwiftProtobuf.Message conformance is added in an extension below. See the
     // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
     // methods supported on all messages.
@@ -454,9 +454,7 @@ fileprivate let _protobuf_package = "opentelemetry.proto.trace.v1"
 
 extension Opentelemetry_Proto_Trace_V1_TracesData: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".TracesData"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "resource_spans"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}resource_spans\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -486,14 +484,7 @@ extension Opentelemetry_Proto_Trace_V1_TracesData: SwiftProtobuf.Message, SwiftP
 
 extension Opentelemetry_Proto_Trace_V1_ResourceSpans: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ResourceSpans"
-  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(
-      reservedNames: [],
-      reservedRanges: [1000..<1001],
-      numberNameMappings: [
-        1: .same(proto: "resource"),
-        2: .standard(proto: "scope_spans"),
-        3: .standard(proto: "schema_url"),
-  ])
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}resource\0\u{3}scope_spans\0\u{3}schema_url\0\u{c}h\u{f}\u{1}")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -537,11 +528,7 @@ extension Opentelemetry_Proto_Trace_V1_ResourceSpans: SwiftProtobuf.Message, Swi
 
 extension Opentelemetry_Proto_Trace_V1_ScopeSpans: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".ScopeSpans"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .same(proto: "scope"),
-    2: .same(proto: "spans"),
-    3: .standard(proto: "schema_url"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}scope\0\u{1}spans\0\u{3}schema_url\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -585,23 +572,7 @@ extension Opentelemetry_Proto_Trace_V1_ScopeSpans: SwiftProtobuf.Message, SwiftP
 
 extension Opentelemetry_Proto_Trace_V1_Span: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Span"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "trace_id"),
-    2: .standard(proto: "span_id"),
-    3: .standard(proto: "trace_state"),
-    4: .standard(proto: "parent_span_id"),
-    5: .same(proto: "name"),
-    6: .same(proto: "kind"),
-    7: .standard(proto: "start_time_unix_nano"),
-    8: .standard(proto: "end_time_unix_nano"),
-    9: .same(proto: "attributes"),
-    10: .standard(proto: "dropped_attributes_count"),
-    11: .same(proto: "events"),
-    12: .standard(proto: "dropped_events_count"),
-    13: .same(proto: "links"),
-    14: .standard(proto: "dropped_links_count"),
-    15: .same(proto: "status"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}trace_id\0\u{3}span_id\0\u{3}trace_state\0\u{3}parent_span_id\0\u{1}name\0\u{1}kind\0\u{3}start_time_unix_nano\0\u{3}end_time_unix_nano\0\u{1}attributes\0\u{3}dropped_attributes_count\0\u{1}events\0\u{3}dropped_events_count\0\u{1}links\0\u{3}dropped_links_count\0\u{1}status\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -704,24 +675,12 @@ extension Opentelemetry_Proto_Trace_V1_Span: SwiftProtobuf.Message, SwiftProtobu
 }
 
 extension Opentelemetry_Proto_Trace_V1_Span.SpanKind: SwiftProtobuf._ProtoNameProviding {
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "SPAN_KIND_UNSPECIFIED"),
-    1: .same(proto: "SPAN_KIND_INTERNAL"),
-    2: .same(proto: "SPAN_KIND_SERVER"),
-    3: .same(proto: "SPAN_KIND_CLIENT"),
-    4: .same(proto: "SPAN_KIND_PRODUCER"),
-    5: .same(proto: "SPAN_KIND_CONSUMER"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0SPAN_KIND_UNSPECIFIED\0\u{1}SPAN_KIND_INTERNAL\0\u{1}SPAN_KIND_SERVER\0\u{1}SPAN_KIND_CLIENT\0\u{1}SPAN_KIND_PRODUCER\0\u{1}SPAN_KIND_CONSUMER\0")
 }
 
 extension Opentelemetry_Proto_Trace_V1_Span.Event: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = Opentelemetry_Proto_Trace_V1_Span.protoMessageName + ".Event"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "time_unix_nano"),
-    2: .same(proto: "name"),
-    3: .same(proto: "attributes"),
-    4: .standard(proto: "dropped_attributes_count"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}time_unix_nano\0\u{1}name\0\u{1}attributes\0\u{3}dropped_attributes_count\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -766,13 +725,7 @@ extension Opentelemetry_Proto_Trace_V1_Span.Event: SwiftProtobuf.Message, SwiftP
 
 extension Opentelemetry_Proto_Trace_V1_Span.Link: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = Opentelemetry_Proto_Trace_V1_Span.protoMessageName + ".Link"
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    1: .standard(proto: "trace_id"),
-    2: .standard(proto: "span_id"),
-    3: .standard(proto: "trace_state"),
-    4: .same(proto: "attributes"),
-    5: .standard(proto: "dropped_attributes_count"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}trace_id\0\u{3}span_id\0\u{3}trace_state\0\u{1}attributes\0\u{3}dropped_attributes_count\0")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -822,13 +775,7 @@ extension Opentelemetry_Proto_Trace_V1_Span.Link: SwiftProtobuf.Message, SwiftPr
 
 extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   package static let protoMessageName: String = _protobuf_package + ".Status"
-  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(
-      reservedNames: [],
-      reservedRanges: [1..<2],
-      numberNameMappings: [
-        2: .same(proto: "message"),
-        3: .same(proto: "code"),
-  ])
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\u{2}message\0\u{1}code\0\u{c}\u{1}\u{1}")
 
   package mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -862,10 +809,6 @@ extension Opentelemetry_Proto_Trace_V1_Status: SwiftProtobuf.Message, SwiftProto
 }
 
 extension Opentelemetry_Proto_Trace_V1_Status.StatusCode: SwiftProtobuf._ProtoNameProviding {
-  package static let _protobuf_nameMap: SwiftProtobuf._NameMap = [
-    0: .same(proto: "STATUS_CODE_UNSET"),
-    1: .same(proto: "STATUS_CODE_OK"),
-    2: .same(proto: "STATUS_CODE_ERROR"),
-  ]
+  package static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{2}\0STATUS_CODE_UNSET\0\u{1}STATUS_CODE_OK\0\u{1}STATUS_CODE_ERROR\0")
 }
 #endif


### PR DESCRIPTION
## Motivation

Building with Swift OTel with the newly released Swift Protobuf 1.31.0` produced a couple of instances of this build warning:

> warning: 'init(dictionaryLiteral:)' is deprecated: Please regenerate your .pb.swift files with the current version of the SwiftProtobuf protoc plugin. [#DeprecatedDeclaration]

We recently configured our CI to treat warnings as errors so it started failing unit test jobs.

As suggested, these warnings are fixed by re-generating.

## Modifications

- Re-generate Swift files based on latest Swift Protobuf release

## Result

The project compiles without warnings and therefore makes the unit tests pass again on CI.