### PR TITLE
Throw an error when calling `bootstrap` with all telemetry disabled

### DIFF
--- a/Sources/OTel/OTelAPI/OTel+Bootstrap.swift
+++ b/Sources/OTel/OTelAPI/OTel+Bootstrap.swift
@@ -113,9 +113,17 @@ extension OTel {
     /// try await serviceGroup.run()
     /// ```
     public static func bootstrap(configuration: Configuration = .default) throws -> some Service {
+        try Self.bootstrap(configuration: configuration, environment: ProcessInfo.processInfo.environment)
+    }
+
+    package static func bootstrap(configuration: Configuration = .default, environment: [String: String]) throws -> some Service {
         let logger = configuration.makeDiagnosticLogger().withMetadata(component: "bootstrap")
         var configuration = configuration
-        configuration.applyEnvironmentOverrides(environment: ProcessInfo.processInfo.environment, logger: logger)
+        if configuration.logs.disabled, configuration.metrics.disabled, configuration.traces.disabled {
+            throw OTel.Configuration.Error.invalidConfiguration("bootstrap called but config has all telemetry disabled")
+        }
+
+        configuration.applyEnvironmentOverrides(environment: environment, logger: logger)
 
         var services: [Service] = []
 


### PR DESCRIPTION
As discussed in https://github.com/swift-otel/swift-otel/pull/378#discussion_r2428715232.