### PR TITLE
Do not send infinity as explicit bucket bound

### DIFF
--- a/Sources/OTel/OTLPCore+Extensions/Metrics/OTelMetricDataModel+Proto.swift
+++ b/Sources/OTel/OTLPCore+Extensions/Metrics/OTelMetricDataModel+Proto.swift
@@ -177,10 +177,8 @@ extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint {
         if let max = point.max {
             self.max = max
         }
-        for bucket in point.buckets {
-            bucketCounts.append(bucket.count)
-            explicitBounds.append(bucket.upperBound)
-        }
+        bucketCounts = point.bucketCounts
+        explicitBounds = point.explicitBounds
     }
 }
 

--- a/Sources/OTel/OTelCore/Metrics/OTelMetricProducer/OTLPMetricsDataModel.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelMetricProducer/OTLPMetricsDataModel.swift
@@ -135,5 +135,6 @@ struct OTelHistogramDataPoint: Equatable, Sendable {
     var sum: Double?
     var min: Double?
     var max: Double?
-    var buckets: [Bucket]
+    var bucketCounts: [UInt64]
+    var explicitBounds: [Double]
 }

--- a/Tests/OTelTests/OTLPCoreTests/Metrics/OTelMetricDataModelProtoTests.swift
+++ b/Tests/OTelTests/OTLPCoreTests/Metrics/OTelMetricDataModelProtoTests.swift
@@ -177,7 +177,8 @@ final class OTelMetricDataModelProtoTests: XCTestCase {
             sum: 13,
             min: 14,
             max: 15,
-            buckets: [.stub(), .stub()]
+            bucketCounts: [1, 2, 3],
+            explicitBounds: [0.1, 0.2]
         )
         let proto = Opentelemetry_Proto_Metrics_V1_HistogramDataPoint(point)
         XCTAssertEqual(proto.attributes.count, 1)
@@ -187,6 +188,7 @@ final class OTelMetricDataModelProtoTests: XCTestCase {
         XCTAssertEqual(proto.sum, 13)
         XCTAssertEqual(proto.min, 14)
         XCTAssertEqual(proto.max, 15)
-        XCTAssertEqual(proto.bucketCounts.count, 2)
+        XCTAssertEqual(proto.bucketCounts.count, 3)
+        XCTAssertEqual(proto.explicitBounds.count, 2)
     }
 }

--- a/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
+++ b/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
@@ -307,7 +307,7 @@ import Tracing
                         #expect(histogram.dataPoints.first?.min == 41)
                         #expect(histogram.dataPoints.first?.max == 43)
                         #expect(histogram.dataPoints.first?.sum == 42.0 + 41.0 + 43.0)
-                        #expect(histogram.dataPoints.first?.explicitBounds == [0, 42.0, .infinity])
+                        #expect(histogram.dataPoints.first?.explicitBounds == [0, 42.0])
                         #expect(histogram.dataPoints.first?.bucketCounts == [0, 2, 1])
                     default: Issue.record("Unexpected metric type: \(recorder)")
                     }
@@ -319,7 +319,7 @@ import Tracing
                         #expect(histogram.dataPoints.first?.min == 41e-6)
                         #expect(histogram.dataPoints.first?.max == 43e-6)
                         #expect(histogram.dataPoints.first?.sum == 42e-6 + 41e-6 + 43e-6)
-                        #expect(histogram.dataPoints.first?.explicitBounds == [0, 42e-6, .infinity])
+                        #expect(histogram.dataPoints.first?.explicitBounds == [0, 42e-6])
                         #expect(histogram.dataPoints.first?.bucketCounts == [0, 2, 1])
                     default: Issue.record("Unexpected metric type: \(timer)")
                     }
@@ -431,7 +431,7 @@ import Tracing
                         #expect(histogram.dataPoints.first?.min == 41)
                         #expect(histogram.dataPoints.first?.max == 43)
                         #expect(histogram.dataPoints.first?.sum == 42.0 + 41.0 + 43.0)
-                        #expect(histogram.dataPoints.first?.explicitBounds == [0, 42.0, .infinity])
+                        #expect(histogram.dataPoints.first?.explicitBounds == [0, 42.0])
                         #expect(histogram.dataPoints.first?.bucketCounts == [0, 2, 1])
                     default: Issue.record("Unexpected metric type: \(recorder)")
                     }
@@ -443,7 +443,7 @@ import Tracing
                         #expect(histogram.dataPoints.first?.min == 41e-6)
                         #expect(histogram.dataPoints.first?.max == 43e-6)
                         #expect(histogram.dataPoints.first?.sum == 42e-6 + 41e-6 + 43e-6)
-                        #expect(histogram.dataPoints.first?.explicitBounds == [0, 42e-6, .infinity])
+                        #expect(histogram.dataPoints.first?.explicitBounds == [0, 42e-6])
                         #expect(histogram.dataPoints.first?.bucketCounts == [0, 2, 1])
                     default: Issue.record("Unexpected metric type: \(timer)")
                     }

--- a/Tests/OTelTests/OTelCoreTests/Metrics/OTelInstrument/HistogramMeasurementTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/OTelInstrument/HistogramMeasurementTests.swift
@@ -22,49 +22,44 @@ final class HistogramMeasurementTests: XCTestCase {
             .milliseconds(500),
             .seconds(1),
         ])
-        histogram.measure().data.assertIsCumulativeHistogramWith(count: 0, sum: 0.0, buckets: [
-            .init(upperBound: 0.1, count: 0),
-            .init(upperBound: 0.25, count: 0),
-            .init(upperBound: 0.5, count: 0),
-            .init(upperBound: 1.0, count: 0),
-            .init(upperBound: .infinity, count: 0),
-        ])
+        histogram.measure().data.assertIsCumulativeHistogramWith(
+            count: 0,
+            sum: 0.0,
+            bucketCounts: [0, 0, 0, 0, 0],
+            explicitBounds: [0.1, 0.25, 0.5, 1.0]
+        )
 
         histogram.record(.milliseconds(400))
-        histogram.measure().data.assertIsCumulativeHistogramWith(count: 1, sum: 0.4, buckets: [
-            .init(upperBound: 0.1, count: 0),
-            .init(upperBound: 0.25, count: 0),
-            .init(upperBound: 0.5, count: 1),
-            .init(upperBound: 1.0, count: 0),
-            .init(upperBound: .infinity, count: 0),
-        ])
+        histogram.measure().data.assertIsCumulativeHistogramWith(
+            count: 1,
+            sum: 0.4,
+            bucketCounts: [0, 0, 1, 0, 0],
+            explicitBounds: [0.1, 0.25, 0.5, 1.0]
+        )
 
         histogram.record(.milliseconds(600))
-        histogram.measure().data.assertIsCumulativeHistogramWith(count: 2, sum: 1.0, buckets: [
-            .init(upperBound: 0.1, count: 0),
-            .init(upperBound: 0.25, count: 0),
-            .init(upperBound: 0.5, count: 1),
-            .init(upperBound: 1.0, count: 1),
-            .init(upperBound: .infinity, count: 0),
-        ])
+        histogram.measure().data.assertIsCumulativeHistogramWith(
+            count: 2,
+            sum: 1.0,
+            bucketCounts: [0, 0, 1, 1, 0],
+            explicitBounds: [0.1, 0.25, 0.5, 1.0]
+        )
 
         histogram.record(.milliseconds(1200))
-        histogram.measure().data.assertIsCumulativeHistogramWith(count: 3, sum: 2.2, buckets: [
-            .init(upperBound: 0.1, count: 0),
-            .init(upperBound: 0.25, count: 0),
-            .init(upperBound: 0.5, count: 1),
-            .init(upperBound: 1.0, count: 1),
-            .init(upperBound: .infinity, count: 1),
-        ])
+        histogram.measure().data.assertIsCumulativeHistogramWith(
+            count: 3,
+            sum: 2.2,
+            bucketCounts: [0, 0, 1, 1, 1],
+            explicitBounds: [0.1, 0.25, 0.5, 1.0]
+        )
 
         histogram.record(.milliseconds(80))
-        histogram.measure().data.assertIsCumulativeHistogramWith(count: 4, sum: 2.28, buckets: [
-            .init(upperBound: 0.1, count: 1),
-            .init(upperBound: 0.25, count: 0),
-            .init(upperBound: 0.5, count: 1),
-            .init(upperBound: 1.0, count: 1),
-            .init(upperBound: .infinity, count: 1),
-        ])
+        histogram.measure().data.assertIsCumulativeHistogramWith(
+            count: 4,
+            sum: 2.28,
+            bucketCounts: [1, 0, 1, 1, 1],
+            explicitBounds: [0.1, 0.25, 0.5, 1.0]
+        )
     }
 
     func test_measure_followingConcurrentRecord_returnsCumulativeHistogram() async {
@@ -81,10 +76,12 @@ final class HistogramMeasurementTests: XCTestCase {
                 }
             }
         }
-        histogram.measure().data.assertIsCumulativeHistogramWith(count: 200_000, sum: 100_000, buckets: [
-            .init(upperBound: 0.5, count: 100_000),
-            .init(upperBound: .infinity, count: 100_000),
-        ])
+        histogram.measure().data.assertIsCumulativeHistogramWith(
+            count: 200_000,
+            sum: 100_000,
+            bucketCounts: [100_000, 100_000],
+            explicitBounds: [0.5]
+        )
     }
 
     func test_measure_measurementIncludesIdentifyingFields() {

--- a/Tests/OTelTests/OTelTesting/Metrics+TestHelpers.swift
+++ b/Tests/OTelTests/OTelTesting/Metrics+TestHelpers.swift
@@ -96,7 +96,7 @@ extension OTelMetricPoint.OTelMetricData {
         XCTAssertEqual(point.value, value, file: file, line: line)
     }
 
-    func assertIsCumulativeHistogramWith(count: Int, sum: Double, buckets: [OTelHistogramDataPoint.Bucket], file: StaticString = #filePath, line: UInt = #line) {
+    func assertIsCumulativeHistogramWith(count: Int, sum: Double, bucketCounts: [UInt64], explicitBounds: [Double], file: StaticString = #filePath, line: UInt = #line) {
         guard
             case .histogram(let histogram) = data,
             histogram.aggregationTemporality == .cumulative,
@@ -109,7 +109,8 @@ extension OTelMetricPoint.OTelMetricData {
 
         XCTAssertEqual(point.count, UInt64(count), file: file, line: line)
         XCTAssertEqual(point.sum, sum, file: file, line: line)
-        XCTAssertEqual(point.buckets, buckets, file: file, line: line)
+        XCTAssertEqual(point.bucketCounts, bucketCounts, file: file, line: line)
+        XCTAssertEqual(point.explicitBounds, explicitBounds, file: file, line: line)
     }
 }
 #endif

--- a/Tests/OTelTests/OTelTesting/OTelMetricDataModel+Stub.swift
+++ b/Tests/OTelTests/OTelTesting/OTelMetricDataModel+Stub.swift
@@ -149,7 +149,8 @@ extension OTelHistogramDataPoint {
         sum: Double? = nil,
         min: Double? = nil,
         max: Double? = nil,
-        buckets: [Bucket] = []
+        bucketCounts: [UInt64] = [],
+        explicitBounds: [Double] = []
     ) -> Self {
         .init(
             attributes: attributes,
@@ -159,7 +160,8 @@ extension OTelHistogramDataPoint {
             sum: sum,
             min: min,
             max: max,
-            buckets: buckets
+            bucketCounts: bucketCounts,
+            explicitBounds: explicitBounds
         )
     }
 }


### PR DESCRIPTION
## Motivation

OTLP histograms contain the bucket counts and the _explicit_ bucket bounds as separate fields. Values are bucketed according to the explicit bounds, with values that are higher than the highest _explicit_ upper bound, being bucketed into an explicit bucket, up to infinity. For example, specifying bounds of `[5, 10]` results in buckets of `(-inf, 5], (5, 10], (10,+inf)`.

Until now, Swift OTel was including the `+infinity` in the `explicit_bounds` field during OTLP export, which is incorrect:

```
  // bucket_counts is an optional field contains the count values of histogram
  // for each bucket.
  //
  // The sum of the bucket_counts must equal the value in the count field.
  //
  // The number of elements in bucket_counts array must be by one greater than
  // the number of elements in explicit_bounds array. The exception to this rule
  // is when the length of bucket_counts is 0, then the length of explicit_bounds
  // must also be 0.
  repeated fixed64 bucket_counts = 6;

  // explicit_bounds specifies buckets with explicitly defined bounds for values.
  //
  // The boundaries for bucket at index i are:
  //
  // (-infinity, explicit_bounds[i]] for i == 0
  // (explicit_bounds[i-1], explicit_bounds[i]] for 0 < i < size(explicit_bounds)
  // (explicit_bounds[i-1], +infinity) for i == size(explicit_bounds)
  //
  // The values in the explicit_bounds array must be strictly increasing.
  //
  // Histogram buckets are inclusive of their upper boundary, except the last
  // bucket where the boundary is at infinity. This format is intentionally
  // compatible with the OpenMetrics histogram definition.
  //
  // If bucket_counts length is 0 then explicit_bounds length must also be 0,
  // otherwise the data point is invalid.
  repeated double explicit_bounds = 7;
```
— source: https://github.com/open-telemetry/opentelemetry-proto/blob/v1.8.0/opentelemetry/proto/metrics/v1/metrics.proto

This is breaking collectors that are very strict, e.g. VictoriaMetrics, as described in #386.

## Modifications

Do not include `+infinity` in the `explicit_bounds` of OTLP histograms.

## Result

Histogram exports are now more compliant with OTLP, with corrected `explicit_bounds`, which might help with strict collectors.

Fixes #386.