### PR TITLE
Adopt `LogEvent`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.2.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.11.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.0.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.4.1"),

--- a/Sources/OTel/OTelCore/Logging/OTelLogHandler.swift
+++ b/Sources/OTel/OTelCore/Logging/OTelLogHandler.swift
@@ -58,35 +58,27 @@ struct OTelLogHandler: Sendable, LogHandler {
         set { metadata[key] = newValue }
     }
 
-    func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
+    func log(event: LogEvent) {
         let codeMetadata: Logger.Metadata = [
-            "code.file.path": "\(file)",
-            "code.function.name": "\(function)",
-            "code.line.number": "\(line)",
+            "code.file.path": "\(event.file)",
+            "code.function.name": "\(event.function)",
+            "code.line.number": "\(event.line)",
         ]
 
         let effectiveMetadata: Logger.Metadata
-        if let metadata {
+        if let metadata = event.metadata {
             effectiveMetadata = codeMetadata
                 .merging(self.metadata, uniquingKeysWith: { $1 })
                 .merging(metadata, uniquingKeysWith: { $1 })
-        } else if !self.metadata.isEmpty {
-            effectiveMetadata = codeMetadata.merging(self.metadata, uniquingKeysWith: { $1 })
+        } else if !metadata.isEmpty {
+            effectiveMetadata = codeMetadata.merging(metadata, uniquingKeysWith: { $1 })
         } else {
             effectiveMetadata = codeMetadata
         }
 
         var record = OTelLogRecord(
-            body: message,
-            level: level,
+            body: event.message,
+            level: event.level,
             metadata: effectiveMetadata,
             timeNanosecondsSinceEpoch: nanosecondsSinceEpoch(),
             resource: resource,

--- a/Tests/OTelTests/OTelTesting/RecordingLogHandler.swift
+++ b/Tests/OTelTests/OTelTesting/RecordingLogHandler.swift
@@ -28,19 +28,11 @@ struct RecordingLogHandler: LogHandler {
         (recordedLogMessageStream, recordedLogMessageContinuation) = AsyncStream<LogFunctionCall>.makeStream()
     }
 
-    func log(
-        level: Logger.Level,
-        message: Logger.Message,
-        metadata: Logger.Metadata?,
-        source: String,
-        file: String,
-        function: String,
-        line: UInt
-    ) {
-        let metadata = self.metadata.merging(metadata ?? [:], uniquingKeysWith: { _, new in new })
-        recordedLogMessages.withLockedValue { $0.append((level, message, metadata)) }
-        counts.withLockedValue { $0[level] = $0[level, default: 0] + 1 }
-        recordedLogMessageContinuation.yield((level, message, metadata))
+    func log(event: LogEvent) {
+        let metadata = metadata.merging(event.metadata ?? [:], uniquingKeysWith: { _, new in new })
+        recordedLogMessages.withLockedValue { $0.append((event.level, event.message, metadata)) }
+        counts.withLockedValue { $0[event.level] = $0[event.level, default: 0] + 1 }
+        recordedLogMessageContinuation.yield((event.level, event.message, metadata))
     }
 
     var metadata: Logging.Logger.Metadata {


### PR DESCRIPTION
`swift-log` has recently gained a convenience improvement in `LogHandler` API in form of `LogEvent`. Let's adopt it in `swift-otel` to silence deprecation warning.

This is the minimal change necessary to silence the warning. `OTelLogRecord` is left unchanged and I suggest changing it as part of #413.