### PR TITLE
Update README to link to docs for latest release instead of main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ try await app.runService()
 > This, and other examples, can be be found in the [Examples][examples] directory.
 
 [otlp]: https://opentelemetry.io/docs/specs/otel/protocol
-<!-- TODO: Remove /main/ from following URL once 1.0.0 ships -->
-[docs]: https://swiftpackageindex.com/swift-otel/swift-otel/main/documentation
+[docs]: https://swiftpackageindex.com/swift-otel/swift-otel/documentation
 [examples]: https://github.com/swift-otel/swift-otel/tree/main/Examples/
 [license]: https://github.com/swift-otel/swift-otel/tree/main/LICENSE.txt
 [swift-log]: https://github.com/apple/swift-log


### PR DESCRIPTION
## Motivation

The link to Swift Package Index, in the README, currently points to the docs for the main branch. It should point to the docs for the latest release.

## Modifications

Update the link to point to the docs for the latest release.

## Result

Clicking the link from the README takes you to the docs for the latest release, rather than the docs for main.