### PR TITLE
Prepare docs and examples for 1.0.0 release

### DIFF
--- a/Examples/hello-world-grafana-lgtm/Package.swift
+++ b/Examples/hello-world-grafana-lgtm/Package.swift
@@ -7,8 +7,7 @@ let package = Package(
     platforms: [.macOS(.v15)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
-        // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2", traits: ["OTLPGRPC"]),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0", traits: ["OTLPGRPC"]),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-logging-metadata-provider/Package.swift
+++ b/Examples/hello-world-hummingbird-server-logging-metadata-provider/Package.swift
@@ -7,8 +7,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
-        // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-mtls/Package.swift
+++ b/Examples/hello-world-hummingbird-server-mtls/Package.swift
@@ -7,8 +7,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
-        // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-only-traces/Package.swift
+++ b/Examples/hello-world-hummingbird-server-only-traces/Package.swift
@@ -7,8 +7,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
-        // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-otlp-grpc/Package.swift
+++ b/Examples/hello-world-hummingbird-server-otlp-grpc/Package.swift
@@ -7,8 +7,7 @@ let package = Package(
     platforms: [.macOS(.v15)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
-        // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2", traits: ["OTLPGRPC"]),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0", traits: ["OTLPGRPC"]),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-otlp-http-json/Package.swift
+++ b/Examples/hello-world-hummingbird-server-otlp-http-json/Package.swift
@@ -7,8 +7,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
-        // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2", traits: ["OTLPHTTP"]),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0", traits: ["OTLPHTTP"]),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-otlp-http-protobuf/Package.swift
+++ b/Examples/hello-world-hummingbird-server-otlp-http-protobuf/Package.swift
@@ -7,8 +7,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
-        // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2", traits: ["OTLPHTTP"]),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0", traits: ["OTLPHTTP"]),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-hummingbird-server-tls/Package.swift
+++ b/Examples/hello-world-hummingbird-server-tls/Package.swift
@@ -7,8 +7,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     dependencies: [
         .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
-        // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Examples/hello-world-vapor-server-otlp-http-protobuf/Package.swift
+++ b/Examples/hello-world-vapor-server-otlp-http-protobuf/Package.swift
@@ -7,8 +7,7 @@ let package = Package(
     platforms: [.macOS(.v13)],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.115.0"),
-        // TODO: update this to `from: 1.0.0` when we release 1.0.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.2", traits: ["OTLPHTTP"]),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0", traits: ["OTLPHTTP"]),
     ],
     targets: [
         .executableTarget(

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ let package = Package(
     dependencies: [
         // ...
         // NOTE: this will use `from: "1.0.0"` once its available.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(

--- a/Sources/OTel/Docs.docc/Swift-OTel.md
+++ b/Sources/OTel/Docs.docc/Swift-OTel.md
@@ -36,7 +36,7 @@ let package = Package(
     dependencies: [
         // ...
         // NOTE: this will use `from: "1.0.0"` once its available.
-        .package(url: "https://github.com/swift-otel/swift-otel.git", exact: "1.0.0-alpha.1"),
+        .package(url: "https://github.com/swift-otel/swift-otel.git", from: "1.0.0"),
     ],
     targets: [
         .executableTarget(


### PR DESCRIPTION
## Motivation

We're close to tagging the 1.0 release. It would be good if the repo, at this tag, had all the examples and documentation updated as if the tag was available. For that, we'll need to update them just prior to tagging.

## Modifications

- Update docs to use `from: "1.0.0"`
- Update examples to use `from: "1.0.0"`

## Result

Docs and examples show how to depend on Swift OTel in a post-1.0 world.