### PR TITLE
Combine coverage from matrix jobs of all Swift versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
         run: swift test --enable-code-coverage
 
       - name: Merge code coverage
-        if: matrix.swift.version == '6.1'
         run: |
           llvm-cov export -format "lcov" \
             .build/debug/swift-otelPackageTests.xctest \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
           > info.lcov
 
       - name: Upload code coverage report to Codecov
-        if: matrix.swift.version == '6.1'
         uses: codecov/codecov-action@v5.5.1
         with:
           files: ./info.lcov


### PR DESCRIPTION
## Motivation

We have a coverage report generated at the end of the unit test pipeline, but only for Swift 6.1. However, we have a bunch of tests that make use of features that are only in Swift Testing from 6.2 toolchains, so these currently do not contribute to the coverage result. Now Swift 6.2 is released, it seems reasonable that we should include these too.

## Modifications

- Combine coverage from matrix jobs of all Swift versions

## Result

Coverage result should now include tests that require Swift 6.2.