### PR TITLE
Add DocC curation for otelTraceID ServiceContext property

### DIFF
--- a/Sources/OTel/Docs.docc/OTel.md
+++ b/Sources/OTel/Docs.docc/OTel.md
@@ -16,3 +16,7 @@
 - ``makeMetricsBackend(configuration:)``
 - ``makeTracingBackend(configuration:)``
 - ``makeLoggingMetadataProvider(configuration:)``
+
+### Trace ID
+
+- ``ServiceContextModule/ServiceContext/otelTraceID``


### PR DESCRIPTION
## Motivation

Symbols that haven't been _curated_ in the DocC bundle hang out in an automatic section. In the case of the trace ID context property, it gets lumped into _extensions on other modules_, but it'd be nice to have it categorised in the sidebar, since it's the only thing that is not.

## Modification

Curate `ServiceContext.otelTraceID` in DocC

## Result

Docs better organised.