### PR TITLE
Enable benchmarks CI on PRs to main

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,7 +18,6 @@ env:
 
 jobs:
   benchmark:
-    if: false  # disabled until main has working benchmaks merged
     name: Check benchmark regressions (Swift ${{ matrix.swift.version }})
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
## Motivation

We updated the benchmarks and added CI config in #345. But, because that CI tests PRs against main, we needed main to actually have the benchmarks. Thus, that PR landed the CI in disabled state. Now it's merged, we can enable it.

## Modifications

Enable the benchmarks CI on main.

## Result

PRs to main will have CI that reports whether benchmarks have regressed.

## Notes

We should see the result of this pipeline on _this_ PR to see it's working before merging.