### PR TITLE
Add workaround for trait-based dependencies in broken 6.2.x toolchains

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -63,21 +63,15 @@ let package = Package(
                 .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
                 .product(name: "Atomics", package: "swift-atomics"),
                 .product(name: "W3CTraceContext", package: "swift-w3c-trace-context"),
-                /// NOTE: Using `.when(traits: ["A", "B"])` is supposed to work as an OR, but is currently broken.
-                ///       so we "splat" it into two conditional dependencies. This produces a build warning about a
-                ///       duplicate dependency when both traits are enabled (which is the default, too), but it's the
-                ///       best we can do until the SwiftPM issue is addressed.
-                // Depend on this if either trait is enabled.
-                // .product(name: "SwiftProtobuf", package: "swift-protobuf", condition: .when(traits: ["OTLPHTTP", "OTLPGRPC"])),
-                .product(name: "SwiftProtobuf", package: "swift-protobuf", condition: .when(traits: ["OTLPHTTP"])),
-                .product(name: "SwiftProtobuf", package: "swift-protobuf", condition: .when(traits: ["OTLPGRPC"])),
+                // OTLP exporter -- only when OTLPHTTP and/or OTLPGRPC traits are enabled.
+                .product(name: "SwiftProtobuf", package: "swift-protobuf", condition: .when(traits: ["OTLPHTTP", "OTLPGRPC"], alwaysIncludeOnKnownBrokenToolchains: true)),
                 // OTLP/HTTP exporter -- only when OTLPHTTP trait is enabled.
-                .product(name: "AsyncHTTPClient", package: "async-http-client", condition: .when(traits: ["OTLPHTTP"])),
-                .product(name: "NIOSSL", package: "swift-nio-ssl", condition: .when(traits: ["OTLPHTTP"])),
+                .product(name: "AsyncHTTPClient", package: "async-http-client", condition: .when(traits: ["OTLPHTTP"], alwaysIncludeOnKnownBrokenToolchains: true)),
+                .product(name: "NIOSSL", package: "swift-nio-ssl", condition: .when(traits: ["OTLPHTTP"], alwaysIncludeOnKnownBrokenToolchains: true)),
                 // OTLP/GRPC exporter -- only when OTLPGRPC trait is enabled.
-                .product(name: "GRPCProtobuf", package: "grpc-swift-protobuf", condition: .when(traits: ["OTLPGRPC"])),
-                .product(name: "GRPCCore", package: "grpc-swift-2", condition: .when(traits: ["OTLPGRPC"])),
-                .product(name: "GRPCNIOTransportHTTP2", package: "grpc-swift-nio-transport", condition: .when(traits: ["OTLPGRPC"])),
+                .product(name: "GRPCProtobuf", package: "grpc-swift-protobuf", condition: .when(traits: ["OTLPGRPC"], alwaysIncludeOnKnownBrokenToolchains: true)),
+                .product(name: "GRPCCore", package: "grpc-swift-2", condition: .when(traits: ["OTLPGRPC"], alwaysIncludeOnKnownBrokenToolchains: true)),
+                .product(name: "GRPCNIOTransportHTTP2", package: "grpc-swift-nio-transport", condition: .when(traits: ["OTLPGRPC"], alwaysIncludeOnKnownBrokenToolchains: true)),
             ],
             swiftSettings: sharedSwiftSettings
         ),
@@ -93,6 +87,22 @@ let package = Package(
     ],
     swiftLanguageModes: [.v6]
 )
+
+extension TargetDependencyCondition {
+    static func when(traits: Set<String>, alwaysIncludeOnKnownBrokenToolchains: Bool) -> Self? {
+        if alwaysIncludeOnKnownBrokenToolchains {
+            // NOTE: Once 6.2.1 has been out for some reasonable time, we could potentially remove this workaround.
+            // See: https://github.com/swiftlang/swift-package-manager/pull/9141
+            #if compiler(>=6.2.0) && compiler(<6.2.1)
+            return nil
+            #else
+            return .when(traits: traits)
+            #endif
+        } else {
+            return .when(traits: traits)
+        }
+    }
+}
 
 /// A set of related platform requirements to prevent version drift in availability annotations and package platforms.
 struct PlatformRequirements {

--- a/scripts/check-example-dependencies.sh
+++ b/scripts/check-example-dependencies.sh
@@ -21,7 +21,7 @@ fatal() { error "$@"; exit 1; }
 current_script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 repo_root="$(git -C "${current_script_dir}" rev-parse --show-toplevel)"
 
-if [ "${PWD}" == "${repo_root}" ] || [ ! -r "${PWD}/Package.resolved" ]; then
+if [ "${PWD}" == "${repo_root}" ] || [ ! -r "${PWD}/Package.swift" ]; then
   fatal "This script should be run from the package root of an example projects _after_ building."
 fi
 


### PR DESCRIPTION
## Motivation

We had a workaround in our package manifest for the use of `.when(traits:)` not using its argument as a boolean-OR. The good news is that this bug has been addressed and the fix available in the 6.2.0 release. The bad news is that there was still an issue with resolving dependencies that themselves had trait-conditional transitive dependencies, and the fix for that did _not_ make the Xcode 26.0 release.

The outcome is that if you were to try to compile a project that depends on Swift OTel with _only_ the `OTLPHTTP` trait, it will fail to resolve. We have such an example in our `Examples/` directory:

```console
% rm -rf .build Package.resolved && swift build
...
error: 'swift-otel': product 'SwiftProtobuf' required by package 'swift-otel' target 'OTel' not found in package 'swift-protobuf'.
```

The fix is included in the nightly main, and I have verified that works. It also has been cherry-picked into 6.2.1 here: https://github.com/swiftlang/swift-package-manager/pull/9141. So it is just 6.2.0 that's the problem.

Fortunately, all our trait-conditional dependencies are only used with `internal import`, which means we can add a workaround without having to make a future API-breaking change.

We can just unconditionally include these dependencies on the known problematic toolchain (6.2.0).

## Modifications

- Add 6.2.0-specific workaround for trait-conditional dependencies

## Result

Packages that depend on Swift OTel with only `OTLPHTTP` trait will now compile with Xcode 26.0 toolchains.
