### PR TITLE
Use container jobs instead of Swiftly in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ concurrency:
 jobs:
   soundness:
     name: Soundness Check
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -24,21 +24,17 @@ jobs:
 
   unit-test:
     name: Unit Test
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        swift: ["latest", "6.2-snapshot"]
+        image: ["swift:6.1-noble", "swiftlang/swift:nightly-6.2-jammy"]
+
+    container:
+      image: ${{ matrix.image }}
 
     steps:
-      - name: Install Swift
-        uses: vapor/swiftly-action@v0.2.0
-        with:
-          toolchain: ${{ matrix.swift }}
-        env:
-          SWIFTLY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Checkout
         uses: actions/checkout@v5.0.0
 
@@ -110,8 +106,10 @@ jobs:
     strategy:
       matrix:
         example: ${{ fromJSON(needs.construct-examples-matrix.outputs.examples) }}
-        swift: ["6.1", "6.2-snapshot"]
+        image: ["swift:6.1-noble", "swiftlang/swift:nightly-6.2-jammy"]
       fail-fast: false
+    container:
+      image: ${{ matrix.image }}
     defaults:
       run:
         working-directory: ${{ matrix.example }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
     container:
       image: ${{ matrix.swift.image }}
-      options: --network host
+      options: --dns 1.1.1.1 --dns 8.8.8.8
 
     steps:
       - name: Checkout
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: swift:6.1-noble
-      options: --network host
+      options: --dns 1.1.1.1 --dns 8.8.8.8
     steps:
       - uses: actions/checkout@v5.0.0
       - name: Run documentation check
@@ -120,7 +120,7 @@ jobs:
       fail-fast: false
     container:
       image: ${{ matrix.swift.image }}
-      options: --network host
+      options: --dns 1.1.1.1 --dns 8.8.8.8
     defaults:
       run:
         working-directory: ${{ matrix.example }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
       matrix:
         swift:
           - version: "6.1"
-            image: swift:6.1
+            image: swift:6.1-rhel-ubi9
           - version: "6.2-snapshot"
-            image: swiftlang/swift:nightly-6.2-jammy
+            image: swiftlang/swift:nightly-6.2-rhel-ubi9
 
     container:
       image: ${{ matrix.swift.image }}
@@ -112,9 +112,9 @@ jobs:
         example: ${{ fromJSON(needs.construct-examples-matrix.outputs.examples) }}
         swift:
           - version: "6.1"
-            image: swift:6.1
+            image: swift:6.1-rhel-ubi9
           - version: "6.2-snapshot"
-            image: swiftlang/swift:nightly-6.2-jammy
+            image: swiftlang/swift:nightly-6.2-rhel-ubi9
       fail-fast: false
     container:
       image: ${{ matrix.swift.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         swift:
           - version: "6.1"
-            image: swift:6.1-noble
+            image: swift:6.1
           - version: "6.2-snapshot"
             image: swiftlang/swift:nightly-6.2-jammy
 
@@ -112,7 +112,7 @@ jobs:
         example: ${{ fromJSON(needs.construct-examples-matrix.outputs.examples) }}
         swift:
           - version: "6.1"
-            image: swift:6.1-noble
+            image: swift:6.1
           - version: "6.2-snapshot"
             image: swiftlang/swift:nightly-6.2-jammy
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,16 +23,20 @@ jobs:
           exit $(git status --porcelain | wc -l)
 
   unit-test:
-    name: Unit Test
+    name: Unit Test (Swift ${{ matrix.swift.version }})
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        image: ["swift:6.1-noble", "swiftlang/swift:nightly-6.2-jammy"]
+        swift:
+          - version: "6.1"
+            image: swift:6.1-noble
+          - version: "6.2-snapshot"
+            image: swiftlang/swift:nightly-6.2-jammy
 
     container:
-      image: ${{ matrix.image }}
+      image: ${{ matrix.swift.image }}
 
     steps:
       - name: Checkout
@@ -45,7 +49,7 @@ jobs:
         run: swift test -Xswiftc -warnings-as-errors --enable-code-coverage
 
       - name: Merge code coverage
-        if: matrix.swift == 'latest'
+        if: matrix.swift.version == '6.1'
         run: |
           llvm-cov export -format "lcov" \
             .build/debug/swift-otelPackageTests.xctest \
@@ -56,7 +60,7 @@ jobs:
           > info.lcov
 
       - name: Upload code coverage report to Codecov
-        if: matrix.swift == 'latest'
+        if: matrix.swift.version == '6.1'
         uses: codecov/codecov-action@v5.5.0
         with:
           files: ./info.lcov
@@ -100,26 +104,24 @@ jobs:
           | tee -a $GITHUB_OUTPUT # format: examples=["Examples/a", "Examples/b"]
 
   test-examples:
-    name: Example Package
+    name: Example Package (Swift ${{ matrix.swift.version }}, ${{ matrix.example }})
     runs-on: ubuntu-latest
     needs: construct-examples-matrix
     strategy:
       matrix:
         example: ${{ fromJSON(needs.construct-examples-matrix.outputs.examples) }}
-        image: ["swift:6.1-noble", "swiftlang/swift:nightly-6.2-jammy"]
+        swift:
+          - version: "6.1"
+            image: swift:6.1-noble
+          - version: "6.2-snapshot"
+            image: swiftlang/swift:nightly-6.2-jammy
       fail-fast: false
     container:
-      image: ${{ matrix.image }}
+      image: ${{ matrix.swift.image }}
     defaults:
       run:
         working-directory: ${{ matrix.example }}
     steps:
-      - name: Install Swift
-        uses: vapor/swiftly-action@v0.2.0
-        with:
-          toolchain: ${{ matrix.swift }}
-        env:
-          SWIFTLY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v5.0.0
       - name: Override example package dependency on root package
         run: swift package edit swift-otel --path ${{ github.workspace }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
 
     container:
       image: ${{ matrix.swift.image }}
+      options: --network host
 
     steps:
       - name: Checkout
@@ -73,6 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: swift:6.1-noble
+      options: --network host
     steps:
       - uses: actions/checkout@v5.0.0
       - name: Run documentation check
@@ -118,6 +120,7 @@ jobs:
       fail-fast: false
     container:
       image: ${{ matrix.swift.image }}
+      options: --network host
     defaults:
       run:
         working-directory: ${{ matrix.example }}


### PR DESCRIPTION
## Motivation

The CI run times are a little unpredictable and it seems that a variable amount of time is spent installing Swift from Swiftly. In the best case this is still quite some time and time we needn't spend if we used the Swift container images.

## Modifications

Move CI to use the `swift` and `swiftlang/nightly-swift` images.

## Result

Faster, less variable CI.