### PR TITLE
Bump protobuf dependency to 1.31.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
 
         // MARK: - OTLPCore
 
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.30.0"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.31.0"),
 
         // MARK: - OTLPGRPC
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/swift-otel/swift-otel/issues/374.

When a new version of the Swift protobuf generator uses new features not present in an older version of the runtime library, the runtime dependency needs to be bumped, otherwise adopters who resolve the minimum version end up with a build error.

## Test Plan

N/A
