### PR TITLE
Update 6.2 matrix jobs to 6.2 release image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
         swift:
           - version: "6.1"
             image: swift:6.1-rhel-ubi9
-          - version: "6.2-snapshot"
-            image: swiftlang/swift:nightly-6.2-rhel-ubi9
+          - version: "6.2"
+            image: swift:6.2-rhel-ubi9
 
     container:
       image: ${{ matrix.swift.image }}
@@ -118,8 +118,8 @@ jobs:
         swift:
           - version: "6.1"
             image: swift:6.1-rhel-ubi9
-          - version: "6.2-snapshot"
-            image: swiftlang/swift:nightly-6.2-rhel-ubi9
+          - version: "6.2"
+            image: swift:6.2-rhel-ubi9
       fail-fast: false
     container:
       image: ${{ matrix.swift.image }}


### PR DESCRIPTION
## Motivation

We have been CI'ing against Swift 6.1 and a nightly snapshot of Swift 6.2 for a while. Swift 6.2 has now been released so we should move to the released version for CI.

## Modifications

- Update 6.2 matrix jobs to 6.2 release image

## Result

CI now uses released Swift 6.2 instead of nightly snapshot.
