### PR TITLE
Add description to package traits in manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
         .library(name: "OTel", targets: ["OTel"]),
     ],
     traits: [
-        .trait(name: "OTLPHTTP"),
-        .trait(name: "OTLPGRPC"),
+        .trait(name: "OTLPHTTP", description: "OTLP/HTTP exporter support"),
+        .trait(name: "OTLPGRPC", description: "OTLP/gRPC exporter support"),
         .default(enabledTraits: ["OTLPHTTP", "OTLPGRPC"]),
     ],
     dependencies: [


### PR DESCRIPTION
## Motivation

The package uses two traits, `OTLPHTTP` and `OTLPGRPC`, which are used to conditionally provide OTLP/HTTP and OTLP/gRPC exporter support, respectively (both enabled by default). The package manifest API for declaring traits supports a string description, which we were not using, but could to help adopters.

## Modifications

- Add description to package traits in manifest

## Result

Package traits have accompanying description.
