### PR TITLE
[Discussion]: Add OTel.makeBackends to allow user-driven factories bootstrapping

### DIFF
--- a/Sources/OTel/OTelAPI/OTel+Bootstrap.swift
+++ b/Sources/OTel/OTelAPI/OTel+Bootstrap.swift
@@ -24,6 +24,63 @@ import Tracing
 // MARK: - API
 
 extension OTel {
+    /// Create observability backends without setting process-global factories.
+    ///
+    /// - Parameter configuration: Configuration for observability backends.
+    ///
+    ///   This value can be used to configure or disable the bootstrapped backends and defaults to
+    ///   `OTel.Configuration.default`, which creates all backends with the default configuration defined in the
+    ///   OpenTelemetry specification.
+    ///
+    ///   Configuration can also be provided at runtime with environment variable overrides.
+    ///
+    /// - Returns: An ``OTelService`` that manages the lifecycle of all enabled backends and provides access to
+    ///   their factories.
+    ///
+    ///   The returned service manages the complete lifecycle of all observability backends. It handles startup,
+    ///   background processing, and graceful shutdown of exporters and processors.
+    ///
+    ///   > Important: You must run this service in a `ServiceGroup` alongside your application services for
+    ///   observability data to be exported.
+    ///
+    /// Unlike ``bootstrap(configuration:)``, this function does **not** set any process-global factories. The caller
+    /// is responsible for deciding how to use the returned factories — for example, setting them globally, using them
+    /// as task-local values, or composing them with other backends.
+    ///
+    /// This API supports overriding the configuration using environment variables defined in the OpenTelemetry
+    /// specification. This enables operators to customize the observability of your application during deployment.
+    /// For more details on the configuration options, their defaults, and their associated environment variables, see
+    /// `OTel.Configuration`.
+    ///
+    /// ## Example usage
+    ///
+    /// ### Task-local metrics with global logging and tracing
+    ///
+    /// ```swift
+    /// let otel = try OTel.makeBackends()
+    ///
+    /// // Use process-global factories for logging and tracing.
+    /// if let loggingFactory = otel.loggingFactory {
+    ///     LoggingSystem.bootstrap(loggingFactory)
+    /// }
+    /// if let tracer = otel.tracer {
+    ///     InstrumentationSystem.bootstrap(tracer)
+    /// }
+    ///
+    /// // Use task-local factory for metrics.
+    /// let serviceGroup = ServiceGroup(services: [otel, server], logger: logger)
+    /// try await withMetricsFactory(otel.metricsFactory!) {
+    ///     try await serviceGroup.run()
+    /// }
+    /// ```
+    ///
+    /// - SeeAlso:
+    ///   - ``bootstrap(configuration:)`` for simple, all-in-one observability setup that sets process-global factories
+    ///   - ``Configuration`` for configuration options and environment variables
+    public static func makeBackends(configuration: Configuration = .default) throws -> OTelService {
+        try Self.makeBackends(configuration: configuration, environment: ProcessInfo.processInfo.environment)
+    }
+
     /// Bootstrap observability backends with OTLP exporters.
     ///
     /// - Parameter configuration: Configuration for observability backends.
@@ -116,26 +173,107 @@ extension OTel {
         try Self.bootstrap(configuration: configuration, environment: ProcessInfo.processInfo.environment)
     }
 
-    package static func bootstrap(configuration: Configuration = .default, environment: [String: String]) throws -> some Service {
-        let logger = configuration.makeDiagnosticLogger().withMetadata(component: "bootstrap")
+    package static func makeBackends(
+        configuration: Configuration = .default,
+        environment: [String: String]
+    ) throws -> OTelService {
+        let logger = configuration.makeDiagnosticLogger().withMetadata(component: "makeBackends")
         var configuration = configuration
         if configuration.logs.disabled, configuration.metrics.disabled, configuration.traces.disabled {
-            throw OTel.Configuration.Error.invalidConfiguration("bootstrap called but config has all telemetry disabled")
+            throw OTel.Configuration.Error.invalidConfiguration(
+                "makeBackends called but config has all telemetry disabled"
+            )
         }
 
         configuration.applyEnvironmentOverrides(environment: environment, logger: logger)
 
-        var services: [Service] = []
+        return try makeBackends(resolvedConfiguration: configuration, logger: logger)
+    }
 
-        if configuration.logs.enabled {
-            try services.append(bootstrapLogs(resolvedConfiguration: configuration, logger: logger))
+    package static func bootstrap(
+        configuration: Configuration = .default,
+        environment: [String: String]
+    ) throws -> some Service {
+        let logger = configuration.makeDiagnosticLogger().withMetadata(component: "bootstrap")
+        var configuration = configuration
+        if configuration.logs.disabled, configuration.metrics.disabled, configuration.traces.disabled {
+            throw OTel.Configuration.Error.invalidConfiguration(
+                "bootstrap called but config has all telemetry disabled"
+            )
         }
-        if configuration.metrics.enabled {
-            try services.append(bootstrapMetrics(resolvedConfiguration: configuration, logger: logger))
+
+        configuration.applyEnvironmentOverrides(environment: environment, logger: logger)
+
+        let otelService = try makeBackends(resolvedConfiguration: configuration, logger: logger)
+
+        if let loggingFactory = otelService.loggingFactory {
+            if configuration.logs.exporter.backing != .console {
+                logger.info(
+                    """
+                    Bootstrapping logging system with \(configuration.logs.exporterName) exporter.
+                    ---
+                    Only Swift OTel diagnostic logging will use the console logger.
+
+                    If you require console logging for local development, use the
+                    console logs exporter, which can be enabled using the
+                    following configuration:
+
+                        config.logs.exporter = .console
+
+                    Or, run your process with the following environment variable:
+
+                        OTEL_LOGS_EXPORTER=console
+
+                    If you require logs to go to both the console and another
+                    exporter, manually bootstrap the logging subsystem with a
+                    multiplex log handler. See the documentation of
+                    `makeLoggingBackend` for details.
+                    ---
+                    """
+                )
+            } else {
+                logger.info("Bootstrapping logging system with \(configuration.logs.exporterName) exporter.")
+            }
+            LoggingSystem.bootstrap(loggingFactory)
         }
-        if configuration.traces.enabled {
-            try services.append(bootstrapTraces(resolvedConfiguration: configuration, logger: logger))
+        if let metricsFactory = otelService.metricsFactory {
+            logger.info("Bootstrapping metrics system with \(configuration.metrics.exporterName) exporter.")
+            MetricsSystem.bootstrap(metricsFactory)
         }
+        if let tracer = otelService.tracer {
+            logger.info("Bootstrapping instrumentation system with \(configuration.traces.exporterName) exporter.")
+            InstrumentationSystem.bootstrap(tracer)
+        }
+
+        return otelService
+    }
+}
+
+// MARK: - Internal
+
+extension OTel {
+    internal static func makeBackends(resolvedConfiguration: OTel.Configuration, logger: Logger) throws -> OTelService {
+        var services: [Service] = []
+        var loggingFactory: (@Sendable (String) -> any LogHandler)?
+        var metricsFactory: (any MetricsFactory)?
+        var tracer: (any Tracer)?
+
+        if resolvedConfiguration.logs.enabled {
+            let backend = try makeLoggingBackend(resolvedConfiguration: resolvedConfiguration, logger: logger)
+            loggingFactory = backend.factory
+            services.append(backend.service)
+        }
+        if resolvedConfiguration.metrics.enabled {
+            let backend = try makeMetricsBackend(resolvedConfiguration: resolvedConfiguration, logger: logger)
+            metricsFactory = backend.factory
+            services.append(backend.service)
+        }
+        if resolvedConfiguration.traces.enabled {
+            let backend = try makeTracingBackend(resolvedConfiguration: resolvedConfiguration, logger: logger)
+            tracer = backend.factory
+            services.append(backend.service)
+        }
+
         if services.isEmpty {
             // If we created a service group that doesn't contain any services, it would return immediately, which would
             // then take down the entire service lifecycle of a server because OTel terminates unexpectedly. To fix
@@ -149,58 +287,12 @@ extension OTel {
             services.append(DummyService())
         }
 
-        return ServiceGroup(services: services, logger: logger)
-    }
-}
-
-// MARK: - Internal
-
-extension OTel {
-    internal static func bootstrapTraces(resolvedConfiguration: OTel.Configuration, logger: Logger) throws -> some Service {
-        let backend = try makeTracingBackend(resolvedConfiguration: resolvedConfiguration, logger: logger)
-        logger.info("Bootstrapping instrumentation system with \(resolvedConfiguration.traces.exporterName) exporter.")
-        InstrumentationSystem.bootstrap(backend.factory)
-        return backend.service
-    }
-
-    internal static func bootstrapMetrics(resolvedConfiguration: OTel.Configuration, logger: Logger) throws -> some Service {
-        let backend = try makeMetricsBackend(resolvedConfiguration: resolvedConfiguration, logger: logger)
-        logger.info("Bootstrapping metrics system with \(resolvedConfiguration.metrics.exporterName) exporter.")
-        MetricsSystem.bootstrap(backend.factory)
-        return backend.service
-    }
-
-    internal static func bootstrapLogs(resolvedConfiguration: OTel.Configuration, logger: Logger) throws -> some Service {
-        let backend = try makeLoggingBackend(resolvedConfiguration: resolvedConfiguration, logger: logger)
-        if resolvedConfiguration.logs.exporter.backing != .console {
-            logger.info(
-                """
-                Bootstrapping logging system with \(resolvedConfiguration.logs.exporterName) exporter.
-                ---
-                Only Swift OTel diagnostic logging will use the console logger.
-
-                If you require console logging for local development, use the
-                console logs exporter, which can be enabled using the
-                following configuration:
-
-                    config.logs.exporter = .console
-
-                Or, run your process with the following environment variable:
-
-                    OTEL_LOGS_EXPORTER=console
-
-                If you require logs to go to both the console and another
-                exporter, manually bootstrap the logging subsystem with a
-                multiplex log handler. See the documentation of
-                `makeLoggingBackend` for details.
-                ---
-                """
-            )
-        } else {
-            logger.info("Bootstrapping logging system with \(resolvedConfiguration.logs.exporterName) exporter.")
-        }
-        LoggingSystem.bootstrap(backend.factory)
-        return backend.service
+        return OTelService(
+            loggingFactory: loggingFactory,
+            metricsFactory: metricsFactory,
+            tracer: tracer,
+            serviceGroup: ServiceGroup(services: services, logger: logger)
+        )
     }
 }
 

--- a/Sources/OTel/OTelAPI/OTelService.swift
+++ b/Sources/OTel/OTelAPI/OTelService.swift
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2025 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+public import CoreMetrics
+public import Logging
+public import ServiceLifecycle
+public import Tracing
+
+/// A service that manages the lifecycle of OpenTelemetry backends and provides access to their factories.
+///
+/// `OTelService` conforms to ``Service`` and manages the background work for all enabled observability
+/// backends (exporters, processors, etc.). It exposes optional factory properties that callers can use
+/// to set up process-global or task-local observability without `OTelService` itself touching any globals.
+///
+/// Use ``OTel/makeBackends(configuration:)`` to create an instance.
+///
+/// ## Example: Task-local metrics with global logging and tracing
+///
+/// ```swift
+/// let otel = try OTel.makeBackends()
+///
+/// // Use process-global factories for logging and tracing.
+/// if let loggingFactory = otel.loggingFactory {
+///     LoggingSystem.bootstrap(loggingFactory)
+/// }
+/// if let tracer = otel.tracer {
+///     InstrumentationSystem.bootstrap(tracer)
+/// }
+///
+/// // Use task-local factory for metrics.
+/// let serviceGroup = ServiceGroup(services: [otel, server], logger: logger)
+/// try await withMetricsFactory(otel.metricsFactory!) {
+///     try await serviceGroup.run()
+/// }
+/// ```
+public struct OTelService: Service {
+    /// The logging factory, or `nil` if logging is disabled in the configuration.
+    public let loggingFactory: (@Sendable (String) -> any LogHandler)?
+
+    /// The metrics factory, or `nil` if metrics is disabled in the configuration.
+    public let metricsFactory: (any MetricsFactory)?
+
+    /// The tracer, or `nil` if tracing is disabled in the configuration.
+    public let tracer: (any Tracer)?
+
+    private let serviceGroup: ServiceGroup
+
+    package init(
+        loggingFactory: (@Sendable (String) -> any LogHandler)?,
+        metricsFactory: (any MetricsFactory)?,
+        tracer: (any Tracer)?,
+        serviceGroup: ServiceGroup
+    ) {
+        self.loggingFactory = loggingFactory
+        self.metricsFactory = metricsFactory
+        self.tracer = tracer
+        self.serviceGroup = serviceGroup
+    }
+
+    public func run() async throws {
+        try await serviceGroup.run()
+    }
+}

--- a/Tests/OTelTests/OTelAPITests/BootstrapTests.swift
+++ b/Tests/OTelTests/OTelAPITests/BootstrapTests.swift
@@ -157,5 +157,51 @@ import Tracing
             }
         }
     }
+
+    // MARK: - makeBackends
+
+    @Test func testMakeBackendsAllEnabled() async throws {
+        await #expect(processExitsWith: .success, "Running in a separate process because test creates backends") {
+            let otelService = try OTel.makeBackends()
+            #expect(otelService.loggingFactory != nil)
+            #expect(otelService.metricsFactory != nil)
+            #expect(otelService.tracer != nil)
+        }
+    }
+
+    @Test func testMakeBackendsWithDisabledSignals() async throws {
+        await #expect(processExitsWith: .success, "Running in a separate process because test creates backends") {
+            var config = OTel.Configuration.default
+            config.logs.enabled = false
+            config.traces.enabled = false
+            let otelService = try OTel.makeBackends(configuration: config)
+            #expect(otelService.loggingFactory == nil)
+            #expect(otelService.metricsFactory != nil)
+            #expect(otelService.tracer == nil)
+        }
+    }
+
+    @Test func testMakeBackendsDoesNotBootstrapGlobals() async throws {
+        await #expect(processExitsWith: .success, "Running in a separate process because test uses bootstrap") {
+            var config = OTel.Configuration.default
+            config.logs.enabled = false
+            config.traces.enabled = false
+            _ = try OTel.makeBackends(configuration: config)
+            // If makeBackends had bootstrapped MetricsSystem, this second bootstrap would crash.
+            MetricsSystem.bootstrap(NOOPMetricsHandler.instance)
+        }
+    }
+
+    @Test func testMakeBackendsThrowsWhenAllDisabled() async throws {
+        await #expect(processExitsWith: .success, "Running in a separate process because test creates backends") {
+            var config = OTel.Configuration.default
+            config.logs.enabled = false
+            config.metrics.enabled = false
+            config.traces.enabled = false
+            #expect(throws: (any Error).self) {
+                _ = try OTel.makeBackends(configuration: config)
+            }
+        }
+    }
 }
 #endif // compiler(>=6.2)


### PR DESCRIPTION
@simonjbeaumont @slashmo I would like to discuss API addition to allow user-driven factories bootstrapping.

## Motivation

The current `OTel.bootstrap()` always sets process-global factories without exposing the underlying factories. This doesn't allow applications to control how telemetry is bootstrapped — for example, using task-local metrics via `withMetricsFactory` from `swift-metrics` 2.10 (or other observability packages, if/when they support task-local factories), or if they want to chain factories with something like [`MappingMetricsFactory`](https://github.com/apple/swift-metrics/blob/main/Sources/CoreMetrics/MappingMetricsFactory.swift).

## Modification

Add `OTel.makeBackends(configuration:)` which returns an `OTelService` — a Service-conforming struct that exposes optional factory properties (loggingFactory, metricsFactory, tracer) without touching any globals. Refactor the existing `OTel.bootstrap()` to be a thin wrapper that calls `makeBackends()` and then sets the process-global factories.

## Alternatives

- **Return a tuple of factories + service.** Avoid introducing a new OTelService type, but makes it harder to evolve the API in the future if the set of factories changes. Follows the existing API design.
- **Use closure.** Instead of returning, provide created factories (and the service?) in a closure. Better for scoping, but introduces unnecessary closures nesting.
- **Bootstrap task-local metrics factory inside swift-otel.** Another alternative would be to do task-lock bootstrapping inside swift-otel bootstrapping. This will produce the cleanest API, smth like `OTel.with(configuration) { service in ... }` and then factories can be accessed via the task-local `.current` and user can do whatever they want. But it is unclear how this would work while not all three of them have task-local APIs. We can also wait until they do have it.