### PR TITLE
Log bootstrap at info and downgrade all other logging to debug

### DIFF
--- a/Sources/OTel/OTelCore/Logging/Processing/Batch/OTelBatchLogRecordProcessor.swift
+++ b/Sources/OTel/OTelCore/Logging/Processing/Batch/OTelBatchLogRecordProcessor.swift
@@ -69,7 +69,7 @@ actor OTelBatchLogRecordProcessor<Exporter: OTelLogRecordExporter, Clock: _Concu
     }
 
     func run() async throws {
-        logger.info("Starting.")
+        logger.debug("Starting.")
         let timerSequence = AsyncTimerSequence(interval: configuration.scheduleDelay, clock: clock).map { _ in }
         let mergedSequence = merge(timerSequence, explicitTickStream).cancelOnGracefulShutdown()
 
@@ -88,13 +88,13 @@ actor OTelBatchLogRecordProcessor<Exporter: OTelLogRecordExporter, Clock: _Concu
                 }
                 await taskGroup.waitForAll()
             } onGracefulShutdown: {
-                self.logger.info("Shutting down.")
+                self.logger.debug("Shutting down.")
                 self.logContinuation.finish()
                 self.explicitTick.finish()
             }
             try? await self.forceFlush()
             await self.exporter.shutdown()
-            self.logger.info("Shut down.")
+            self.logger.debug("Shut down.")
         }
     }
 
@@ -103,7 +103,7 @@ actor OTelBatchLogRecordProcessor<Exporter: OTelLogRecordExporter, Clock: _Concu
             logger.debug("Skipping force flush: buffer is empty")
             return
         }
-        logger.info("Force flushing.", metadata: ["buffer_size": "\(buffer.count)"])
+        logger.debug("Force flushing.", metadata: ["buffer_size": "\(buffer.count)"])
         try await withTimeout(configuration.exportTimeout, clock: clock) {
             await withTaskGroup { group in
                 var buffer = self.buffer

--- a/Sources/OTel/OTelCore/Logging/Processing/OTelSimpleLogRecordProcessor.swift
+++ b/Sources/OTel/OTelCore/Logging/Processing/OTelSimpleLogRecordProcessor.swift
@@ -27,7 +27,7 @@ struct OTelSimpleLogRecordProcessor<Exporter: OTelLogRecordExporter>: OTelLogRec
     }
 
     func run() async throws {
-        logger.info("Starting.")
+        logger.debug("Starting.")
         await withGracefulShutdownHandler {
             for await record in stream {
                 do {
@@ -38,11 +38,11 @@ struct OTelSimpleLogRecordProcessor<Exporter: OTelLogRecordExporter>: OTelLogRec
                 }
             }
         } onGracefulShutdown: {
-            logger.info("Shutting down.")
+            logger.debug("Shutting down.")
             continuation.finish()
         }
         await exporter.shutdown()
-        logger.info("Shut down.")
+        logger.debug("Shut down.")
     }
 
     func onEmit(_ record: inout OTelLogRecord) {
@@ -51,7 +51,7 @@ struct OTelSimpleLogRecordProcessor<Exporter: OTelLogRecordExporter>: OTelLogRec
     }
 
     func forceFlush() async throws {
-        logger.info("Force flushing exporter.")
+        logger.debug("Force flushing exporter.")
         try await exporter.forceFlush()
     }
 }

--- a/Sources/OTel/OTelCore/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReader.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReader.swift
@@ -68,17 +68,17 @@ extension OTelPeriodicExportingMetricsReader: CustomStringConvertible, Service {
 
     func run() async throws {
         let interval = configuration.exportInterval
-        logger.info("Started periodic loop.", metadata: ["interval": "\(interval)"])
+        logger.debug("Started periodic loop.", metadata: ["interval": "\(interval)"])
         for try await _ in AsyncTimerSequence.repeating(every: interval, clock: clock).cancelOnGracefulShutdown() {
             logger.trace("Timer fired.", metadata: ["interval": "\(interval)"])
             await tick()
         }
-        logger.info("Shutting down.")
+        logger.debug("Shutting down.")
         // Unlike traces, force-flush is just a regular tick for metrics; no need for a different function.
         await tick()
         try await exporter.forceFlush()
         await exporter.shutdown()
-        logger.info("Shut down.")
+        logger.debug("Shut down.")
     }
 }
 

--- a/Sources/OTel/OTelCore/Tracing/OTelTracer.swift
+++ b/Sources/OTel/OTelCore/Tracing/OTelTracer.swift
@@ -94,7 +94,7 @@ extension OTelTracer where Clock == ContinuousClock {
 
 extension OTelTracer: Service {
     func run() async throws {
-        logger.info("Starting.")
+        logger.debug("Starting.")
         await withGracefulShutdownHandler {
             for await event in eventStream {
                 // We don't want to propagate the current span's service context into
@@ -111,10 +111,10 @@ extension OTelTracer: Service {
                 }
             }
         } onGracefulShutdown: {
-            self.logger.info("Shutting down.")
+            self.logger.debug("Shutting down.")
             self.eventStreamContinuation.finish()
         }
-        logger.info("Shut down.")
+        logger.debug("Shut down.")
     }
 }
 

--- a/Sources/OTel/OTelCore/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
+++ b/Sources/OTel/OTelCore/Tracing/Processing/Batch/OTelBatchSpanProcessor.swift
@@ -90,13 +90,13 @@ actor OTelBatchSpanProcessor<Exporter: OTelSpanExporter, Clock: _Concurrency.Clo
                 }
                 await taskGroup.waitForAll()
             } onGracefulShutdown: {
-                self.logger.info("Shutting down.")
+                self.logger.debug("Shutting down.")
                 self.spanContinuation.finish()
                 self.explicitTick.finish()
             }
             try? await self.forceFlush()
             await self.exporter.shutdown()
-            self.logger.info("Shut down.")
+            self.logger.debug("Shut down.")
         }
     }
 
@@ -105,7 +105,7 @@ actor OTelBatchSpanProcessor<Exporter: OTelSpanExporter, Clock: _Concurrency.Clo
             logger.debug("Skipping force flush: buffer is empty")
             return
         }
-        logger.info("Force flushing.", metadata: ["buffer_size": "\(buffer.count)"])
+        logger.debug("Force flushing.", metadata: ["buffer_size": "\(buffer.count)"])
         try await withTimeout(configuration.exportTimeout, clock: clock) {
             await withTaskGroup { group in
                 var buffer = self.buffer

--- a/Sources/OTel/OTelCore/Tracing/Processing/OTelSimpleSpanProcessor.swift
+++ b/Sources/OTel/OTelCore/Tracing/Processing/OTelSimpleSpanProcessor.swift
@@ -38,7 +38,7 @@ struct OTelSimpleSpanProcessor<Exporter: OTelSpanExporter>: OTelSpanProcessor {
     }
 
     func run() async throws {
-        logger.info("Starting.")
+        logger.debug("Starting.")
         await withGracefulShutdownHandler {
             for await span in stream {
                 do {
@@ -50,11 +50,11 @@ struct OTelSimpleSpanProcessor<Exporter: OTelSpanExporter>: OTelSpanProcessor {
                 }
             }
         } onGracefulShutdown: {
-            logger.info("Shutting down.")
+            logger.debug("Shutting down.")
             continuation.finish()
         }
         await exporter.shutdown()
-        logger.info("Shut down.")
+        logger.debug("Shut down.")
     }
 
     func onStart(_ span: OTelSpan, parentContext: ServiceContext) {


### PR DESCRIPTION
## Motivation

Our startup logging is noisy and inconsistent. For logging it's very useful and only verbose when there's a useful information to convey to the user. But we also log a bunch of lifecycle events at info. On reflection, I think this is a sub-par experience out of the box.

## Modifications

- Add an info level bootstrap message for traces and metrics, like we have for logging. 
- Downgrade all other logging to debug.

## Result

### Before

```
2025-09-29T09:34:57+0100 info swift-otel: component=bootstrap [OTel] Bootstrapping logging system with OTLP/HTTP+Protobuf exporter.
---
Only Swift OTel diagnostic logging will use the console logger.

If you require console logging for local development, use the
console logs exporter, which can be enabled using the
following configuration:

    config.logs.exporter = .console

Or, run your process with the following environment variable:

    OTEL_LOGS_EXPORTER=console

If you require logs to go to both the console and another
exporter, manually bootstrap the logging subsystem with a
multiplex log handler. See the documentation of
`makeLoggingBackend` for details.
---
2025-09-29T09:34:57+0100 info swift-otel: component=OTelBatchLogRecordProcessor [OTel] Starting.
2025-09-29T09:34:57+0100 info swift-otel: component=OTelTracer [OTel] Starting.
2025-09-29T09:34:57+0100 info swift-otel: component=OTelPeriodicExportingMetricsReader interval=3.0 seconds [OTel] Started periodic loop.
```

### After

```
2025-09-29T09:34:03+0100 info swift-otel: component=bootstrap [OTel] Bootstrapping logging system with OTLP/HTTP+Protobuf exporter.
---
Only Swift OTel diagnostic logging will use the console logger.

If you require console logging for local development, use the
console logs exporter, which can be enabled using the
following configuration:

    config.logs.exporter = .console

Or, run your process with the following environment variable:

    OTEL_LOGS_EXPORTER=console

If you require logs to go to both the console and another
exporter, manually bootstrap the logging subsystem with a
multiplex log handler. See the documentation of
`makeLoggingBackend` for details.
---
2025-09-29T09:34:03+0100 info swift-otel: component=bootstrap [OTel] Bootstrapping metrics system with OTLP/HTTP+Protobuf exporter.
2025-09-29T09:34:03+0100 info swift-otel: component=bootstrap [OTel] Bootstrapping instrumentation system with OTLP/HTTP+Protobuf exporter.
```


