### PR TITLE
Fix expression used in GitHub actions YAML to skip PR comment

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -118,7 +118,7 @@ jobs:
           set -e
 
       - name: Comment PR (if from non-fork)
-        if: ${{ env.hasBenchmark == '1' github.event.pull_request.head.repo.fork == false }}
+        if: ${{ env.hasBenchmark == '1' && github.event.pull_request.head.repo.fork == false }}
         uses: thollander/actions-comment-pull-request@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Motivation

The GitHub Actions YAML expression used to skip posting a PR comment on PRs from forks was incorrect, which caused the pipeline to show as a false error.

## Modifications

- Fix expression used in GitHub actions YAML to skip PR comment

## Result

PRs from forks don't result in a PR comment from the benchmark CI.