### PR TITLE
Update attributes used in log handler to latest semantic conventions

### DIFF
--- a/Sources/OTel/OTelCore/Logging/OTelLogHandler.swift
+++ b/Sources/OTel/OTelCore/Logging/OTelLogHandler.swift
@@ -68,9 +68,9 @@ struct OTelLogHandler: Sendable, LogHandler {
         line: UInt
     ) {
         let codeMetadata: Logger.Metadata = [
-            "code.filepath": "\(file)",
-            "code.function": "\(function)",
-            "code.lineno": "\(line)",
+            "code.file.path": "\(file)",
+            "code.function.name": "\(function)",
+            "code.line.number": "\(line)",
         ]
 
         let effectiveMetadata: Logger.Metadata


### PR DESCRIPTION
## Motivation

The log handler is adding some attributes for file, line, and function to the OTLP log record, based on the OTel Semantic Conventions. When these were added, these attributes were not stable and have since changed.

This can cause problems with more recent OTel Collectors that try to process these attributes as part of exporting.

The good news is that they _are_ now stable, so we can continue to set them, using the updated names.

## Modification

Update attributes used in log handler to latest semantic conventions:
- `code.filepath` -> `code.file.path`
- `code.function` -> `code.function.name`
- `code.lineno` -> `code.line.number`

## Result

OTLP log records now include stable semantic convention attirbutes for file, line number, and function.