### PR TITLE
Bump minimum Swift to 6.2 and test against 6.3

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -31,8 +31,8 @@ jobs:
       fail-fast: false
       matrix:
         swift:
-          - version: "6.1"
-            image: swift:6.1
+          - version: "6.2"
+            image: swift:6.2
 
     container:
       image: ${{ matrix.swift.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         swift:
           - version: "6.2"
             image: swift:6.2-rhel-ubi9
+          - version: "6.3"
+            image: swift:6.3-rhel-ubi9
 
     container:
       image: ${{ matrix.swift.image }}
@@ -131,6 +133,8 @@ jobs:
         swift:
           - version: "6.2"
             image: swift:6.2-rhel-ubi9
+          - version: "6.3"
+            image: swift:6.3-rhel-ubi9
       fail-fast: false
     container:
       image: ${{ matrix.swift.image }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         swift:
-          - version: "6.1"
-            image: swift:6.1-rhel-ubi9
           - version: "6.2"
             image: swift:6.2-rhel-ubi9
 
@@ -74,7 +72,7 @@ jobs:
     name: Documentation Check
     runs-on: ubuntu-latest
     container:
-      image: swift:6.1-noble
+      image: swift:6.2-noble
       options: --dns 1.1.1.1 --dns 8.8.8.8
     steps:
       - uses: actions/checkout@v5.0.0
@@ -131,8 +129,6 @@ jobs:
       matrix:
         example: ${{ fromJSON(needs.construct-examples-matrix.outputs.examples) }}
         swift:
-          - version: "6.1"
-            image: swift:6.1-rhel-ubi9
           - version: "6.2"
             image: swift:6.2-rhel-ubi9
       fail-fast: false

--- a/.spi.yml
+++ b/.spi.yml
@@ -2,4 +2,4 @@ version: 1
 builder:
   configs:
     - documentation_targets: [OTel]
-      swift_version: 6.1
+      swift_version: 6.2

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,6 +1,6 @@
 # file options
 
---swiftversion 6.1
+--swiftversion 6.2
 --exclude .build
 --exclude **/*.pb.swift
 --exclude **/*.grpc.swift

--- a/Examples/hello-world-grafana-lgtm/Package.swift
+++ b/Examples/hello-world-grafana-lgtm/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Examples/hello-world-hummingbird-server-logging-metadata-provider/Package.swift
+++ b/Examples/hello-world-hummingbird-server-logging-metadata-provider/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Examples/hello-world-hummingbird-server-mtls/Package.swift
+++ b/Examples/hello-world-hummingbird-server-mtls/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Examples/hello-world-hummingbird-server-only-traces/Package.swift
+++ b/Examples/hello-world-hummingbird-server-only-traces/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Examples/hello-world-hummingbird-server-otlp-grpc/Package.swift
+++ b/Examples/hello-world-hummingbird-server-otlp-grpc/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Examples/hello-world-hummingbird-server-otlp-http-json/Package.swift
+++ b/Examples/hello-world-hummingbird-server-otlp-http-json/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Examples/hello-world-hummingbird-server-otlp-http-protobuf/Package.swift
+++ b/Examples/hello-world-hummingbird-server-otlp-http-protobuf/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Examples/hello-world-hummingbird-server-tls/Package.swift
+++ b/Examples/hello-world-hummingbird-server-tls/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Examples/hello-world-vapor-server-otlp-http-protobuf/Package.swift
+++ b/Examples/hello-world-vapor-server-otlp-http-protobuf/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 
 import PackageDescription
 

--- a/Examples/hummingbird-vapor-async-http-client/Package.swift
+++ b/Examples/hummingbird-vapor-async-http-client/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.2
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.2
 import PackageDescription
 
 let sharedSwiftSettings: [SwiftSetting] = [

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ An [OpenTelemetry Protocol (OTLP)][otlp] backend for Swift Log, Swift Metrics, a
 Add the dependencies to your package and target:
 
 ```swift
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Sources/OTel/Docs.docc/Swift-OTel.md
+++ b/Sources/OTel/Docs.docc/Swift-OTel.md
@@ -27,7 +27,7 @@ An OpenTelemetry Protocol (OTLP) backend for Swift Log, Swift Metrics, and Swift
 Add the dependencies to your package and target:
 
 ```swift
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 import PackageDescription
 
 let package = Package(

--- a/Sources/OTel/OTelCore/Logging/OTelLogHandler.swift
+++ b/Sources/OTel/OTelCore/Logging/OTelLogHandler.swift
@@ -58,26 +58,18 @@ struct OTelLogHandler: Sendable, LogHandler {
         set { metadata[key] = newValue }
     }
 
-    func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
+    func log(event: LogEvent) {
         let codeMetadata: Logger.Metadata = [
-            "code.file.path": "\(file)",
-            "code.function.name": "\(function)",
-            "code.line.number": "\(line)",
+            "code.file.path": "\(event.file)",
+            "code.function.name": "\(event.function)",
+            "code.line.number": "\(event.line)",
         ]
 
         let effectiveMetadata: Logger.Metadata
-        if let metadata {
+        if let eventMetadata = event.metadata {
             effectiveMetadata = codeMetadata
                 .merging(self.metadata, uniquingKeysWith: { $1 })
-                .merging(metadata, uniquingKeysWith: { $1 })
+                .merging(eventMetadata, uniquingKeysWith: { $1 })
         } else if !self.metadata.isEmpty {
             effectiveMetadata = codeMetadata.merging(self.metadata, uniquingKeysWith: { $1 })
         } else {
@@ -85,8 +77,8 @@ struct OTelLogHandler: Sendable, LogHandler {
         }
 
         var record = OTelLogRecord(
-            body: message,
-            level: level,
+            body: event.message,
+            level: event.level,
             metadata: effectiveMetadata,
             timeNanosecondsSinceEpoch: nanosecondsSinceEpoch(),
             resource: resource,

--- a/Tests/OTelTests/OTelAPITests/BootstrapTests.swift
+++ b/Tests/OTelTests/OTelAPITests/BootstrapTests.swift
@@ -11,7 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6.2) // Swift Testing exit tests only added in 6.2
 import Foundation
 import Logging
 import Metrics
@@ -158,4 +157,3 @@ import Tracing
         }
     }
 }
-#endif // compiler(>=6.2)

--- a/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
+++ b/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
@@ -11,7 +11,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=6.2) // Swift Testing exit tests only added in 6.2
 #if canImport(FoundationEssentials)
 import struct FoundationEssentials.Data
 #else
@@ -912,4 +911,3 @@ import Tracing
         }
     }
 }
-#endif // compiler(>=6.2)

--- a/Tests/OTelTests/OTelTesting/RecordingLogHandler.swift
+++ b/Tests/OTelTests/OTelTesting/RecordingLogHandler.swift
@@ -28,19 +28,11 @@ struct RecordingLogHandler: LogHandler {
         (recordedLogMessageStream, recordedLogMessageContinuation) = AsyncStream<LogFunctionCall>.makeStream()
     }
 
-    func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
-        let metadata = self.metadata.merging(metadata ?? [:], uniquingKeysWith: { _, new in new })
-        recordedLogMessages.withLockedValue { $0.append((level, message, metadata)) }
-        counts.withLockedValue { $0[level] = $0[level, default: 0] + 1 }
-        recordedLogMessageContinuation.yield((level, message, metadata))
+    func log(event: LogEvent) {
+        let metadata = self.metadata.merging(event.metadata ?? [:], uniquingKeysWith: { _, new in new })
+        recordedLogMessages.withLockedValue { $0.append((event.level, event.message, metadata)) }
+        counts.withLockedValue { $0[event.level] = $0[event.level, default: 0] + 1 }
+        recordedLogMessageContinuation.yield((event.level, event.message, metadata))
     }
 
     var metadata: Logging.Logger.Metadata {


### PR DESCRIPTION
## Summary
- Drop Swift 6.1 support; require Swift 6.2 as the minimum toolchain.
- Add Swift 6.3 to the unit-test and examples CI matrices.

## Test plan
- [ ] CI passes on Swift 6.2
- [ ] CI passes on Swift 6.3