### PR TITLE
Disabled exporters should run until shut down

### DIFF
--- a/Sources/OTel/OTelCore/OTelCore+GenericWrappers.swift
+++ b/Sources/OTel/OTelCore/OTelCore+GenericWrappers.swift
@@ -12,9 +12,9 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
+import ServiceLifecycle
 import Tracing
 import W3CTraceContext
-import ServiceLifecycle
 
 /// The wrapper types in this file exist to support our simplified public API surface.
 ///


### PR DESCRIPTION
## Summary

Fixes https://github.com/swift-otel/swift-otel/issues/382.

## Test Plan

I tried writing a unit test, but couldn't figure out how without it being flaky (wait some amount of time to see if the call returned or is still running), and couldn't write a reliable unit test since swift-service-lifecycle doesn't actually allow you to inject a test clock.
