### PR TITLE
Add configurable delta aggregation temporality for metrics

### DIFF
--- a/Sources/OTel/OTelAPI/OTel+Backends.swift
+++ b/Sources/OTel/OTelAPI/OTel+Backends.swift
@@ -237,7 +237,11 @@ extension OTel {
             throw OTel.Configuration.Error.invalidConfiguration("makeMetricsBackend called but config has metrics disabled")
         }
         let resource = OTelResource(configuration: resolvedConfiguration)
-        let registry = OTelMetricRegistry(logger: logger)
+        let temporality: OTelAggregationTemporality = switch resolvedConfiguration.metrics.temporalityPreference.backing {
+        case .cumulative: .cumulative
+        case .delta: .delta
+        }
+        let registry = OTelMetricRegistry(temporality: temporality, logger: logger)
         let factory = OTLPMetricsFactory(
             registry: registry,
             configuration: .init(

--- a/Sources/OTel/OTelAPI/OTel+Configuration.swift
+++ b/Sources/OTel/OTelAPI/OTel+Configuration.swift
@@ -367,7 +367,17 @@ extension OTel.Configuration {
         /// - Default value: `.default`.
         public var otlpExporter: OTLPExporterConfiguration
 
-        /// Default logs configuration.
+        /// Preference for aggregation temporality of exported metrics.
+        ///
+        /// - `cumulative`: Each export sends the running total since process start.
+        /// - `delta`: Each export sends only the change since the last export.
+        ///
+        /// - Environment variable(s): `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`.
+        /// - Default value: `.cumulative`.
+        /// - Notes: Gauges always use cumulative temporality regardless of this setting.
+        public var temporalityPreference: TemporalityPreference
+
+        /// Default metrics configuration.
         ///
         /// See individual property documentation for specific default values, which respect the OTel specification
         /// where possible.
@@ -381,7 +391,8 @@ extension OTel.Configuration {
             defaultValueHistogramBuckets: defaultHistogramBuckets,
             valueHistogramBuckets: [:],
             exporter: .otlp,
-            otlpExporter: .default
+            otlpExporter: .default,
+            temporalityPreference: .cumulative,
         )
 
         static let defaultHistogramBuckets = [0.0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000]
@@ -588,6 +599,27 @@ extension OTel.Configuration.TracesConfiguration {
         /// Console exporter for traces (development/debugging).
         @available(*, unavailable, message: "This option is not supported by Swift OTel")
         public static let console: Self = .init(backing: .console)
+    }
+}
+
+extension OTel.Configuration.MetricsConfiguration {
+    /// Preference for the aggregation temporality of exported metrics.
+    ///
+    /// Determines whether metrics are exported as cumulative running totals or as
+    /// deltas representing change since the last export.
+    public struct TemporalityPreference: Sendable {
+        enum Backing: String, CaseIterable, Sendable {
+            case cumulative
+            case delta
+        }
+
+        var backing: Backing
+
+        /// Cumulative temporality — each export sends the running total since process start.
+        public static let cumulative: Self = .init(backing: .cumulative)
+
+        /// Delta temporality — each export sends only the change since the last export.
+        public static let delta: Self = .init(backing: .delta)
     }
 }
 

--- a/Sources/OTel/OTelCore/Metrics/MetricStore/Counter.swift
+++ b/Sources/OTel/OTelCore/Metrics/MetricStore/Counter.swift
@@ -42,17 +42,19 @@ final class Counter: Sendable {
     let unit: String?
     let description: String?
     let attributes: Set<Attribute>
+    let temporality: OTelAggregationTemporality
 
-    init(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = []) {
+    init(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = [], temporality: OTelAggregationTemporality = .cumulative) {
         self.name = name
         self.unit = unit
         self.description = description
         self.attributes = attributes
-        self.startTimeNanoseconds = ManagedAtomic(DefaultTracerClock.now.nanosecondsSinceEpoch)
+        self.temporality = temporality
+        startTimeNanoseconds = ManagedAtomic(DefaultTracerClock.now.nanosecondsSinceEpoch)
     }
 
-    convenience init(name: String, unit: String? = nil, description: String? = nil, attributes: [(String, String)] = []) {
-        self.init(name: name, unit: unit, description: description, attributes: Set(attributes))
+    convenience init(name: String, unit: String? = nil, description: String? = nil, attributes: [(String, String)] = [], temporality: OTelAggregationTemporality = .cumulative) {
+        self.init(name: name, unit: unit, description: description, attributes: Set(attributes), temporality: temporality)
     }
 
     func increment() {

--- a/Sources/OTel/OTelCore/Metrics/MetricStore/Counter.swift
+++ b/Sources/OTel/OTelCore/Metrics/MetricStore/Counter.swift
@@ -25,6 +25,7 @@
 //===----------------------------------------------------------------------===//
 
 import Atomics
+import Tracing
 
 /// A counter is a cumulative metric that represents a single monotonically increasing
 /// counter whose value can only increase or be ``reset()`` to zero on restart.
@@ -35,6 +36,7 @@ import Atomics
 /// number of currently running processes; instead use a ``Gauge``.
 final class Counter: Sendable {
     let atomic = ManagedAtomic(Int64(0))
+    let startTimeNanoseconds: ManagedAtomic<UInt64>
 
     let name: String
     let unit: String?
@@ -46,6 +48,7 @@ final class Counter: Sendable {
         self.unit = unit
         self.description = description
         self.attributes = attributes
+        self.startTimeNanoseconds = ManagedAtomic(DefaultTracerClock.now.nanosecondsSinceEpoch)
     }
 
     convenience init(name: String, unit: String? = nil, description: String? = nil, attributes: [(String, String)] = []) {

--- a/Sources/OTel/OTelCore/Metrics/MetricStore/FloatingPointCounter.swift
+++ b/Sources/OTel/OTelCore/Metrics/MetricStore/FloatingPointCounter.swift
@@ -25,6 +25,7 @@
 //===----------------------------------------------------------------------===//
 
 import Atomics
+import Tracing
 
 /// A counter is a cumulative metric that represents a single monotonically increasing
 /// counter whose value can only increase or be ``reset()`` to zero on restart.
@@ -35,6 +36,7 @@ import Atomics
 /// number of currently running processes; instead use a ``Gauge``.
 final class FloatingPointCounter: Sendable {
     let atomic = ManagedAtomic(Double.zero.bitPattern)
+    let startTimeNanoseconds: ManagedAtomic<UInt64>
 
     let name: String
     let unit: String?
@@ -46,6 +48,7 @@ final class FloatingPointCounter: Sendable {
         self.unit = unit
         self.description = description
         self.attributes = attributes
+        self.startTimeNanoseconds = ManagedAtomic(DefaultTracerClock.now.nanosecondsSinceEpoch)
     }
 
     convenience init(name: String, unit: String? = nil, description: String? = nil, attributes: [(String, String)] = []) {

--- a/Sources/OTel/OTelCore/Metrics/MetricStore/FloatingPointCounter.swift
+++ b/Sources/OTel/OTelCore/Metrics/MetricStore/FloatingPointCounter.swift
@@ -42,17 +42,19 @@ final class FloatingPointCounter: Sendable {
     let unit: String?
     let description: String?
     let attributes: Set<Attribute>
+    let temporality: OTelAggregationTemporality
 
-    init(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = []) {
+    init(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = [], temporality: OTelAggregationTemporality = .cumulative) {
         self.name = name
         self.unit = unit
         self.description = description
         self.attributes = attributes
-        self.startTimeNanoseconds = ManagedAtomic(DefaultTracerClock.now.nanosecondsSinceEpoch)
+        self.temporality = temporality
+        startTimeNanoseconds = ManagedAtomic(DefaultTracerClock.now.nanosecondsSinceEpoch)
     }
 
-    convenience init(name: String, unit: String? = nil, description: String? = nil, attributes: [(String, String)] = []) {
-        self.init(name: name, unit: unit, description: description, attributes: Set(attributes))
+    convenience init(name: String, unit: String? = nil, description: String? = nil, attributes: [(String, String)] = [], temporality: OTelAggregationTemporality = .cumulative) {
+        self.init(name: name, unit: unit, description: description, attributes: Set(attributes), temporality: temporality)
     }
 
     func increment() {
@@ -71,7 +73,7 @@ final class FloatingPointCounter: Sendable {
             let (exchanged, _) = atomic.compareExchange(
                 expected: bits,
                 desired: value.bitPattern,
-                ordering: .relaxed
+                ordering: .relaxed,
             )
             if exchanged {
                 break

--- a/Sources/OTel/OTelCore/Metrics/MetricStore/Histogram.swift
+++ b/Sources/OTel/OTelCore/Metrics/MetricStore/Histogram.swift
@@ -44,6 +44,8 @@ final class Histogram<Value: Bucketable>: Sendable {
     let unit: String?
     let description: String?
     let attributes: Set<Attribute>
+    let temporality: OTelAggregationTemporality
+    let emptyState: State
 
     @usableFromInline
     struct State: Sendable {
@@ -69,16 +71,19 @@ final class Histogram<Value: Bucketable>: Sendable {
 
     @usableFromInline let box: NIOLockedValueBox<State>
 
-    init(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = [], buckets: [Value]) {
+    init(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = [], buckets: [Value], temporality: OTelAggregationTemporality = .cumulative) {
         self.name = name
         self.unit = unit
         self.description = description
         self.attributes = attributes
-        box = .init(.init(buckets: buckets))
+        self.temporality = temporality
+        let initialState = State(buckets: buckets)
+        emptyState = initialState
+        box = .init(initialState)
     }
 
-    convenience init(name: String, unit: String? = nil, description: String? = nil, attributes: [(String, String)] = [], buckets: [Value]) {
-        self.init(name: name, unit: unit, description: description, attributes: Set(attributes), buckets: buckets)
+    convenience init(name: String, unit: String? = nil, description: String? = nil, attributes: [(String, String)] = [], buckets: [Value], temporality: OTelAggregationTemporality = .cumulative) {
+        self.init(name: name, unit: unit, description: description, attributes: Set(attributes), buckets: buckets, temporality: temporality)
     }
 
     func record(_ value: Value) {

--- a/Sources/OTel/OTelCore/Metrics/MetricStore/Histogram.swift
+++ b/Sources/OTel/OTelCore/Metrics/MetricStore/Histogram.swift
@@ -25,6 +25,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOConcurrencyHelpers
+import Tracing
 
 /// A type that can be used in a ``Histogram`` to create bucket boundaries.
 protocol Bucketable: AdditiveArithmetic, Comparable, Sendable {
@@ -52,6 +53,7 @@ final class Histogram<Value: Bucketable>: Sendable {
         @usableFromInline var max: Value?
         @usableFromInline var sum: Value
         @usableFromInline var count: Int
+        @usableFromInline var startTimeNanoseconds: UInt64
 
         @inlinable
         init(buckets: [Value]) {
@@ -60,6 +62,7 @@ final class Histogram<Value: Bucketable>: Sendable {
             max = nil
             sum = .zero
             count = 0
+            startTimeNanoseconds = DefaultTracerClock.now.nanosecondsSinceEpoch
             self.buckets = buckets.map { ($0, 0) }
         }
     }

--- a/Sources/OTel/OTelCore/Metrics/MetricStore/OTelMetricRegistry.swift
+++ b/Sources/OTel/OTelCore/Metrics/MetricStore/OTelMetricRegistry.swift
@@ -20,6 +20,7 @@ import struct NIOConcurrencyHelpers.NIOLockedValueBox
 /// measurements.
 final class OTelMetricRegistry: Sendable {
     private let logger: Logger
+    private let temporality: OTelAggregationTemporality
 
     struct Storage {
         var counters = [InstrumentIdentifier: [Set<Attribute>: Counter]]()
@@ -70,23 +71,25 @@ final class OTelMetricRegistry: Sendable {
         static let crash = Self(behavior: .crash)
     }
 
-    init(duplicateRegistrationHandler: some DuplicateRegistrationHandler, logger: Logger) {
+    init(duplicateRegistrationHandler: some DuplicateRegistrationHandler, temporality: OTelAggregationTemporality = .cumulative, logger: Logger) {
         self.logger = logger.withMetadata(component: "OTelMetricRegistry")
-        self.storage = .init(Storage(duplicateRegistrationHandler: duplicateRegistrationHandler))
+        self.temporality = temporality
+        storage = .init(Storage(duplicateRegistrationHandler: duplicateRegistrationHandler))
     }
 
     /// Create a new ``OTelMetricRegistry``.
     /// - Parameters:
     ///   - onDuplicateRegistration: Action to take when more than one instrument of the same name is created with
     ///     different identifying fields.
+    ///   - temporality: The aggregation temporality preference for exported metrics.
     ///
     /// - Seealso: ``OTelMetricRegistry/DuplicateRegistrationBehavior``.
-    convenience init(onDuplicateRegistration: DuplicateRegistrationBehavior = .warn, logger: Logger) {
+    convenience init(onDuplicateRegistration: DuplicateRegistrationBehavior = .warn, temporality: OTelAggregationTemporality = .cumulative, logger: Logger) {
         switch onDuplicateRegistration.behavior {
         case .warn:
-            self.init(duplicateRegistrationHandler: WarningDuplicateRegistrationHandler(logger: logger), logger: logger)
+            self.init(duplicateRegistrationHandler: WarningDuplicateRegistrationHandler(logger: logger), temporality: temporality, logger: logger)
         case .crash:
-            self.init(duplicateRegistrationHandler: FatalErrorDuplicateRegistrationHandler(), logger: logger)
+            self.init(duplicateRegistrationHandler: FatalErrorDuplicateRegistrationHandler(), temporality: temporality, logger: logger)
         }
     }
 
@@ -97,13 +100,13 @@ final class OTelMetricRegistry: Sendable {
                 if let existingInstrument = existingInstruments[attributes] {
                     return existingInstrument
                 }
-                let newInstrument = Counter(name: name, unit: unit, description: description, attributes: attributes)
+                let newInstrument = Counter(name: name, unit: unit, description: description, attributes: attributes, temporality: temporality)
                 existingInstruments[attributes] = newInstrument
                 storage.counters[identifier] = existingInstruments
                 return newInstrument
             }
             storage.register(identifier, forName: name)
-            let newInstrument = Counter(name: name, unit: unit, description: description, attributes: attributes)
+            let newInstrument = Counter(name: name, unit: unit, description: description, attributes: attributes, temporality: temporality)
             storage.counters[identifier] = [attributes: newInstrument]
             return newInstrument
         }
@@ -116,13 +119,13 @@ final class OTelMetricRegistry: Sendable {
                 if let existingInstrument = existingInstruments[attributes] {
                     return existingInstrument
                 }
-                let newInstrument = FloatingPointCounter(name: name, unit: unit, description: description, attributes: attributes)
+                let newInstrument = FloatingPointCounter(name: name, unit: unit, description: description, attributes: attributes, temporality: temporality)
                 existingInstruments[attributes] = newInstrument
                 storage.floatingPointCounters[identifier] = existingInstruments
                 return newInstrument
             }
             storage.register(identifier, forName: name)
-            let newInstrument = FloatingPointCounter(name: name, unit: unit, description: description, attributes: attributes)
+            let newInstrument = FloatingPointCounter(name: name, unit: unit, description: description, attributes: attributes, temporality: temporality)
             storage.floatingPointCounters[identifier] = [attributes: newInstrument]
             return newInstrument
         }
@@ -154,13 +157,13 @@ final class OTelMetricRegistry: Sendable {
                 if let existingInstrument = existingInstruments[attributes] {
                     return existingInstrument
                 }
-                let newInstrument = DurationHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets)
+                let newInstrument = DurationHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets, temporality: temporality)
                 existingInstruments[attributes] = newInstrument
                 storage.durationHistograms[identifier] = existingInstruments
                 return newInstrument
             }
             storage.register(identifier, forName: name)
-            let newInstrument = DurationHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets)
+            let newInstrument = DurationHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets, temporality: temporality)
             storage.durationHistograms[identifier] = [attributes: newInstrument]
             return newInstrument
         }
@@ -173,13 +176,13 @@ final class OTelMetricRegistry: Sendable {
                 if let existingInstrument = existingInstruments[attributes] {
                     return existingInstrument
                 }
-                let newInstrument = ValueHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets)
+                let newInstrument = ValueHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets, temporality: temporality)
                 existingInstruments[attributes] = newInstrument
                 storage.valueHistograms[identifier] = existingInstruments
                 return newInstrument
             }
             storage.register(identifier, forName: name)
-            let newInstrument = ValueHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets)
+            let newInstrument = ValueHistogram(name: name, unit: unit, description: description, attributes: attributes, buckets: buckets, temporality: temporality)
             storage.valueHistograms[identifier] = [attributes: newInstrument]
             return newInstrument
         }

--- a/Sources/OTel/OTelCore/Metrics/OTelInstrument/Counter+OTelInstrument.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelInstrument/Counter+OTelInstrument.swift
@@ -34,6 +34,7 @@ extension Counter: OTelMetricInstrument {
             data: .sum(OTelSum(
                 points: [.init(
                     attributes: attributes.map { OTelAttribute(key: $0.key, value: $0.value) },
+                    startTimeNanosecondsSinceEpoch: startTime,
                     timeNanosecondsSinceEpoch: instant.nanosecondsSinceEpoch,
                     value: .int64(value)
                 )],

--- a/Sources/OTel/OTelCore/Metrics/OTelInstrument/Counter+OTelInstrument.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelInstrument/Counter+OTelInstrument.swift
@@ -14,19 +14,26 @@ import Tracing
 
 extension Counter: OTelMetricInstrument {
     /// Return the current state as an OTel metric data point.
-    ///
-    /// Since our simplifed Swift Metrics backend datamodel only stores the current count, the only sensible mapping to
-    /// an OTel data point we can provide is a sum, with cumulative aggregation temporality.
     func measure() -> OTelMetricPoint {
         measure(instant: DefaultTracerClock.now)
     }
 
     /// Return the current state as an OTel metric data point.
     ///
-    /// Since our simplifed Swift Metrics backend datamodel only stores the current count, the only sensible mapping to
-    /// an OTel data point we can provide is a sum, with cumulative aggregation temporality.
+    /// For cumulative temporality, reports the running total.
+    /// For delta temporality, atomically reads and resets the counter,
+    /// advancing the start time for the next interval.
     func measure(instant: some TracerInstant) -> OTelMetricPoint {
-        let value = atomic.load(ordering: .relaxed)
+        let value: Int64
+        let startTime: UInt64
+        switch temporality.temporality {
+        case .delta:
+            value = atomic.exchange(0, ordering: .relaxed)
+            startTime = startTimeNanoseconds.exchange(instant.nanosecondsSinceEpoch, ordering: .relaxed)
+        case .cumulative:
+            value = atomic.load(ordering: .relaxed)
+            startTime = startTimeNanoseconds.load(ordering: .relaxed)
+        }
         return OTelMetricPoint(
             name: name,
             description: description ?? "",
@@ -36,11 +43,11 @@ extension Counter: OTelMetricInstrument {
                     attributes: attributes.map { OTelAttribute(key: $0.key, value: $0.value) },
                     startTimeNanosecondsSinceEpoch: startTime,
                     timeNanosecondsSinceEpoch: instant.nanosecondsSinceEpoch,
-                    value: .int64(value)
+                    value: .int64(value),
                 )],
-                aggregationTemporality: .cumulative,
-                monotonic: true
-            ))
+                aggregationTemporality: temporality,
+                monotonic: true,
+            )),
         )
     }
 }

--- a/Sources/OTel/OTelCore/Metrics/OTelInstrument/FloatingPointCounter+OTelInstrument.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelInstrument/FloatingPointCounter+OTelInstrument.swift
@@ -34,6 +34,7 @@ extension FloatingPointCounter: OTelMetricInstrument {
             data: .sum(OTelSum(
                 points: [.init(
                     attributes: attributes.map { OTelAttribute(key: $0.key, value: $0.value) },
+                    startTimeNanosecondsSinceEpoch: startTime,
                     timeNanosecondsSinceEpoch: instant.nanosecondsSinceEpoch,
                     value: .double(value)
                 )],

--- a/Sources/OTel/OTelCore/Metrics/OTelInstrument/FloatingPointCounter+OTelInstrument.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelInstrument/FloatingPointCounter+OTelInstrument.swift
@@ -14,19 +14,26 @@ import Tracing
 
 extension FloatingPointCounter: OTelMetricInstrument {
     /// Return the current state as an OTel metric data point.
-    ///
-    /// Since our simplifed Swift Metrics backend datamodel only stores the current count, the only sensible mapping to
-    /// an OTel data point we can provide is a sum, with cumulative aggregation temporality.
     func measure() -> OTelMetricPoint {
         measure(instant: DefaultTracerClock.now)
     }
 
     /// Return the current state as an OTel metric data point.
     ///
-    /// Since our simplifed Swift Metrics backend datamodel only stores the current count, the only sensible mapping to
-    /// an OTel data point we can provide is a sum, with cumulative aggregation temporality.
+    /// For cumulative temporality, reports the running total.
+    /// For delta temporality, atomically reads and resets the counter,
+    /// advancing the start time for the next interval.
     func measure(instant: some TracerInstant) -> OTelMetricPoint {
-        let value = Double(bitPattern: atomic.load(ordering: .relaxed))
+        let value: Double
+        let startTime: UInt64
+        switch temporality.temporality {
+        case .delta:
+            value = Double(bitPattern: atomic.exchange(Double.zero.bitPattern, ordering: .relaxed))
+            startTime = startTimeNanoseconds.exchange(instant.nanosecondsSinceEpoch, ordering: .relaxed)
+        case .cumulative:
+            value = Double(bitPattern: atomic.load(ordering: .relaxed))
+            startTime = startTimeNanoseconds.load(ordering: .relaxed)
+        }
         return OTelMetricPoint(
             name: name,
             description: description ?? "",
@@ -36,11 +43,11 @@ extension FloatingPointCounter: OTelMetricInstrument {
                     attributes: attributes.map { OTelAttribute(key: $0.key, value: $0.value) },
                     startTimeNanosecondsSinceEpoch: startTime,
                     timeNanosecondsSinceEpoch: instant.nanosecondsSinceEpoch,
-                    value: .double(value)
+                    value: .double(value),
                 )],
-                aggregationTemporality: .cumulative,
-                monotonic: true
-            ))
+                aggregationTemporality: temporality,
+                monotonic: true,
+            )),
         )
     }
 }

--- a/Sources/OTel/OTelCore/Metrics/OTelInstrument/Histogram+OTelInstrument.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelInstrument/Histogram+OTelInstrument.swift
@@ -14,19 +14,27 @@ import Tracing
 
 extension Histogram: OTelMetricInstrument {
     /// Return the current state as an OTel metric data point.
-    ///
-    /// Since our simplifed Swift Metrics backend datamodel only stores the current bucket counts, the only sensible
-    /// mapping to an OTel data point we can provide uses cumulative aggregation temporality.
     func measure() -> OTelMetricPoint {
         measure(instant: DefaultTracerClock.now)
     }
 
     /// Return the current state as an OTel metric data point.
     ///
-    /// Since our simplifed Swift Metrics backend datamodel only stores the current bucket counts, the only sensible
-    /// mapping to an OTel data point we can provide uses cumulative aggregation temporality.
+    /// For cumulative temporality, reports the all-time state.
+    /// For delta temporality, snapshots the state, resets it, and
+    /// advances the start time for the next interval.
     func measure(instant: some TracerInstant) -> OTelMetricPoint {
-        let state = box.withLockedValue { $0 }
+        let state: State = box.withLockedValue { state in
+            switch temporality.temporality {
+            case .delta:
+                let snapshot = state
+                state = emptyState
+                state.startTimeNanoseconds = instant.nanosecondsSinceEpoch
+                return snapshot
+            case .cumulative:
+                return state
+            }
+        }
         var bucketCounts = [UInt64]()
         var explicitBounds = [Double]()
         explicitBounds.reserveCapacity(state.buckets.count)
@@ -35,14 +43,13 @@ extension Histogram: OTelMetricInstrument {
             bucketCounts.append(UInt64(bucket.count))
             explicitBounds.append(bucket.bound.bucketRepresentation)
         }
-        // The count above the highest explicit bound, should be present in bucket counts, but not explicit bounds.
         bucketCounts.append(UInt64(state.countAboveUpperBound))
         return OTelMetricPoint(
             name: name,
             description: description ?? "",
             unit: unit ?? "",
             data: .histogram(OTelHistogram(
-                aggregationTemporality: .cumulative,
+                aggregationTemporality: temporality,
                 points: [.init(
                     attributes: attributes.map { OTelAttribute(key: $0.key, value: $0.value) },
                     startTimeNanosecondsSinceEpoch: state.startTimeNanoseconds,
@@ -52,9 +59,9 @@ extension Histogram: OTelMetricInstrument {
                     min: state.min?.bucketRepresentation,
                     max: state.max?.bucketRepresentation,
                     bucketCounts: bucketCounts,
-                    explicitBounds: explicitBounds
-                )]
-            ))
+                    explicitBounds: explicitBounds,
+                )],
+            )),
         )
     }
 }

--- a/Sources/OTel/OTelCore/Metrics/OTelInstrument/Histogram+OTelInstrument.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelInstrument/Histogram+OTelInstrument.swift
@@ -45,6 +45,7 @@ extension Histogram: OTelMetricInstrument {
                 aggregationTemporality: .cumulative,
                 points: [.init(
                     attributes: attributes.map { OTelAttribute(key: $0.key, value: $0.value) },
+                    startTimeNanosecondsSinceEpoch: state.startTimeNanoseconds,
                     timeNanosecondsSinceEpoch: instant.nanosecondsSinceEpoch,
                     count: UInt64(state.count),
                     sum: state.sum.bucketRepresentation,

--- a/Sources/OTel/OTelCore/OTel+Configuration+Environment.swift
+++ b/Sources/OTel/OTelCore/OTel+Configuration+Environment.swift
@@ -55,6 +55,7 @@ extension OTel.Configuration.Key.GeneralKey {
     static let logLevel = Self(key: "OTEL_LOG_LEVEL")
     static let tracesExporter = Self(key: "OTEL_TRACES_EXPORTER")
     static let metricsExporter = Self(key: "OTEL_METRICS_EXPORTER")
+    static let metricsTemporalityPreference = Self(key: "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE")
     static let metricExportInterval = Self(key: "OTEL_METRIC_EXPORT_INTERVAL")
     static let metricExportTimeout = Self(key: "OTEL_METRIC_EXPORT_TIMEOUT")
     static let metricDefaultValueHistogramBuckets = Self(key: "OTEL_SWIFT_METRICS_DEFAULT_VALUE_HISTOGRAM_BUCKETS")

--- a/Sources/OTel/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
+++ b/Sources/OTel/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
@@ -43,6 +43,7 @@ extension OTel.Configuration.MetricsConfiguration {
         defaultValueHistogramBuckets.override(using: .metricDefaultValueHistogramBuckets, from: environment, logger: logger)
         defaultDurationHistogramBuckets.override(using: .metricDefaultDurationHistogramBuckets, from: environment, logger: logger)
         exporter.override(using: .metricsExporter, from: environment, logger: logger)
+        temporalityPreference.override(using: .metricsTemporalityPreference, from: environment, logger: logger)
         otlpExporter.applyEnvironmentOverrides(environment: environment, signal: .metrics, logger: logger)
     }
 }

--- a/Sources/OTel/OTelCore/OTel+Configuration+EnvironmentVariableRepresentable.swift
+++ b/Sources/OTel/OTelCore/OTel+Configuration+EnvironmentVariableRepresentable.swift
@@ -221,6 +221,7 @@ extension OTel.Configuration.Propagator: OTelEnum {}
 extension OTel.Configuration.LogLevel: OTelEnum {}
 extension OTel.Configuration.LogsConfiguration.ExporterSelection: OTelEnum {}
 extension OTel.Configuration.MetricsConfiguration.ExporterSelection: OTelEnum {}
+extension OTel.Configuration.MetricsConfiguration.TemporalityPreference: OTelEnum {}
 extension OTel.Configuration.TracesConfiguration.ExporterSelection: OTelEnum {}
 extension OTel.Configuration.OTLPExporterConfiguration.Compression: OTelEnum {}
 // swiftformat:disable:next redundantBackticks

--- a/Tests/OTelTests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
@@ -488,6 +488,24 @@ import Testing
         }
     }
 
+    // OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE
+    // https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/#additional-environment-variable-configuration
+    @Test func metricsTemporalityPreference() {
+        #expect(OTel.Configuration.default.metrics.temporalityPreference.backing == .cumulative)
+
+        #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": "delta",
+        ]).metrics.temporalityPreference.backing == .delta)
+
+        #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": "cumulative",
+        ]).metrics.temporalityPreference.backing == .cumulative)
+
+        #expect(OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE": "mumble",
+        ]).metrics.temporalityPreference.backing == .cumulative)
+    }
+
     // OTEL_LOGS_EXPORTER
     // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
     // https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_logs_exporter

--- a/Tests/OTelTests/OTelCoreTests/Metrics/OTelInstrument/CounterMeasurementTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/OTelInstrument/CounterMeasurementTests.swift
@@ -67,4 +67,31 @@ final class CounterMeasurementTests: XCTestCase {
         let counter = Counter(name: "my_counter", attributes: [])
         XCTAssertEqual(counter.measure(instant: .constant(42)).data.asSum?.points.first?.timeNanosecondsSinceEpoch, 42)
     }
+
+    func test_measure_withDeltaTemporality_returnsDeltaSum() {
+        let counter = Counter(name: "my_counter", attributes: [], temporality: .delta)
+        counter.measure().data.assertIsDeltaSumWithOneValue(.int64(0))
+
+        counter.increment(by: 5)
+        counter.measure().data.assertIsDeltaSumWithOneValue(.int64(5))
+
+        counter.measure().data.assertIsDeltaSumWithOneValue(.int64(0))
+
+        counter.increment(by: 3)
+        counter.increment(by: 2)
+        counter.measure().data.assertIsDeltaSumWithOneValue(.int64(5))
+    }
+
+    func test_measure_withDeltaTemporality_followingConcurrentIncrement_returnsDeltaSum() async {
+        let counter = Counter(name: "my_counter", attributes: [], temporality: .delta)
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 100_000 {
+                group.addTask {
+                    counter.increment(by: 1)
+                }
+            }
+        }
+        counter.measure().data.assertIsDeltaSumWithOneValue(.int64(100_000))
+        counter.measure().data.assertIsDeltaSumWithOneValue(.int64(0))
+    }
 }

--- a/Tests/OTelTests/OTelCoreTests/Metrics/OTelInstrument/FloatingPointCounterMeasurementTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/OTelInstrument/FloatingPointCounterMeasurementTests.swift
@@ -70,4 +70,17 @@ final class FloatingPointCounterMeasurementTests: XCTestCase {
         let counter = FloatingPointCounter(name: "my_floating_point_counter", attributes: [])
         XCTAssertEqual(counter.measure(instant: .constant(42)).data.asSum?.points.first?.timeNanosecondsSinceEpoch, 42)
     }
+
+    func test_measure_withDeltaTemporality_returnsDeltaSum() {
+        let counter = FloatingPointCounter(name: "my_floating_point_counter", attributes: [], temporality: .delta)
+        counter.measure().data.assertIsDeltaSumWithOneValue(.double(0))
+
+        counter.increment(by: 5.5)
+        counter.measure().data.assertIsDeltaSumWithOneValue(.double(5.5))
+
+        counter.measure().data.assertIsDeltaSumWithOneValue(.double(0))
+
+        counter.increment(by: 2.5)
+        counter.measure().data.assertIsDeltaSumWithOneValue(.double(2.5))
+    }
 }

--- a/Tests/OTelTests/OTelCoreTests/Metrics/OTelInstrument/HistogramMeasurementTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/OTelInstrument/HistogramMeasurementTests.swift
@@ -104,4 +104,33 @@ final class HistogramMeasurementTests: XCTestCase {
         let histogram = DurationHistogram(name: "my_histogram", attributes: [], buckets: [])
         XCTAssertEqual(histogram.measure(instant: .constant(42)).data.asHistogram?.points.first?.timeNanosecondsSinceEpoch, 42)
     }
+
+    func test_measure_withDeltaTemporality_returnsDeltaHistogram() {
+        let histogram = DurationHistogram(name: "my_histogram", attributes: [], buckets: [
+            .milliseconds(100),
+            .milliseconds(500),
+            .seconds(1),
+        ], temporality: .delta)
+
+        histogram.record(.milliseconds(400))
+        histogram.record(.milliseconds(600))
+        histogram.measure().data.assertIsDeltaHistogramWith(
+            count: 2, sum: 1.0,
+            bucketCounts: [0, 1, 1, 0],
+            explicitBounds: [0.1, 0.5, 1.0],
+        )
+
+        histogram.measure().data.assertIsDeltaHistogramWith(
+            count: 0, sum: 0.0,
+            bucketCounts: [0, 0, 0, 0],
+            explicitBounds: [0.1, 0.5, 1.0],
+        )
+
+        histogram.record(.milliseconds(50))
+        histogram.measure().data.assertIsDeltaHistogramWith(
+            count: 1, sum: 0.05,
+            bucketCounts: [1, 0, 0, 0],
+            explicitBounds: [0.1, 0.5, 1.0],
+        )
+    }
 }

--- a/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
@@ -451,7 +451,8 @@ extension OTel.Configuration.MetricsConfiguration {
             defaultValueHistogramBuckets: defaultValueHistogramBuckets,
             valueHistogramBuckets: valueHistogramBuckets,
             exporter: exporter,
-            otlpExporter: otlpExporter
+            otlpExporter: otlpExporter,
+            temporalityPreference: .cumulative,
         )
     }
 }

--- a/Tests/OTelTests/OTelTesting/Metrics+TestHelpers.swift
+++ b/Tests/OTelTests/OTelTesting/Metrics+TestHelpers.swift
@@ -39,7 +39,7 @@ extension Histogram {
         buckets: [(bound: Value, count: Int)],
         countAboveUpperBound: Int,
         file: StaticString = #filePath,
-        line: UInt = #line
+        line: UInt = #line,
     ) {
         let state = box.withLockedValue { $0 }
         XCTAssertEqual(state.count, count, "Unexpected count", file: file, line: line)
@@ -48,7 +48,7 @@ extension Histogram {
             state.buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
             buckets.map { EquatableBucket(bound: $0.bound, count: $0.count) },
             "Unexpected buckets",
-            file: file, line: line
+            file: file, line: line,
         )
         XCTAssertEqual(state.countAboveUpperBound, countAboveUpperBound, "Unexpected countAboveUpperBound", file: file, line: line)
     }
@@ -71,14 +71,22 @@ extension OTelMetricPoint.OTelMetricData {
     }
 
     func assertIsCumulativeSumWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #filePath, line: UInt = #line) {
+        assertIsSumWithOneValue(value, temporality: .cumulative, file: file, line: line)
+    }
+
+    func assertIsDeltaSumWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #filePath, line: UInt = #line) {
+        assertIsSumWithOneValue(value, temporality: .delta, file: file, line: line)
+    }
+
+    private func assertIsSumWithOneValue(_ value: OTelNumberDataPoint.Value, temporality: OTelAggregationTemporality, file: StaticString = #filePath, line: UInt = #line) {
         guard
             case .sum(let sum) = data,
             sum.monotonic,
-            sum.aggregationTemporality == .cumulative,
+            sum.aggregationTemporality == temporality,
             sum.points.count == 1,
             let point = sum.points.first
         else {
-            XCTFail("Not cumulative sum with one point: \(self)", file: file, line: line)
+            XCTFail("Not \(temporality) sum with one point: \(self)", file: file, line: line)
             return
         }
         XCTAssertEqual(point.value, value, file: file, line: line)

--- a/Tests/OTelTests/OTelTesting/Metrics+TestHelpers.swift
+++ b/Tests/OTelTests/OTelTesting/Metrics+TestHelpers.swift
@@ -105,13 +105,21 @@ extension OTelMetricPoint.OTelMetricData {
     }
 
     func assertIsCumulativeHistogramWith(count: Int, sum: Double, bucketCounts: [UInt64], explicitBounds: [Double], file: StaticString = #filePath, line: UInt = #line) {
+        assertIsHistogramWith(count: count, sum: sum, bucketCounts: bucketCounts, explicitBounds: explicitBounds, temporality: .cumulative, file: file, line: line)
+    }
+
+    func assertIsDeltaHistogramWith(count: Int, sum: Double, bucketCounts: [UInt64], explicitBounds: [Double], file: StaticString = #filePath, line: UInt = #line) {
+        assertIsHistogramWith(count: count, sum: sum, bucketCounts: bucketCounts, explicitBounds: explicitBounds, temporality: .delta, file: file, line: line)
+    }
+
+    private func assertIsHistogramWith(count: Int, sum: Double, bucketCounts: [UInt64], explicitBounds: [Double], temporality: OTelAggregationTemporality, file: StaticString = #filePath, line: UInt = #line) {
         guard
             case .histogram(let histogram) = data,
-            histogram.aggregationTemporality == .cumulative,
+            histogram.aggregationTemporality == temporality,
             histogram.points.count == 1,
             let point = histogram.points.first
         else {
-            XCTFail("Not cumulative histogram with one point: \(self)", file: file, line: line)
+            XCTFail("Not \(temporality) histogram with one point: \(self)", file: file, line: line)
             return
         }
 


### PR DESCRIPTION
## Motivation

All metric instruments currently hardcode cumulative aggregation
temporality. The OTel specification allows users to choose between
cumulative and delta aggregation temporality depending on their
backend's preferred ingest format, but swift-otel only supports
cumulative.

The specification defines
`OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` to control this:

> **Delta**: Choose Delta aggregation temporality for Counter,
> Asynchronous Counter and Histogram instrument kinds, choose
> Cumulative aggregation for UpDownCounter and Asynchronous
> UpDownCounter.

— source: https://opentelemetry.io/docs/specs/otel/metrics/sdk_exporters/otlp/#additional-environment-variable-configuration

Additionally, the data model specification strongly recommends including
`start_time_unix_nano` for Sum and Histogram data points, which was
previously omitted:

— source: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality

## Modifications

- Populate `startTimeNanosecondsSinceEpoch` in all Sum and Histogram
  data points.
- Add `TemporalityPreference` configuration with `.cumulative` (default)
  and `.delta`, including environment variable override support.
- Implement delta aggregation for `Counter` and `FloatingPointCounter`
  using atomic exchange-and-reset, and for `Histogram` using
  snapshot-and-reset with a pre-computed empty state.
- Wire temporality preference from configuration through the metric
  registry to all instrument constructors. Gauges are unaffected.

## Result

Users can select delta temporality via
`config.metrics.temporalityPreference = .delta` or the
`OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=delta` environment
variable. Default behavior is unchanged.