### PR TITLE
Add support for histogram min and max values

### DIFF
--- a/Sources/OTel/OTelCore/Metrics/OTelInstrument/Histogram+OTelInstrument.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelInstrument/Histogram+OTelInstrument.swift
@@ -38,8 +38,8 @@ extension Histogram: OTelMetricInstrument {
                     timeNanosecondsSinceEpoch: instant.nanosecondsSinceEpoch,
                     count: UInt64(state.count),
                     sum: state.sum.bucketRepresentation,
-                    min: nil,
-                    max: nil,
+                    min: state.min?.bucketRepresentation,
+                    max: state.max?.bucketRepresentation,
                     buckets: state.buckets.map {
                         .init(
                             upperBound: $0.bound.bucketRepresentation,

--- a/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
+++ b/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
@@ -304,8 +304,8 @@ import Tracing
                     switch recorder.data {
                     case .histogram(let histogram):
                         #expect(histogram.dataPoints.count == 1)
-                        #expect(histogram.dataPoints.first?.min == 0) // Swift OTel doesn't support this yet.
-                        #expect(histogram.dataPoints.first?.max == 0) // Swift OTel doesn't support this yet.
+                        #expect(histogram.dataPoints.first?.min == 41)
+                        #expect(histogram.dataPoints.first?.max == 43)
                         #expect(histogram.dataPoints.first?.sum == 42.0 + 41.0 + 43.0)
                         #expect(histogram.dataPoints.first?.explicitBounds == [0, 42.0, .infinity])
                         #expect(histogram.dataPoints.first?.bucketCounts == [0, 2, 1])
@@ -316,8 +316,8 @@ import Tracing
                     switch timer.data {
                     case .histogram(let histogram):
                         #expect(histogram.dataPoints.count == 1)
-                        #expect(histogram.dataPoints.first?.min == 0) // Swift OTel doesn't support this yet.
-                        #expect(histogram.dataPoints.first?.max == 0) // Swift OTel doesn't support this yet.
+                        #expect(histogram.dataPoints.first?.min == 41e-6)
+                        #expect(histogram.dataPoints.first?.max == 43e-6)
                         #expect(histogram.dataPoints.first?.sum == 42e-6 + 41e-6 + 43e-6)
                         #expect(histogram.dataPoints.first?.explicitBounds == [0, 42e-6, .infinity])
                         #expect(histogram.dataPoints.first?.bucketCounts == [0, 2, 1])
@@ -428,8 +428,8 @@ import Tracing
                     switch recorder.data {
                     case .histogram(let histogram):
                         #expect(histogram.dataPoints.count == 1)
-                        #expect(histogram.dataPoints.first?.min == 0) // Swift OTel doesn't support this yet.
-                        #expect(histogram.dataPoints.first?.max == 0) // Swift OTel doesn't support this yet.
+                        #expect(histogram.dataPoints.first?.min == 41)
+                        #expect(histogram.dataPoints.first?.max == 43)
                         #expect(histogram.dataPoints.first?.sum == 42.0 + 41.0 + 43.0)
                         #expect(histogram.dataPoints.first?.explicitBounds == [0, 42.0, .infinity])
                         #expect(histogram.dataPoints.first?.bucketCounts == [0, 2, 1])
@@ -440,8 +440,8 @@ import Tracing
                     switch timer.data {
                     case .histogram(let histogram):
                         #expect(histogram.dataPoints.count == 1)
-                        #expect(histogram.dataPoints.first?.min == 0) // Swift OTel doesn't support this yet.
-                        #expect(histogram.dataPoints.first?.max == 0) // Swift OTel doesn't support this yet.
+                        #expect(histogram.dataPoints.first?.min == 41e-6)
+                        #expect(histogram.dataPoints.first?.max == 43e-6)
                         #expect(histogram.dataPoints.first?.sum == 42e-6 + 41e-6 + 43e-6)
                         #expect(histogram.dataPoints.first?.explicitBounds == [0, 42e-6, .infinity])
                         #expect(histogram.dataPoints.first?.bucketCounts == [0, 2, 1])


### PR DESCRIPTION
## Motivation

The internal histogram type only keeps track of the running total and bucket counts. It does not keep track of the min and max value seen. When exporting over OTLP, it therefore only includes the `sum` and bucket counts. The `min` and `max` fields are left unset (which results in 0 values).

## Modifications

- Add support for histogram min and max values
- Update tests to check for min and max histogram values

## Result

OTLP export of histogram metrics includes min and max values.