### PR TITLE
chore: use Jaeger v2 in examples

### DIFF
--- a/Examples/hello-world-hummingbird-server-logging-metadata-provider/docker/docker-compose.yaml
+++ b/Examples/hello-world-hummingbird-server-logging-metadata-provider/docker/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       - "4318:4318"  # OTLP/HTTP receiver
 
   jaeger:
-    image: jaegertracing/all-in-one
+    image: jaegertracing/jaeger:latest
     ports:
       - "16686:16686"  # Jaeger Web UI
 

--- a/Examples/hello-world-hummingbird-server-mtls/docker/docker-compose.yaml
+++ b/Examples/hello-world-hummingbird-server-mtls/docker/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       - "9090:9090"  # Prometheus web UI
 
   jaeger:
-    image: jaegertracing/all-in-one
+    image: jaegertracing/jaeger:latest
     ports:
       - "16686:16686"  # Jaeger Web UI
 

--- a/Examples/hello-world-hummingbird-server-only-traces/docker/docker-compose.yaml
+++ b/Examples/hello-world-hummingbird-server-only-traces/docker/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       - "4318:4318"  # OTLP/HTTP receiver
 
   jaeger:
-    image: jaegertracing/all-in-one
+    image: jaegertracing/jaeger:latest
     ports:
       - "16686:16686"  # Jaeger Web UI
 

--- a/Examples/hello-world-hummingbird-server-otlp-grpc/docker/docker-compose.yaml
+++ b/Examples/hello-world-hummingbird-server-otlp-grpc/docker/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       - "9090:9090"  # Prometheus web UI
 
   jaeger:
-    image: jaegertracing/all-in-one
+    image: jaegertracing/jaeger:latest
     ports:
       - "16686:16686"  # Jaeger Web UI
 

--- a/Examples/hello-world-hummingbird-server-otlp-http-json/docker/docker-compose.yaml
+++ b/Examples/hello-world-hummingbird-server-otlp-http-json/docker/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       - "9090:9090"  # Prometheus web UI
 
   jaeger:
-    image: jaegertracing/all-in-one
+    image: jaegertracing/jaeger:latest
     ports:
       - "16686:16686"  # Jaeger Web UI
 

--- a/Examples/hello-world-hummingbird-server-otlp-http-protobuf/docker/docker-compose.yaml
+++ b/Examples/hello-world-hummingbird-server-otlp-http-protobuf/docker/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       - "9090:9090"  # Prometheus web UI
 
   jaeger:
-    image: jaegertracing/all-in-one
+    image: jaegertracing/jaeger:latest
     ports:
       - "16686:16686"  # Jaeger Web UI
 

--- a/Examples/hello-world-hummingbird-server-tls/docker/docker-compose.yaml
+++ b/Examples/hello-world-hummingbird-server-tls/docker/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       - "9090:9090"  # Prometheus web UI
 
   jaeger:
-    image: jaegertracing/all-in-one
+    image: jaegertracing/jaeger:latest
     ports:
       - "16686:16686"  # Jaeger Web UI
 

--- a/Examples/hello-world-vapor-server-otlp-http-protobuf/docker/docker-compose.yaml
+++ b/Examples/hello-world-vapor-server-otlp-http-protobuf/docker/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       - "9090:9090"  # Prometheus web UI
 
   jaeger:
-    image: jaegertracing/all-in-one
+    image: jaegertracing/jaeger:latest
     ports:
       - "16686:16686"  # Jaeger Web UI
 


### PR DESCRIPTION
Migrate to Jaeger v2 https://medium.com/jaegertracing/towards-jaeger-v2-moar-opentelemetry-2f8239bee48e ; new name of the container: https://hub.docker.com/r/jaegertracing/jaeger 

List of container images: https://www.jaegertracing.io/download/#container-images


Current start of the all-in-one shows:

```
*******************************************************************************

🛑  WARNING: End-of-life Notice for Jaeger v1

You are currently running a v1 version of Jaeger, which is deprecated and will
reach end-of-life on December 31st, 2025. This means there will be no further
development, bug fixes, or security patches for v1 after this date.

We strongly recommend migrating to Jaeger v2 for continued support and access
to new features.

For detailed migration instructions, please refer to the official Jaeger
documentation:  https://www.jaegertracing.io/docs/latest/migration/

Tracking issue: https://github.com/jaegertracing/jaeger/issues/6321

🛑  WARNING: End-of-life Notice for Jaeger v1

*******************************************************************************
```



