### PR TITLE
Fix platform version strings to use major.minor format

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -144,8 +144,8 @@ struct PlatformRequirements {
         .enableExperimentalFeature("AvailabilityMacro=\(name) : macOS \(macOS), iOS \(iOS), tvOS \(tvOS), watchOS \(watchOS), visionOS \(visionOS)")
     }
 
-    static let clockAPI = Self(name: "ClockAPI", macOS: "13", iOS: "16", tvOS: "16", watchOS: "9", visionOS: "1")
-    static let gRPCSwift = Self(name: "gRPCSwift", macOS: "15", iOS: "18", tvOS: "18", watchOS: "11", visionOS: "2")
+    static let clockAPI = Self(name: "ClockAPI", macOS: "13.0", iOS: "16.0", tvOS: "16.0", watchOS: "9.0", visionOS: "1.0")
+    static let gRPCSwift = Self(name: "gRPCSwift", macOS: "15.0", iOS: "18.0", tvOS: "18.0", watchOS: "11.0", visionOS: "2.0")
 }
 
 if ["true", "y", "yes", "on", "1"].contains(Context.environment["OTEL_ENABLE_BENCHMARKS"]?.lowercased()) {


### PR DESCRIPTION
Human message:

Hey, my app currently uses a target from one of my server package that uses swift-otel. My app uses Tuist who is rather picky about the platform versioning in the SwiftPM dependencies. I figure this won't hurt anyway, so I asked my bot to submit the PR. If you are not happy about this, I will try to get Tuist people to relax their version parser too. 

Thanks!

## Summary
- Platform version strings in `PlatformRequirements` use single-component format (`"16"`) which causes tools like Tuist to fail with `fewer than 2 identifiers in version core '16'`
- Changed to `major.minor` format (`"16.0"`) which is consistent with how SPM's enum-based API (`.v16`) serializes versions

## Context
SPM's `SupportedPlatform` string initializer (e.g. `.iOS("16")`) preserves the string as-is in `dump-package` output, producing `"version": "16"`. The enum API (`.iOS(.v16)`) serializes as `"version": "16.0"`. Tools that consume `dump-package` JSON and expect semver-like versions (at least `major.minor`) break on the single-component format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)