### PR TITLE
Add exponential histogram support

### DIFF
--- a/Sources/OTel/OTLPCore+Extensions/Metrics/OTelMetricDataModel+Proto.swift
+++ b/Sources/OTel/OTLPCore+Extensions/Metrics/OTelMetricDataModel+Proto.swift
@@ -69,6 +69,8 @@ extension Opentelemetry_Proto_Metrics_V1_Metric {
             self.sum = .init(sum)
         case .histogram(let histogram):
             self.histogram = .init(histogram)
+        case .exponentialHistogram(let histogram):
+            exponentialHistogram = .init(histogram)
         }
     }
 }
@@ -187,6 +189,47 @@ extension Opentelemetry_Proto_Metrics_V1_HistogramDataPoint {
 extension [Opentelemetry_Proto_Metrics_V1_Metric] {
     init(_ points: [OTelMetricPoint]) {
         self = points.map(Element.init)
+    }
+}
+
+extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogram {
+    init(_ histogram: OTelExponentialHistogram) {
+        self.init()
+        aggregationTemporality = .init(histogram.aggregationTemporality)
+        dataPoints = histogram.points.map(Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.init)
+    }
+}
+
+extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint {
+    init(_ point: OTelExponentialHistogramDataPoint) {
+        self.init()
+        attributes = .init(point.attributes)
+        if let startTime = point.startTimeNanosecondsSinceEpoch {
+            startTimeUnixNano = startTime
+        }
+        timeUnixNano = point.timeNanosecondsSinceEpoch
+        count = point.count
+        if let sum = point.sum {
+            self.sum = sum
+        }
+        if let min = point.min {
+            self.min = min
+        }
+        if let max = point.max {
+            self.max = max
+        }
+        scale = point.scale
+        zeroCount = point.zeroCount
+        positive = .init(point.positive)
+        negative = .init(point.negative)
+    }
+}
+
+extension Opentelemetry_Proto_Metrics_V1_ExponentialHistogramDataPoint.Buckets {
+    init(_ buckets: OTelExponentialHistogramDataPoint.Buckets) {
+        self.init()
+        offset = buckets.offset
+        bucketCounts = buckets.bucketCounts
     }
 }
 #endif

--- a/Sources/OTel/OTelAPI/OTel+Backends.swift
+++ b/Sources/OTel/OTelAPI/OTel+Backends.swift
@@ -236,6 +236,19 @@ extension OTel {
         guard resolvedConfiguration.metrics.enabled else {
             throw OTel.Configuration.Error.invalidConfiguration("makeMetricsBackend called but config has metrics disabled")
         }
+        for type in [resolvedConfiguration.metrics.defaultHistogramType] + resolvedConfiguration.metrics.histogramTypes.values {
+            guard case .exponential(let maxSize, let maxScale) = type.backing else { continue }
+            guard maxSize >= 1 else {
+                throw OTel.Configuration.Error.invalidConfiguration(
+                    "exponential histogram maxSize must be at least 1, got \(maxSize)"
+                )
+            }
+            guard (Int(expoMinScale) ... Int(expoMaxScale)).contains(maxScale) else {
+                throw OTel.Configuration.Error.invalidConfiguration(
+                    "exponential histogram maxScale must be in \(expoMinScale)...\(expoMaxScale), got \(maxScale)"
+                )
+            }
+        }
         let resource = OTelResource(configuration: resolvedConfiguration)
         let temporality: OTelAggregationTemporality = switch resolvedConfiguration.metrics.temporalityPreference.backing {
         case .cumulative: .cumulative
@@ -245,6 +258,8 @@ extension OTel {
         let factory = OTLPMetricsFactory(
             registry: registry,
             configuration: .init(
+                defaultHistogramType: .init(resolvedConfiguration.metrics.defaultHistogramType),
+                histogramTypes: resolvedConfiguration.metrics.histogramTypes.mapValues(OTLPMetricsFactory.Configuration.HistogramType.init),
                 defaultDurationHistogramBuckets: resolvedConfiguration.metrics.defaultDurationHistogramBuckets,
                 durationHistogramBuckets: resolvedConfiguration.metrics.durationHistogramBuckets,
                 defaultValueHistogramBuckets: resolvedConfiguration.metrics.defaultValueHistogramBuckets,

--- a/Sources/OTel/OTelAPI/OTel+Configuration.swift
+++ b/Sources/OTel/OTelAPI/OTel+Configuration.swift
@@ -356,6 +356,18 @@ extension OTel.Configuration {
         /// - Default value: `[:]`.
         public var valueHistogramBuckets: [String: [Double]]
 
+        /// The default histogram implementation used for metrics that don't have a per-label override.
+        ///
+        /// - Environment variable(s): `OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION`.
+        /// - Default value: `.explicitBucket`.
+        public var defaultHistogramType: HistogramType
+
+        /// Per-label histogram implementation overrides.
+        ///
+        /// - Environment variable(s): None.
+        /// - Default value: `[:]`.
+        public var histogramTypes: [String: HistogramType]
+
         /// Selection of metrics exporter implementation.
         ///
         /// - Environment variable(s): `OTEL_METRICS_EXPORTER`.
@@ -390,6 +402,8 @@ extension OTel.Configuration {
             durationHistogramBuckets: [:],
             defaultValueHistogramBuckets: defaultHistogramBuckets,
             valueHistogramBuckets: [:],
+            defaultHistogramType: .explicitBucket,
+            histogramTypes: [:],
             exporter: .otlp,
             otlpExporter: .default,
             temporalityPreference: .cumulative,
@@ -599,6 +613,33 @@ extension OTel.Configuration.TracesConfiguration {
         /// Console exporter for traces (development/debugging).
         @available(*, unavailable, message: "This option is not supported by Swift OTel")
         public static let console: Self = .init(backing: .console)
+    }
+}
+
+extension OTel.Configuration.MetricsConfiguration {
+    /// Selection of histogram implementation for metrics created via the Swift Metrics API.
+    ///
+    /// Explicit-bucket histograms use pre-configured boundaries and are suitable when the
+    /// expected value range is known. Exponential histograms use logarithmic boundaries
+    /// that auto-scale to maintain constant relative precision across all magnitudes.
+    public struct HistogramType: Sendable {
+        enum Backing: Sendable {
+            case explicitBucket
+            case exponential(maxSize: Int, maxScale: Int)
+        }
+
+        var backing: Backing
+
+        /// Explicit-bucket histogram with pre-configured boundaries.
+        public static let explicitBucket: Self = .init(backing: .explicitBucket)
+
+        /// Exponential histogram with logarithmic boundaries that auto-scale.
+        ///
+        /// - Parameter maxSize: Maximum number of buckets per side (positive/negative).
+        /// - Parameter maxScale: Initial (finest) resolution. Higher values give more buckets per doubling.
+        public static func exponential(maxSize: Int = 160, maxScale: Int = 20) -> Self {
+            .init(backing: .exponential(maxSize: maxSize, maxScale: maxScale))
+        }
     }
 }
 

--- a/Sources/OTel/OTelCore/Metrics/MetricStore/ExpoBuckets.swift
+++ b/Sources/OTel/OTelCore/Metrics/MetricStore/ExpoBuckets.swift
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2026 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Sparse bucket storage for exponential histograms.
+///
+/// Stores a dense array of counts starting at `startBin`. Expands
+/// automatically when recording bins outside the current range.
+struct ExpoBuckets: Sendable, Equatable {
+    var startBin: Int32 = 0
+    var counts: [UInt64] = []
+
+    var length: Int { counts.count }
+
+    var totalCount: UInt64 {
+        counts.reduce(0, +)
+    }
+
+    /// Increments the count at the given bin index, expanding the array as needed.
+    mutating func record(_ bin: Int32) {
+        if counts.isEmpty {
+            counts = [1]
+            startBin = bin
+            return
+        }
+
+        let endBin = Int(startBin) + counts.count - 1
+
+        if bin >= startBin, Int(bin) <= endBin {
+            counts[Int(bin - startBin)] += 1
+            return
+        }
+
+        if bin < startBin {
+            let newLength = endBin - Int(bin) + 1
+            let shift = Int(startBin - bin)
+            var newCounts = [UInt64](repeating: 0, count: newLength)
+            for i in 0 ..< counts.count {
+                newCounts[i + shift] = counts[i]
+            }
+            newCounts[0] = 1
+            counts = newCounts
+            startBin = bin
+            return
+        }
+
+        let newLength = Int(bin - startBin) + 1
+        counts.append(contentsOf: repeatElement(UInt64(0), count: newLength - counts.count))
+        counts[Int(bin - startBin)] = 1
+    }
+
+    /// Merges adjacent buckets by reducing resolution by `delta` scale levels.
+    ///
+    /// Merges every `2^delta` adjacent buckets by summing their counts.
+    mutating func downscale(by delta: Int32) {
+        if counts.count <= 1 || delta < 1 {
+            startBin >>= delta
+            return
+        }
+
+        let steps = Int32(1) << delta
+        let offset = ((startBin % steps) + steps) % steps
+        for i in 1 ..< counts.count {
+            let idx = i + Int(offset)
+            if idx % Int(steps) == 0 {
+                counts[idx / Int(steps)] = counts[i]
+            } else {
+                counts[idx / Int(steps)] += counts[i]
+            }
+        }
+
+        let lastIdx = (counts.count - 1 + Int(offset)) / Int(steps)
+        counts.removeLast(counts.count - lastIdx - 1)
+        startBin >>= delta
+    }
+}

--- a/Sources/OTel/OTelCore/Metrics/MetricStore/ExponentialHistogram.swift
+++ b/Sources/OTel/OTelCore/Metrics/MetricStore/ExponentialHistogram.swift
@@ -1,0 +1,203 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2026 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOConcurrencyHelpers
+import Tracing
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
+
+/// An exponential histogram to record timings.
+typealias DurationExponentialHistogram = ExponentialHistogram<Duration>
+/// An exponential histogram to record floating point values.
+typealias ValueExponentialHistogram = ExponentialHistogram<Double>
+
+let expoMaxScale: Int32 = 20
+let expoMinScale: Int32 = -10
+let expoDefaultMaxSize: Int = 160
+
+/// Pre-computed scale factors: `scaleFactors[s] = log2(e) * 2^s`.
+private let scaleFactors: [Double] = (0 ... 20).map {
+    Double(sign: .plus, exponent: $0, significand: M_LOG2E)
+}
+
+/// A histogram with exponentially-growing bucket boundaries that auto-scales
+/// to maintain constant relative precision across all magnitudes.
+///
+/// - SeeAlso: [OTel Exponential Histogram](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram)
+final class ExponentialHistogram<Value: Bucketable>: Sendable {
+    let name: String
+    let unit: String?
+    let description: String?
+    let attributes: Set<Attribute>
+    let temporality: OTelAggregationTemporality
+    let maxSize: Int
+    let maxScale: Int32
+    let emptyState: State
+
+    struct State: Sendable {
+        var scale: Int32
+        var positive: ExpoBuckets
+        var negative: ExpoBuckets
+        var zeroCount: UInt64
+        var sum: Double
+        var min: Double?
+        var max: Double?
+        var startTimeNanoseconds: UInt64
+    }
+
+    let box: NIOLockedValueBox<State>
+
+    init(
+        name: String,
+        unit: String? = nil,
+        description: String? = nil,
+        attributes: Set<Attribute> = [],
+        maxSize: Int = expoDefaultMaxSize,
+        maxScale: Int32 = expoMaxScale,
+        temporality: OTelAggregationTemporality = .cumulative
+    ) {
+        precondition(maxSize >= 1, "maxSize must be at least 1")
+        precondition(maxScale >= expoMinScale && maxScale <= expoMaxScale, "maxScale must be in \(expoMinScale)...\(expoMaxScale)")
+        self.name = name
+        self.unit = unit
+        self.description = description
+        self.attributes = attributes
+        self.maxSize = maxSize
+        self.maxScale = maxScale
+        self.temporality = temporality
+        let initialState = State(
+            scale: maxScale,
+            positive: ExpoBuckets(),
+            negative: ExpoBuckets(),
+            zeroCount: 0,
+            sum: 0,
+            min: nil,
+            max: nil,
+            startTimeNanoseconds: DefaultTracerClock.now.nanosecondsSinceEpoch
+        )
+        emptyState = initialState
+        box = .init(initialState)
+    }
+
+    convenience init(
+        name: String,
+        unit: String? = nil,
+        description: String? = nil,
+        attributes: [(String, String)],
+        maxSize: Int = expoDefaultMaxSize,
+        maxScale: Int32 = expoMaxScale,
+        temporality: OTelAggregationTemporality = .cumulative
+    ) {
+        self.init(
+            name: name,
+            unit: unit,
+            description: description,
+            attributes: Set(attributes),
+            maxSize: maxSize,
+            maxScale: maxScale,
+            temporality: temporality
+        )
+    }
+
+    func record(_ value: Value) {
+        let doubleValue = value.bucketRepresentation
+
+        guard doubleValue.isFinite else { return }
+
+        box.withLockedValue { state in
+            let absValue = Swift.abs(doubleValue)
+            if absValue == 0 {
+                state.sum += doubleValue
+                state.min = state.min.map { Swift.min($0, doubleValue) } ?? doubleValue
+                state.max = state.max.map { Swift.max($0, doubleValue) } ?? doubleValue
+                state.zeroCount += 1
+                return
+            }
+
+            var bin = Self.bucketIndex(for: absValue, scale: state.scale)
+
+            let isPositive = doubleValue > 0
+            let targetStartBin = isPositive ? state.positive.startBin : state.negative.startBin
+            let targetLength = isPositive ? state.positive.length : state.negative.length
+
+            let scaleDelta = Self.scaleChange(
+                bin: bin,
+                startBin: targetStartBin,
+                length: targetLength,
+                maxSize: maxSize
+            )
+
+            if scaleDelta > 0 {
+                guard state.scale - scaleDelta >= expoMinScale else { return }
+                state.scale -= scaleDelta
+                state.positive.downscale(by: scaleDelta)
+                state.negative.downscale(by: scaleDelta)
+                bin = Self.bucketIndex(for: absValue, scale: state.scale)
+            }
+
+            state.sum += doubleValue
+            state.min = state.min.map { Swift.min($0, doubleValue) } ?? doubleValue
+            state.max = state.max.map { Swift.max($0, doubleValue) } ?? doubleValue
+
+            if isPositive {
+                state.positive.record(bin)
+            } else {
+                state.negative.record(bin)
+            }
+        }
+    }
+
+    // MARK: - Bucket index calculation
+
+    /// Maps a positive value to a bucket index at the given scale.
+    ///
+    /// - Coarse scales (≤ 0): bit-shift the IEEE 754 exponent.
+    /// - Fine scales (> 0): logarithm with pre-computed factor.
+    static func bucketIndex(for value: Double, scale: Int32) -> Int32 {
+        var exp = Int32(0)
+        let frac = frexp(value, &exp)
+        if scale <= 0 {
+            let correction: Int32 = (frac == 0.5) ? 2 : 1
+            return (exp - correction) >> -scale
+        }
+        return (exp << scale) + Int32(log(frac) * scaleFactors[Int(scale)]) - 1
+    }
+
+    /// Returns how many scale levels to reduce so that `bin` fits within `maxSize`
+    /// of the existing bucket range.
+    static func scaleChange(bin: Int32, startBin: Int32, length: Int, maxSize: Int) -> Int32 {
+        if length == 0 { return 0 }
+
+        var low = Int(startBin)
+        var high = Int(bin)
+        if startBin >= bin {
+            low = Int(bin)
+            high = Int(startBin) + length - 1
+        }
+
+        var count: Int32 = 0
+        while high - low >= maxSize {
+            low >>= 1
+            high >>= 1
+            count += 1
+            if count > expoMaxScale - expoMinScale { return count }
+        }
+        return count
+    }
+}

--- a/Sources/OTel/OTelCore/Metrics/MetricStore/ExponentialHistogram.swift
+++ b/Sources/OTel/OTelCore/Metrics/MetricStore/ExponentialHistogram.swift
@@ -72,8 +72,6 @@ final class ExponentialHistogram<Value: Bucketable>: Sendable {
         maxScale: Int32 = expoMaxScale,
         temporality: OTelAggregationTemporality = .cumulative
     ) {
-        precondition(maxSize >= 1, "maxSize must be at least 1")
-        precondition(maxScale >= expoMinScale && maxScale <= expoMaxScale, "maxScale must be in \(expoMinScale)...\(expoMaxScale)")
         self.name = name
         self.unit = unit
         self.description = description

--- a/Sources/OTel/OTelCore/Metrics/MetricStore/OTelMetricRegistry.swift
+++ b/Sources/OTel/OTelCore/Metrics/MetricStore/OTelMetricRegistry.swift
@@ -28,6 +28,8 @@ final class OTelMetricRegistry: Sendable {
         var gauges = [InstrumentIdentifier: [Set<Attribute>: Gauge]]()
         var valueHistograms = [InstrumentIdentifier: [Set<Attribute>: ValueHistogram]]()
         var durationHistograms = [InstrumentIdentifier: [Set<Attribute>: DurationHistogram]]()
+        var valueExponentialHistograms = [InstrumentIdentifier: [Set<Attribute>: ValueExponentialHistogram]]()
+        var durationExponentialHistograms = [InstrumentIdentifier: [Set<Attribute>: DurationExponentialHistogram]]()
 
         var registrations = [String: Set<InstrumentIdentifier>]()
         let duplicateRegistrationHandler: DuplicateRegistrationHandler?
@@ -188,6 +190,44 @@ final class OTelMetricRegistry: Sendable {
         }
     }
 
+    func makeDurationExponentialHistogram(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = [], maxSize: Int = expoDefaultMaxSize, maxScale: Int32 = expoMaxScale) -> DurationExponentialHistogram {
+        storage.withLockedValue { storage in
+            let identifier = InstrumentIdentifier.exponentialHistogram(name: name, unit: unit, description: description)
+            if var existingInstruments = storage.durationExponentialHistograms[identifier] {
+                if let existingInstrument = existingInstruments[attributes] {
+                    return existingInstrument
+                }
+                let newInstrument = DurationExponentialHistogram(name: name, unit: unit, description: description, attributes: attributes, maxSize: maxSize, maxScale: maxScale, temporality: temporality)
+                existingInstruments[attributes] = newInstrument
+                storage.durationExponentialHistograms[identifier] = existingInstruments
+                return newInstrument
+            }
+            storage.register(identifier, forName: name)
+            let newInstrument = DurationExponentialHistogram(name: name, unit: unit, description: description, attributes: attributes, maxSize: maxSize, maxScale: maxScale, temporality: temporality)
+            storage.durationExponentialHistograms[identifier] = [attributes: newInstrument]
+            return newInstrument
+        }
+    }
+
+    func makeValueExponentialHistogram(name: String, unit: String? = nil, description: String? = nil, attributes: Set<Attribute> = [], maxSize: Int = expoDefaultMaxSize, maxScale: Int32 = expoMaxScale) -> ValueExponentialHistogram {
+        storage.withLockedValue { storage in
+            let identifier = InstrumentIdentifier.exponentialHistogram(name: name, unit: unit, description: description)
+            if var existingInstruments = storage.valueExponentialHistograms[identifier] {
+                if let existingInstrument = existingInstruments[attributes] {
+                    return existingInstrument
+                }
+                let newInstrument = ValueExponentialHistogram(name: name, unit: unit, description: description, attributes: attributes, maxSize: maxSize, maxScale: maxScale, temporality: temporality)
+                existingInstruments[attributes] = newInstrument
+                storage.valueExponentialHistograms[identifier] = existingInstruments
+                return newInstrument
+            }
+            storage.register(identifier, forName: name)
+            let newInstrument = ValueExponentialHistogram(name: name, unit: unit, description: description, attributes: attributes, maxSize: maxSize, maxScale: maxScale, temporality: temporality)
+            storage.valueExponentialHistograms[identifier] = [attributes: newInstrument]
+            return newInstrument
+        }
+    }
+
     func unregisterCounter(_ counter: Counter) {
         let identifier = counter.instrumentIdentifier
         self.storage.withLockedValue { storage in
@@ -262,13 +302,43 @@ final class OTelMetricRegistry: Sendable {
             }
         }
     }
+
+    func unregisterDurationExponentialHistogram(_ histogram: DurationExponentialHistogram) {
+        let identifier = histogram.instrumentIdentifier
+        self.storage.withLockedValue { storage in
+            if var existingInstrument = storage.durationExponentialHistograms[identifier] {
+                existingInstrument.removeValue(forKey: histogram.attributes)
+                if existingInstrument.isEmpty {
+                    storage.durationExponentialHistograms.removeValue(forKey: identifier)
+                    storage.unregister(identifier, forName: identifier.name)
+                } else {
+                    storage.durationExponentialHistograms[identifier] = existingInstrument
+                }
+            }
+        }
+    }
+
+    func unregisterValueExponentialHistogram(_ histogram: ValueExponentialHistogram) {
+        let identifier = histogram.instrumentIdentifier
+        self.storage.withLockedValue { storage in
+            if var existingInstrument = storage.valueExponentialHistograms[identifier] {
+                existingInstrument.removeValue(forKey: histogram.attributes)
+                if existingInstrument.isEmpty {
+                    storage.valueExponentialHistograms.removeValue(forKey: identifier)
+                    storage.unregister(identifier, forName: identifier.name)
+                } else {
+                    storage.valueExponentialHistograms[identifier] = existingInstrument
+                }
+            }
+        }
+    }
 }
 
 struct InstrumentIdentifier: Equatable, Hashable, Sendable {
     var name: String
     var unit: String?
     var description: String?
-    enum InstrumentKind { case counter, floatingPointCounter, gauge, histogram }
+    enum InstrumentKind { case counter, floatingPointCounter, gauge, histogram, exponentialHistogram }
     var kind: InstrumentKind
 
     private init(name: String, unit: String? = nil, description: String? = nil, kind: InstrumentKind) {
@@ -293,6 +363,10 @@ struct InstrumentIdentifier: Equatable, Hashable, Sendable {
     static func histogram(name: String, unit: String? = nil, description: String? = nil) -> Self {
         self.init(name: name, unit: unit, description: description, kind: .histogram)
     }
+
+    static func exponentialHistogram(name: String, unit: String? = nil, description: String? = nil) -> Self {
+        self.init(name: name, unit: unit, description: description, kind: .exponentialHistogram)
+    }
 }
 
 protocol IdentifiableInstrument {
@@ -313,6 +387,10 @@ extension Gauge: IdentifiableInstrument {
 
 extension Histogram: IdentifiableInstrument {
     var instrumentIdentifier: InstrumentIdentifier { .histogram(name: name, unit: unit, description: description) }
+}
+
+extension ExponentialHistogram: IdentifiableInstrument {
+    var instrumentIdentifier: InstrumentIdentifier { .exponentialHistogram(name: name, unit: unit, description: description) }
 }
 
 protocol DuplicateRegistrationHandler: Sendable {

--- a/Sources/OTel/OTelCore/Metrics/OTelInstrument/ExponentialHistogram+OTelInstrument.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelInstrument/ExponentialHistogram+OTelInstrument.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2026 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Tracing
+
+extension ExponentialHistogram: OTelMetricInstrument {
+    func measure() -> OTelMetricPoint {
+        measure(instant: DefaultTracerClock.now)
+    }
+
+    func measure(instant: some TracerInstant) -> OTelMetricPoint {
+        let state: State = box.withLockedValue { state in
+            switch temporality.temporality {
+            case .delta:
+                let snapshot = state
+                state = emptyState
+                state.startTimeNanoseconds = instant.nanosecondsSinceEpoch
+                return snapshot
+            case .cumulative:
+                return state
+            }
+        }
+
+        let count = state.positive.totalCount + state.negative.totalCount + state.zeroCount
+        let hasRecordedValues = count > 0
+
+        return OTelMetricPoint(
+            name: name,
+            description: description ?? "",
+            unit: unit ?? "",
+            data: .exponentialHistogram(OTelExponentialHistogram(
+                aggregationTemporality: temporality,
+                points: [.init(
+                    attributes: attributes.map { OTelAttribute(key: $0.key, value: $0.value) },
+                    startTimeNanosecondsSinceEpoch: state.startTimeNanoseconds,
+                    timeNanosecondsSinceEpoch: instant.nanosecondsSinceEpoch,
+                    count: count,
+                    sum: hasRecordedValues ? state.sum : nil,
+                    min: hasRecordedValues ? state.min : nil,
+                    max: hasRecordedValues ? state.max : nil,
+                    scale: state.scale,
+                    zeroCount: state.zeroCount,
+                    positive: .init(
+                        offset: state.positive.startBin,
+                        bucketCounts: state.positive.counts
+                    ),
+                    negative: .init(
+                        offset: state.negative.startBin,
+                        bucketCounts: state.negative.counts
+                    ),
+                )],
+            )),
+        )
+    }
+}

--- a/Sources/OTel/OTelCore/Metrics/OTelMetricProducer/OTLPMetricsDataModel.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelMetricProducer/OTLPMetricsDataModel.swift
@@ -59,6 +59,7 @@ struct OTelMetricPoint: Equatable, Sendable {
             case gauge(OTelGauge)
             case sum(OTelSum)
             case histogram(OTelHistogram)
+            case exponentialHistogram(OTelExponentialHistogram)
         }
 
         var data: Data
@@ -66,6 +67,7 @@ struct OTelMetricPoint: Equatable, Sendable {
         static func gauge(_ data: OTelGauge) -> Self { self.init(data: .gauge(data)) }
         static func sum(_ data: OTelSum) -> Self { self.init(data: .sum(data)) }
         static func histogram(_ data: OTelHistogram) -> Self { self.init(data: .histogram(data)) }
+        static func exponentialHistogram(_ data: OTelExponentialHistogram) -> Self { self.init(data: .exponentialHistogram(data)) }
     }
 
     var data: OTelMetricData
@@ -137,4 +139,28 @@ struct OTelHistogramDataPoint: Equatable, Sendable {
     var max: Double?
     var bucketCounts: [UInt64]
     var explicitBounds: [Double]
+}
+
+struct OTelExponentialHistogram: Equatable, Sendable {
+    var aggregationTemporality: OTelAggregationTemporality
+    var points: [OTelExponentialHistogramDataPoint]
+}
+
+struct OTelExponentialHistogramDataPoint: Equatable, Sendable {
+    struct Buckets: Equatable, Sendable {
+        var offset: Int32
+        var bucketCounts: [UInt64]
+    }
+
+    var attributes: [OTelAttribute]
+    var startTimeNanosecondsSinceEpoch: UInt64?
+    var timeNanosecondsSinceEpoch: UInt64
+    var count: UInt64
+    var sum: Double?
+    var min: Double?
+    var max: Double?
+    var scale: Int32
+    var zeroCount: UInt64
+    var positive: Buckets
+    var negative: Buckets
 }

--- a/Sources/OTel/OTelCore/Metrics/OTelMetricProducer/OTelMetricRegistry+Produce.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelMetricProducer/OTelMetricRegistry+Produce.swift
@@ -21,6 +21,8 @@ extension OTelMetricRegistry: OTelMetricProducer {
         appendGrouped(metrics.gauges, to: &buffer)
         appendGrouped(metrics.durationHistograms, to: &buffer)
         appendGrouped(metrics.valueHistograms, to: &buffer)
+        appendGrouped(metrics.durationExponentialHistograms, to: &buffer)
+        appendGrouped(metrics.valueExponentialHistograms, to: &buffer)
         return buffer
     }
 
@@ -68,6 +70,10 @@ extension OTelMetricPoint.OTelMetricData.Data {
             guard case .histogram(let other) = other else { preconditionFailure(Self.kindMismatch) }
             data.points.append(contentsOf: other.points)
             self = .histogram(data)
+        case .exponentialHistogram(var data):
+            guard case .exponentialHistogram(let other) = other else { preconditionFailure(Self.kindMismatch) }
+            data.points.append(contentsOf: other.points)
+            self = .exponentialHistogram(data)
         }
     }
 

--- a/Sources/OTel/OTelCore/Metrics/SwiftMetricsFactory/ExponentialHistogram+SwiftMetrics.swift
+++ b/Sources/OTel/OTelCore/Metrics/SwiftMetricsFactory/ExponentialHistogram+SwiftMetrics.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2026 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import CoreMetrics
+
+extension ExponentialHistogram: _SwiftMetricsSendableProtocol {}
+
+extension ExponentialHistogram: CoreMetrics.TimerHandler where Value == Duration {
+    func recordNanoseconds(_ duration: Int64) {
+        record(Duration.nanoseconds(duration))
+    }
+}
+
+extension ExponentialHistogram: CoreMetrics.RecorderHandler where Value == Double {
+    func record(_ value: Int64) {
+        record(Double(value))
+    }
+}

--- a/Sources/OTel/OTelCore/Metrics/SwiftMetricsFactory/OTLPMetricsFactory.swift
+++ b/Sources/OTel/OTelCore/Metrics/SwiftMetricsFactory/OTLPMetricsFactory.swift
@@ -59,6 +59,27 @@ extension OTLPMetricsFactory {
     ///
     /// - Seealso: See the static property ``default`` for details on the default configuration values.
     struct Configuration: Sendable {
+        /// Which histogram implementation to use for a given metric.
+        enum HistogramType: Sendable {
+            case explicitBucket
+            case exponential(maxSize: Int = expoDefaultMaxSize, maxScale: Int32 = expoMaxScale)
+
+            init(_ type: OTel.Configuration.MetricsConfiguration.HistogramType) {
+                switch type.backing {
+                case .explicitBucket:
+                    self = .explicitBucket
+                case .exponential(let maxSize, let maxScale):
+                    self = .exponential(maxSize: maxSize, maxScale: Int32(maxScale))
+                }
+            }
+        }
+
+        /// The default histogram type for metrics that don't have a per-label override.
+        var defaultHistogramType: HistogramType = .explicitBucket
+
+        /// Per-label histogram type overrides.
+        var histogramTypes: [String: HistogramType] = [:]
+
         /// The default bucket upper bounds for duration histograms created for a Swift Metrics `Timer`.
         var defaultDurationHistogramBuckets: [Duration]
 
@@ -148,6 +169,8 @@ extension OTLPMetricsFactory {
         /// [0]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/sdk.md#explicit-bucket-histogram-aggregation
         /// [1]: https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/sdk.md#duplicate-instrument-registration
         static let `default` = Self(
+            defaultHistogramType: .explicitBucket,
+            histogramTypes: [:],
             defaultDurationHistogramBuckets: defaultOTelHistogramBuckets.map(Duration.milliseconds),
             durationHistogramBuckets: [:],
             defaultValueHistogramBuckets: defaultOTelHistogramBuckets,
@@ -186,8 +209,13 @@ extension OTLPMetricsFactory: CoreMetrics.MetricsFactory {
         guard aggregate else {
             return registry.makeGauge(name: label, unit: unit, description: description, attributes: attributes)
         }
-        let buckets = configuration.valueHistogramBuckets[label] ?? configuration.defaultValueHistogramBuckets
-        return registry.makeValueHistogram(name: label, unit: unit, description: description, attributes: attributes, buckets: buckets)
+        switch configuration.histogramTypes[label] ?? configuration.defaultHistogramType {
+        case .explicitBucket:
+            let buckets = configuration.valueHistogramBuckets[label] ?? configuration.defaultValueHistogramBuckets
+            return registry.makeValueHistogram(name: label, unit: unit, description: description, attributes: attributes, buckets: buckets)
+        case .exponential(let maxSize, let maxScale):
+            return registry.makeValueExponentialHistogram(name: label, unit: unit, description: description, attributes: attributes, maxSize: maxSize, maxScale: maxScale)
+        }
     }
 
     func makeMeter(label: String, dimensions: [(String, String)]) -> CoreMetrics.MeterHandler {
@@ -203,8 +231,13 @@ extension OTLPMetricsFactory: CoreMetrics.MetricsFactory {
             return NOOPMetricsHandler.instance.makeTimer(label: label, dimensions: dimensions)
         }
         let (unit, description, attributes) = extractIdentifyingFieldsAndAttributes(from: dimensions)
-        let buckets = configuration.durationHistogramBuckets[label] ?? configuration.defaultDurationHistogramBuckets
-        return registry.makeDurationHistogram(name: label, unit: unit, description: description, attributes: attributes, buckets: buckets)
+        switch configuration.histogramTypes[label] ?? configuration.defaultHistogramType {
+        case .explicitBucket:
+            let buckets = configuration.durationHistogramBuckets[label] ?? configuration.defaultDurationHistogramBuckets
+            return registry.makeDurationHistogram(name: label, unit: unit, description: description, attributes: attributes, buckets: buckets)
+        case .exponential(let maxSize, let maxScale):
+            return registry.makeDurationExponentialHistogram(name: label, unit: unit, description: description, attributes: attributes, maxSize: maxSize, maxScale: maxScale)
+        }
     }
 
     func destroyCounter(_ handler: CoreMetrics.CounterHandler) {
@@ -227,6 +260,8 @@ extension OTLPMetricsFactory: CoreMetrics.MetricsFactory {
             registry.unregisterGauge(gauge)
         case let histogram as Histogram<Double>:
             registry.unregisterValueHistogram(histogram)
+        case let histogram as ExponentialHistogram<Double>:
+            registry.unregisterValueExponentialHistogram(histogram)
         default:
             break
         }
@@ -240,10 +275,14 @@ extension OTLPMetricsFactory: CoreMetrics.MetricsFactory {
     }
 
     func destroyTimer(_ handler: CoreMetrics.TimerHandler) {
-        guard let histogram = handler as? Histogram<Duration> else {
-            return
+        switch handler {
+        case let histogram as Histogram<Duration>:
+            registry.unregisterDurationHistogram(histogram)
+        case let histogram as ExponentialHistogram<Duration>:
+            registry.unregisterDurationExponentialHistogram(histogram)
+        default:
+            break
         }
-        registry.unregisterDurationHistogram(histogram)
     }
 }
 

--- a/Sources/OTel/OTelCore/OTel+Configuration+Environment.swift
+++ b/Sources/OTel/OTelCore/OTel+Configuration+Environment.swift
@@ -56,6 +56,7 @@ extension OTel.Configuration.Key.GeneralKey {
     static let tracesExporter = Self(key: "OTEL_TRACES_EXPORTER")
     static let metricsExporter = Self(key: "OTEL_METRICS_EXPORTER")
     static let metricsTemporalityPreference = Self(key: "OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE")
+    static let metricsDefaultHistogramAggregation = Self(key: "OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION")
     static let metricExportInterval = Self(key: "OTEL_METRIC_EXPORT_INTERVAL")
     static let metricExportTimeout = Self(key: "OTEL_METRIC_EXPORT_TIMEOUT")
     static let metricDefaultValueHistogramBuckets = Self(key: "OTEL_SWIFT_METRICS_DEFAULT_VALUE_HISTOGRAM_BUCKETS")

--- a/Sources/OTel/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
+++ b/Sources/OTel/OTelCore/OTel+Configuration+EnvironmentOverrides.swift
@@ -44,6 +44,7 @@ extension OTel.Configuration.MetricsConfiguration {
         defaultDurationHistogramBuckets.override(using: .metricDefaultDurationHistogramBuckets, from: environment, logger: logger)
         exporter.override(using: .metricsExporter, from: environment, logger: logger)
         temporalityPreference.override(using: .metricsTemporalityPreference, from: environment, logger: logger)
+        defaultHistogramType.override(using: .metricsDefaultHistogramAggregation, from: environment, logger: logger)
         otlpExporter.applyEnvironmentOverrides(environment: environment, signal: .metrics, logger: logger)
     }
 }

--- a/Sources/OTel/OTelCore/OTel+Configuration+EnvironmentVariableRepresentable.swift
+++ b/Sources/OTel/OTelCore/OTel+Configuration+EnvironmentVariableRepresentable.swift
@@ -222,6 +222,26 @@ extension OTel.Configuration.LogLevel: OTelEnum {}
 extension OTel.Configuration.LogsConfiguration.ExporterSelection: OTelEnum {}
 extension OTel.Configuration.MetricsConfiguration.ExporterSelection: OTelEnum {}
 extension OTel.Configuration.MetricsConfiguration.TemporalityPreference: OTelEnum {}
+extension OTel.Configuration.MetricsConfiguration.HistogramType: OTelEnvironmentVariableRepresentable {
+    init?(environmentVariableValue value: String) {
+        switch value.lowercased() {
+        case "explicit_bucket_histogram":
+            self = .explicitBucket
+        case "base2_exponential_bucket_histogram":
+            self = .exponential()
+        default:
+            return nil
+        }
+    }
+
+    var environmentVariableValue: String {
+        switch backing {
+        case .explicitBucket: "explicit_bucket_histogram"
+        case .exponential: "base2_exponential_bucket_histogram"
+        }
+    }
+}
+
 extension OTel.Configuration.TracesConfiguration.ExporterSelection: OTelEnum {}
 extension OTel.Configuration.OTLPExporterConfiguration.Compression: OTelEnum {}
 // swiftformat:disable:next redundantBackticks

--- a/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
+++ b/Tests/OTelTests/OTelAPITests/EndToEndTests.swift
@@ -909,6 +909,22 @@ import Tracing
             }
             #expect("\(error)" == #"invalidConfiguration("makeTracingBackend called but config has traces disabled")"#)
         }
+        do {
+            let error = try #require(throws: (any Error).self) {
+                var config = OTel.Configuration.default
+                config.metrics.defaultHistogramType = .exponential(maxSize: 0)
+                _ = try OTel.makeMetricsBackend(configuration: config)
+            }
+            #expect("\(error)" == #"invalidConfiguration("exponential histogram maxSize must be at least 1, got 0")"#)
+        }
+        do {
+            let error = try #require(throws: (any Error).self) {
+                var config = OTel.Configuration.default
+                config.metrics.defaultHistogramType = .exponential(maxScale: 50)
+                _ = try OTel.makeMetricsBackend(configuration: config)
+            }
+            #expect("\(error)" == #"invalidConfiguration("exponential histogram maxScale must be in -10...20, got 50")"#)
+        }
     }
 
     @available(gRPCSwift, *)

--- a/Tests/OTelTests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Configuration/OTelConfigurationTests.swift
@@ -506,6 +506,51 @@ import Testing
         ]).metrics.temporalityPreference.backing == .cumulative)
     }
 
+    @Test func metricsHistogramTypeDefaults() {
+        let config = OTel.Configuration.default
+        if case .explicitBucket = config.metrics.defaultHistogramType.backing {} else {
+            Issue.record("expected default histogram type to be .explicitBucket")
+        }
+        #expect(config.metrics.histogramTypes.isEmpty)
+    }
+
+    @Test func metricsHistogramTypeExponential() {
+        let exponential = OTel.Configuration.MetricsConfiguration.HistogramType.exponential(maxSize: 80, maxScale: 10)
+        guard case .exponential(let maxSize, let maxScale) = exponential.backing else {
+            Issue.record("expected .exponential")
+            return
+        }
+        #expect(maxSize == 80)
+        #expect(maxScale == 10)
+    }
+
+    @Test func metricsDefaultHistogramAggregation() {
+        if case .explicitBucket = OTel.Configuration.default.metrics.defaultHistogramType.backing {} else {
+            Issue.record("expected default to be .explicitBucket")
+        }
+
+        let exponentialOverride = OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION": "base2_exponential_bucket_histogram",
+        ]).metrics.defaultHistogramType
+        if case .exponential = exponentialOverride.backing {} else {
+            Issue.record("expected .exponential")
+        }
+
+        let explicitOverride = OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION": "explicit_bucket_histogram",
+        ]).metrics.defaultHistogramType
+        if case .explicitBucket = explicitOverride.backing {} else {
+            Issue.record("expected .explicitBucket")
+        }
+
+        let invalidOverride = OTel.Configuration.default.applyingEnvironmentOverrides(environment: [
+            "OTEL_EXPORTER_OTLP_METRICS_DEFAULT_HISTOGRAM_AGGREGATION": "mumble",
+        ]).metrics.defaultHistogramType
+        if case .explicitBucket = invalidOverride.backing {} else {
+            Issue.record("expected fallback to .explicitBucket")
+        }
+    }
+
     // OTEL_LOGS_EXPORTER
     // https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
     // https://opentelemetry.io/docs/languages/sdk-configuration/general/#otel_logs_exporter

--- a/Tests/OTelTests/OTelCoreTests/Metrics/MetricStore/ExpoBucketsTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/MetricStore/ExpoBucketsTests.swift
@@ -1,0 +1,198 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2026 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import OTel
+import XCTest
+
+final class ExpoBucketsTests: XCTestCase {
+    // MARK: - record: totalCount invariant
+
+    func test_record_incrementsTotalCountByOne() {
+        var b = ExpoBuckets()
+        for i: Int32 in 0 ..< 10 {
+            b.record(i)
+            XCTAssertEqual(b.totalCount, UInt64(i + 1))
+        }
+    }
+
+    func test_record_repeatedSameBin_accumulates() {
+        var b = ExpoBuckets()
+        b.record(3)
+        b.record(3)
+        b.record(3)
+        XCTAssertEqual(b.counts, [3])
+        XCTAssertEqual(b.startBin, 3)
+    }
+
+    // MARK: - record: empty bucket
+
+    func test_record_empty_establishesStartBin() {
+        var b = ExpoBuckets()
+        b.record(-5)
+        XCTAssertEqual(b.startBin, -5)
+        XCTAssertEqual(b.counts, [1])
+    }
+
+    // MARK: - record: in-range (no expansion)
+
+    func test_record_inRange_onlyTargetBinChanges() {
+        var b = ExpoBuckets(startBin: 3, counts: [1, 2, 3, 4, 5, 6])
+        let countBefore = b.totalCount
+        b.record(5)
+        XCTAssertEqual(b.startBin, 3)
+        XCTAssertEqual(b.counts, [1, 2, 4, 4, 5, 6])
+        XCTAssertEqual(b.totalCount, countBefore + 1)
+    }
+
+    // MARK: - record: prepend (expand left)
+
+    func test_record_prepend_expandsWithZeros() {
+        var b = ExpoBuckets(startBin: 1, counts: [1, 2, 3, 4, 5, 6])
+        b.record(-2)
+        XCTAssertEqual(b.startBin, -2)
+        XCTAssertEqual(b.counts, [1, 0, 0, 1, 2, 3, 4, 5, 6])
+    }
+
+    // MARK: - record: append (expand right)
+
+    func test_record_append_expandsWithZeros() {
+        var b = ExpoBuckets(startBin: -2, counts: [1, 2, 3, 4, 5, 6])
+        b.record(4)
+        XCTAssertEqual(b.startBin, -2)
+        XCTAssertEqual(b.counts, [1, 2, 3, 4, 5, 6, 1])
+    }
+
+    // MARK: - downscale: totalCount preservation
+
+    func test_downscale_preservesTotalCount() {
+        let cases: [(startBin: Int32, counts: [UInt64], delta: Int32)] = [
+            (0, [1, 2, 3, 4, 5, 6], 1),
+            (0, [1, 2, 3, 4, 5, 6], 2),
+            (0, [1, 2, 3, 4, 5, 6], 3),
+            (5, [1, 2, 3, 4, 5, 6], 1),
+            (7, [1, 2, 3, 4, 5, 6], 2),
+            (-4, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 1),
+            (-1, [1, 0, 3], 1),
+        ]
+        for (startBin, counts, delta) in cases {
+            var b = ExpoBuckets(startBin: startBin, counts: counts)
+            let countBefore = b.totalCount
+            b.downscale(by: delta)
+            XCTAssertEqual(
+                b.totalCount, countBefore,
+                "totalCount changed for startBin=\(startBin), counts=\(counts), delta=\(delta)"
+            )
+        }
+    }
+
+    // MARK: - downscale: composability
+
+    func test_downscale_composable_twoByOneEqualsByTwo() {
+        var stepwise = ExpoBuckets(startBin: 0, counts: [1, 2, 3, 4, 5, 6, 7, 8])
+        stepwise.downscale(by: 1)
+        stepwise.downscale(by: 1)
+
+        var direct = ExpoBuckets(startBin: 0, counts: [1, 2, 3, 4, 5, 6, 7, 8])
+        direct.downscale(by: 2)
+
+        XCTAssertEqual(stepwise, direct)
+    }
+
+    func test_downscale_composable_unaligned() {
+        var stepwise = ExpoBuckets(startBin: 3, counts: [1, 2, 3, 4, 5, 6, 7, 8])
+        stepwise.downscale(by: 1)
+        stepwise.downscale(by: 1)
+
+        var direct = ExpoBuckets(startBin: 3, counts: [1, 2, 3, 4, 5, 6, 7, 8])
+        direct.downscale(by: 2)
+
+        XCTAssertEqual(stepwise, direct)
+    }
+
+    // MARK: - downscale: boundary conditions
+
+    func test_downscale_empty_noOp() {
+        var b = ExpoBuckets()
+        b.downscale(by: 3)
+        XCTAssertEqual(b, ExpoBuckets())
+    }
+
+    func test_downscale_singleBucket_onlyShiftsStartBin() {
+        var b = ExpoBuckets(startBin: 50, counts: [7])
+        b.downscale(by: 4)
+        XCTAssertEqual(b.startBin, 3)
+        XCTAssertEqual(b.counts, [7])
+    }
+
+    func test_downscale_deltaZero_noOp() {
+        var b = ExpoBuckets(startBin: 50, counts: [7, 5])
+        b.downscale(by: 0)
+        XCTAssertEqual(b.startBin, 50)
+        XCTAssertEqual(b.counts, [7, 5])
+    }
+
+    // MARK: - downscale: negative startBin (modular arithmetic)
+
+    func test_downscale_negativeStartBin() {
+        var b = ExpoBuckets(startBin: -1, counts: [1, 0, 3])
+        b.downscale(by: 1)
+        XCTAssertEqual(b.startBin, -1)
+        XCTAssertEqual(b.counts, [1, 3])
+    }
+
+    func test_downscale_negativeStartBin_long() {
+        var b = ExpoBuckets(startBin: -4, counts: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        b.downscale(by: 1)
+        XCTAssertEqual(b.startBin, -2)
+        XCTAssertEqual(b.counts, [3, 7, 11, 15, 19])
+    }
+
+    // MARK: - downscale: unaligned startBin (offset != 0)
+
+    func test_downscale_unaligned_scale1() {
+        var b = ExpoBuckets(startBin: 5, counts: [1, 2, 3, 4, 5, 6])
+        b.downscale(by: 1)
+        XCTAssertEqual(b.startBin, 2)
+        XCTAssertEqual(b.counts, [1, 5, 9, 6])
+    }
+
+    func test_downscale_unaligned_scale2() {
+        var b = ExpoBuckets(startBin: 7, counts: [1, 2, 3, 4, 5, 6])
+        b.downscale(by: 2)
+        XCTAssertEqual(b.startBin, 1)
+        XCTAssertEqual(b.counts, [1, 14, 6])
+    }
+
+    // MARK: - downscale: aligned startBin (reference vectors)
+
+    func test_downscale_aligned_scale1() {
+        var b = ExpoBuckets(startBin: 0, counts: [1, 2, 3, 4, 5, 6])
+        b.downscale(by: 1)
+        XCTAssertEqual(b.startBin, 0)
+        XCTAssertEqual(b.counts, [3, 7, 11])
+    }
+
+    func test_downscale_aligned_scale2() {
+        var b = ExpoBuckets(startBin: 0, counts: [1, 2, 3, 4, 5, 6])
+        b.downscale(by: 2)
+        XCTAssertEqual(b.startBin, 0)
+        XCTAssertEqual(b.counts, [10, 11])
+    }
+
+    func test_downscale_aligned_scale3() {
+        var b = ExpoBuckets(startBin: 0, counts: [1, 2, 3, 4, 5, 6])
+        b.downscale(by: 3)
+        XCTAssertEqual(b.startBin, 0)
+        XCTAssertEqual(b.counts, [21])
+    }
+}

--- a/Tests/OTelTests/OTelCoreTests/Metrics/MetricStore/ExponentialHistogramTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/MetricStore/ExponentialHistogramTests.swift
@@ -1,0 +1,203 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2026 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import OTel
+import XCTest
+
+final class ExponentialHistogramTests: XCTestCase {
+    // MARK: - Bucket index at known scales
+
+    func test_bucketIndex_scale0_powersOfTwo() {
+        XCTAssertEqual(ExponentialHistogram<Double>.bucketIndex(for: 1.0, scale: 0), -1)
+        XCTAssertEqual(ExponentialHistogram<Double>.bucketIndex(for: 2.0, scale: 0), 0)
+        XCTAssertEqual(ExponentialHistogram<Double>.bucketIndex(for: 4.0, scale: 0), 1)
+        XCTAssertEqual(ExponentialHistogram<Double>.bucketIndex(for: 8.0, scale: 0), 2)
+        XCTAssertEqual(ExponentialHistogram<Double>.bucketIndex(for: 16.0, scale: 0), 3)
+    }
+
+    func test_bucketIndex_scale0_nonPowersOfTwo() {
+        XCTAssertEqual(ExponentialHistogram<Double>.bucketIndex(for: 3.0, scale: 0), 1)
+        XCTAssertEqual(ExponentialHistogram<Double>.bucketIndex(for: 5.0, scale: 0), 2)
+    }
+
+    func test_bucketIndex_negativeScale() {
+        XCTAssertEqual(ExponentialHistogram<Double>.bucketIndex(for: 1.0, scale: -1), -1)
+        XCTAssertEqual(ExponentialHistogram<Double>.bucketIndex(for: 2.0, scale: -1), 0)
+        XCTAssertEqual(ExponentialHistogram<Double>.bucketIndex(for: 4.0, scale: -1), 0)
+        XCTAssertEqual(ExponentialHistogram<Double>.bucketIndex(for: 5.0, scale: -1), 1)
+        XCTAssertEqual(ExponentialHistogram<Double>.bucketIndex(for: 16.0, scale: -1), 1)
+    }
+
+    func test_bucketIndex_scale20_extremeValues() {
+        XCTAssertEqual(
+            ExponentialHistogram<Double>.bucketIndex(for: Double.greatestFiniteMagnitude, scale: 20),
+            1_073_741_823
+        )
+        XCTAssertEqual(
+            ExponentialHistogram<Double>.bucketIndex(for: Double.leastNonzeroMagnitude, scale: 20),
+            -1_126_170_625
+        )
+    }
+
+    // MARK: - Scale change detection
+
+    func test_scaleChange_emptyBucket_noChangeNeeded() {
+        let result = ExponentialHistogram<Double>.scaleChange(bin: 5, startBin: 0, length: 0, maxSize: 4)
+        XCTAssertEqual(result, 0)
+    }
+
+    func test_scaleChange_binInRange_noChangeNeeded() {
+        let result = ExponentialHistogram<Double>.scaleChange(bin: 5, startBin: -1, length: 10, maxSize: 20)
+        XCTAssertEqual(result, 0)
+    }
+
+    func test_scaleChange_binBelowStart_needsRescale() {
+        let result = ExponentialHistogram<Double>.scaleChange(bin: 5, startBin: 8, length: 3, maxSize: 5)
+        XCTAssertEqual(result, 1)
+    }
+
+    func test_scaleChange_binAboveEnd_needsRescale() {
+        let result = ExponentialHistogram<Double>.scaleChange(bin: 7, startBin: 2, length: 3, maxSize: 5)
+        XCTAssertEqual(result, 1)
+    }
+
+    func test_scaleChange_largeGap_needsMultipleRescales() {
+        let result = ExponentialHistogram<Double>.scaleChange(bin: 13, startBin: 2, length: 3, maxSize: 5)
+        XCTAssertEqual(result, 2)
+    }
+
+    func test_scaleChange_maxSizeOne_returnsMaxDelta() {
+        let result = ExponentialHistogram<Double>.scaleChange(bin: 1, startBin: -1, length: 1, maxSize: 1)
+        XCTAssertEqual(result, 31)
+    }
+
+    // MARK: - Record: integrated behavior
+
+    func test_record_maxSize4_downscalesToScale0() {
+        let h = ValueExponentialHistogram(name: "test", maxSize: 4, maxScale: 20)
+        for v in [2.0, 4.0, 1.0] {
+            h.record(v)
+            h.record(-v)
+        }
+        let state = h.box.withLockedValue { $0 }
+        XCTAssertEqual(state.scale, 0)
+        XCTAssertEqual(state.positive, ExpoBuckets(startBin: -1, counts: [1, 1, 1]))
+        XCTAssertEqual(state.negative, ExpoBuckets(startBin: -1, counts: [1, 1, 1]))
+    }
+
+    func test_record_maxSize2_downscalesToNegativeScale() {
+        let h = ValueExponentialHistogram(name: "test", maxSize: 2, maxScale: 20)
+        for v in [1.0, 2.0, 4.0] {
+            h.record(v)
+            h.record(-v)
+        }
+        let state = h.box.withLockedValue { $0 }
+        XCTAssertEqual(state.scale, -1)
+        XCTAssertEqual(state.positive, ExpoBuckets(startBin: -1, counts: [1, 2]))
+        XCTAssertEqual(state.negative, ExpoBuckets(startBin: -1, counts: [1, 2]))
+    }
+
+    func test_record_maxSize4_withDuplicates() {
+        let h = ValueExponentialHistogram(name: "test", maxSize: 4, maxScale: 20)
+        for v in [4.0, 4.0, 4.0, 2.0, 16.0, 1.0] {
+            h.record(v)
+            h.record(-v)
+        }
+        let state = h.box.withLockedValue { $0 }
+        XCTAssertEqual(state.scale, -1)
+        XCTAssertEqual(state.positive, ExpoBuckets(startBin: -1, counts: [1, 4, 1]))
+        XCTAssertEqual(state.negative, ExpoBuckets(startBin: -1, counts: [1, 4, 1]))
+    }
+
+    // MARK: - Scale underflow
+
+    func test_record_scaleUnderflow_dropsValueEntirely() {
+        let h = ValueExponentialHistogram(name: "test", maxSize: 1, maxScale: 20)
+        h.record(1.0)
+        h.record(1_000_000.0)
+
+        let state = h.box.withLockedValue { $0 }
+        XCTAssertEqual(state.sum, 1.0)
+        XCTAssertEqual(state.min, 1.0)
+        XCTAssertEqual(state.max, 1.0)
+        XCTAssertEqual(state.positive.totalCount, 1)
+    }
+
+    // MARK: - NaN and infinity are silently ignored
+
+    func test_record_nanAndInfinity_ignored() {
+        let h = ValueExponentialHistogram(name: "test", maxSize: 4, maxScale: 20)
+        h.record(1.0)
+        h.record(Double.nan)
+        h.record(Double.signalingNaN)
+        h.record(Double.infinity)
+        h.record(-Double.infinity)
+        let state = h.box.withLockedValue { $0 }
+        XCTAssertEqual(state.sum, 1.0)
+        XCTAssertEqual(state.positive.totalCount, 1)
+    }
+
+    // MARK: - Zero handling
+
+    func test_record_zero_incrementsZeroCount() {
+        let h = ValueExponentialHistogram(name: "test", maxSize: 4, maxScale: 20)
+        h.record(0.0)
+        h.record(0.0)
+        h.record(0.0)
+        let state = h.box.withLockedValue { $0 }
+        XCTAssertEqual(state.zeroCount, 3)
+        XCTAssertEqual(state.positive.totalCount, 0)
+        XCTAssertEqual(state.negative.totalCount, 0)
+    }
+
+    // MARK: - Sum, min, max
+
+    func test_record_sumMinMax() {
+        let h = ValueExponentialHistogram(name: "test", maxSize: 4, maxScale: 20)
+        h.record(2.0)
+        h.record(4.0)
+        h.record(1.0)
+        let state = h.box.withLockedValue { $0 }
+        XCTAssertEqual(state.sum, 7.0)
+        XCTAssertEqual(state.min, 1.0)
+        XCTAssertEqual(state.max, 4.0)
+    }
+
+    func test_record_negativeValues_sumMinMax() {
+        let h = ValueExponentialHistogram(name: "test", maxSize: 4, maxScale: 20)
+        h.record(-3.0)
+        h.record(-1.0)
+        h.record(2.0)
+        let state = h.box.withLockedValue { $0 }
+        XCTAssertEqual(state.sum, -2.0)
+        XCTAssertEqual(state.min, -3.0)
+        XCTAssertEqual(state.max, 2.0)
+    }
+
+    // MARK: - Concurrency
+
+    func test_record_concurrent() async {
+        let h = ValueExponentialHistogram(name: "test", maxSize: 160, maxScale: 20)
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 100_000 {
+                group.addTask { h.record(1.0) }
+            }
+            for _ in 0 ..< 100_000 {
+                group.addTask { h.record(-1.0) }
+            }
+        }
+        let state = h.box.withLockedValue { $0 }
+        XCTAssertEqual(state.positive.totalCount + state.negative.totalCount, 200_000)
+        XCTAssertEqual(state.sum, 0.0, accuracy: 1e-9)
+    }
+}

--- a/Tests/OTelTests/OTelCoreTests/Metrics/MetricStore/OTelMetricRegistryTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/MetricStore/OTelMetricRegistryTests.swift
@@ -39,6 +39,14 @@ final class OTelMetricRegistryTests: XCTestCase {
             registry.makeValueHistogram(name: "v", buckets: []),
             registry.makeValueHistogram(name: "v", buckets: [])
         )
+        XCTAssertIdentical(
+            registry.makeDurationExponentialHistogram(name: "de"),
+            registry.makeDurationExponentialHistogram(name: "de")
+        )
+        XCTAssertIdentical(
+            registry.makeValueExponentialHistogram(name: "ve"),
+            registry.makeValueExponentialHistogram(name: "ve")
+        )
     }
 
     func test_identity_sameNameDifferentCase_identical() throws {
@@ -64,6 +72,14 @@ final class OTelMetricRegistryTests: XCTestCase {
             registry.makeValueHistogram(name: "value_histogram", buckets: []),
             registry.makeValueHistogram(name: "vAlUe_hIsToGrAm", buckets: [])
         )
+        XCTAssertIdentical(
+            registry.makeDurationExponentialHistogram(name: "duration_expo_histogram"),
+            registry.makeDurationExponentialHistogram(name: "dUrAtIoN_eXpO_hIsToGrAm")
+        )
+        XCTAssertIdentical(
+            registry.makeValueExponentialHistogram(name: "value_expo_histogram"),
+            registry.makeValueExponentialHistogram(name: "vAlUe_eXpO_hIsToGrAm")
+        )
     }
 
     func test_identity_sameNameSameLabels_identical() {
@@ -87,6 +103,14 @@ final class OTelMetricRegistryTests: XCTestCase {
         XCTAssertIdentical(
             registry.makeValueHistogram(name: "v", attributes: Set([("one", "1")]), buckets: []),
             registry.makeValueHistogram(name: "v", attributes: Set([("one", "1")]), buckets: [])
+        )
+        XCTAssertIdentical(
+            registry.makeDurationExponentialHistogram(name: "de", attributes: Set([("one", "1")])),
+            registry.makeDurationExponentialHistogram(name: "de", attributes: Set([("one", "1")]))
+        )
+        XCTAssertIdentical(
+            registry.makeValueExponentialHistogram(name: "ve", attributes: Set([("one", "1")])),
+            registry.makeValueExponentialHistogram(name: "ve", attributes: Set([("one", "1")]))
         )
     }
 
@@ -112,6 +136,14 @@ final class OTelMetricRegistryTests: XCTestCase {
             registry.makeValueHistogram(name: "v1", buckets: []),
             registry.makeValueHistogram(name: "v2", buckets: [])
         )
+        XCTAssertNotIdentical(
+            registry.makeDurationExponentialHistogram(name: "de1"),
+            registry.makeDurationExponentialHistogram(name: "de2")
+        )
+        XCTAssertNotIdentical(
+            registry.makeValueExponentialHistogram(name: "ve1"),
+            registry.makeValueExponentialHistogram(name: "ve2")
+        )
     }
 
     func test_identity_sameNameSameLabelKeysDifferentValues_distinct() {
@@ -135,6 +167,14 @@ final class OTelMetricRegistryTests: XCTestCase {
         XCTAssertNotIdentical(
             registry.makeValueHistogram(name: "v", attributes: Set([("x", "1"), ("y", "2")]), buckets: []),
             registry.makeValueHistogram(name: "v", attributes: Set([("x", "2"), ("y", "4")]), buckets: [])
+        )
+        XCTAssertNotIdentical(
+            registry.makeDurationExponentialHistogram(name: "d", attributes: Set([("x", "1"), ("y", "2")])),
+            registry.makeDurationExponentialHistogram(name: "d", attributes: Set([("x", "2"), ("y", "4")]))
+        )
+        XCTAssertNotIdentical(
+            registry.makeValueExponentialHistogram(name: "v", attributes: Set([("x", "1"), ("y", "2")])),
+            registry.makeValueExponentialHistogram(name: "v", attributes: Set([("x", "2"), ("y", "4")]))
         )
     }
 
@@ -160,6 +200,14 @@ final class OTelMetricRegistryTests: XCTestCase {
         XCTAssertNotIdentical(
             registry.makeValueHistogram(name: "v", attributes: Set([("x", "1")]), buckets: []),
             registry.makeValueHistogram(name: "v", attributes: Set([("y", "1")]), buckets: [])
+        )
+        XCTAssertNotIdentical(
+            registry.makeDurationExponentialHistogram(name: "d", attributes: Set([("x", "1")])),
+            registry.makeDurationExponentialHistogram(name: "d", attributes: Set([("y", "1")]))
+        )
+        XCTAssertNotIdentical(
+            registry.makeValueExponentialHistogram(name: "v", attributes: Set([("x", "1")])),
+            registry.makeValueExponentialHistogram(name: "v", attributes: Set([("y", "1")]))
         )
     }
 
@@ -188,6 +236,14 @@ final class OTelMetricRegistryTests: XCTestCase {
         XCTAssertNotIdentical(
             registry.makeValueHistogram(name: "v", attributes: Set([("x", "1")]), buckets: []),
             registry.makeValueHistogram(name: "v", attributes: Set([("x", "1"), ("y", "1")]), buckets: [])
+        )
+        XCTAssertNotIdentical(
+            registry.makeDurationExponentialHistogram(name: "d", attributes: Set([("x", "1")])),
+            registry.makeDurationExponentialHistogram(name: "d", attributes: Set([("x", "1"), ("y", "1")]))
+        )
+        XCTAssertNotIdentical(
+            registry.makeValueExponentialHistogram(name: "v", attributes: Set([("x", "1")])),
+            registry.makeValueExponentialHistogram(name: "v", attributes: Set([("x", "1"), ("y", "1")]))
         )
     }
 
@@ -269,6 +325,8 @@ final class OTelMetricRegistryTests: XCTestCase {
         registry.unregisterGauge(registry.makeGauge(name: "name"))
         registry.unregisterDurationHistogram(registry.makeDurationHistogram(name: "name", buckets: []))
         registry.unregisterValueHistogram(registry.makeValueHistogram(name: "name", buckets: []))
+        registry.unregisterDurationExponentialHistogram(registry.makeDurationExponentialHistogram(name: "name"))
+        registry.unregisterValueExponentialHistogram(registry.makeValueExponentialHistogram(name: "name"))
         _ = registry.makeCounter(name: "name")
 
         XCTAssertEqual(duplicateRegistrationHandler.invocations.withLockedValue { $0 }.count, 0)
@@ -292,6 +350,12 @@ final class OTelMetricRegistryTests: XCTestCase {
 
         registry.unregisterValueHistogram(registry.makeValueHistogram(name: "name", attributes: Set([("a", "1")]), buckets: []))
         registry.unregisterValueHistogram(registry.makeValueHistogram(name: "name", attributes: Set([("b", "1")]), buckets: []))
+
+        registry.unregisterDurationExponentialHistogram(registry.makeDurationExponentialHistogram(name: "name", attributes: Set([("a", "1")])))
+        registry.unregisterDurationExponentialHistogram(registry.makeDurationExponentialHistogram(name: "name", attributes: Set([("b", "1")])))
+
+        registry.unregisterValueExponentialHistogram(registry.makeValueExponentialHistogram(name: "name", attributes: Set([("a", "1")])))
+        registry.unregisterValueExponentialHistogram(registry.makeValueExponentialHistogram(name: "name", attributes: Set([("b", "1")])))
 
         _ = registry.makeCounter(name: "name", attributes: Set([("a", "1")]))
 
@@ -463,6 +527,8 @@ extension OTelMetricRegistry {
             metrics.gauges.values.map(\.values.count).reduce(0, +),
             metrics.durationHistograms.values.map(\.values.count).reduce(0, +),
             metrics.valueHistograms.values.map(\.values.count).reduce(0, +),
+            metrics.durationExponentialHistograms.values.map(\.values.count).reduce(0, +),
+            metrics.valueExponentialHistograms.values.map(\.values.count).reduce(0, +),
         ]
         return x.reduce(0, +)
     }

--- a/Tests/OTelTests/OTelCoreTests/Metrics/OTelInstrument/ExponentialHistogramMeasurementTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/OTelInstrument/ExponentialHistogramMeasurementTests.swift
@@ -1,0 +1,107 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OTel open source project
+//
+// Copyright (c) 2026 the Swift OTel project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import OTel
+import Tracing
+import XCTest
+
+final class ExponentialHistogramMeasurementTests: XCTestCase {
+    func test_measure_cumulative_returnsFullState() throws {
+        let h = ValueExponentialHistogram(name: "test", maxSize: 4, maxScale: 20, temporality: .cumulative)
+        h.record(1.0)
+        h.record(2.0)
+        h.record(4.0)
+
+        let point = h.measure(instant: DefaultTracerClock.now)
+        let histogram = try XCTUnwrap(point.data.asExponentialHistogram)
+        let dp = try XCTUnwrap(histogram.points.first)
+        XCTAssertEqual(dp.count, 3)
+        XCTAssertEqual(dp.sum, 7.0)
+        XCTAssertEqual(dp.min, 1.0)
+        XCTAssertEqual(dp.max, 4.0)
+        XCTAssertEqual(dp.scale, 0)
+        XCTAssertEqual(dp.positive.offset, -1)
+        XCTAssertEqual(dp.positive.bucketCounts, [1, 1, 1])
+        XCTAssertEqual(dp.zeroCount, 0)
+
+        let dp2 = try XCTUnwrap(h.measure(instant: DefaultTracerClock.now).data.asExponentialHistogram?.points.first)
+        XCTAssertEqual(dp2.count, 3)
+    }
+
+    func test_measure_delta_resetsState() throws {
+        let h = ValueExponentialHistogram(name: "test", maxSize: 160, temporality: .delta)
+        h.record(1.0)
+        h.record(2.0)
+        h.record(4.0)
+
+        let dp1 = try XCTUnwrap(h.measure(instant: DefaultTracerClock.now).data.asExponentialHistogram?.points.first)
+        XCTAssertEqual(dp1.count, 3)
+        XCTAssertEqual(dp1.sum, 7.0)
+
+        let dp2 = try XCTUnwrap(h.measure(instant: DefaultTracerClock.now).data.asExponentialHistogram?.points.first)
+        XCTAssertEqual(dp2.count, 0)
+        XCTAssertNil(dp2.sum)
+        XCTAssertNil(dp2.min)
+        XCTAssertNil(dp2.max)
+    }
+
+    func test_measure_zeroValues() throws {
+        let h = ValueExponentialHistogram(name: "test", maxSize: 160)
+        h.record(0.0)
+        h.record(0.0)
+        h.record(1.0)
+
+        let dp = try XCTUnwrap(h.measure(instant: DefaultTracerClock.now).data.asExponentialHistogram?.points.first)
+        XCTAssertEqual(dp.count, 3)
+        XCTAssertEqual(dp.zeroCount, 2)
+        XCTAssertEqual(dp.positive.bucketCounts.reduce(0, +), 1)
+    }
+
+    func test_measure_delta_resetsScaleToMax() throws {
+        let h = ValueExponentialHistogram(name: "test", maxSize: 4, maxScale: 20, temporality: .delta)
+        h.record(1.0)
+        h.record(2.0)
+        h.record(4.0)
+
+        let dp1 = try XCTUnwrap(h.measure(instant: DefaultTracerClock.now).data.asExponentialHistogram?.points.first)
+        XCTAssertEqual(dp1.scale, 0)
+
+        h.record(1.0)
+        let dp2 = try XCTUnwrap(h.measure(instant: DefaultTracerClock.now).data.asExponentialHistogram?.points.first)
+        XCTAssertEqual(dp2.scale, 20)
+    }
+
+    func test_measure_nameAndMetadata() {
+        let h = ExponentialHistogram<Double>(
+            name: "request_duration",
+            unit: "s",
+            description: "Request duration"
+        )
+        let point = h.measure()
+        XCTAssertEqual(point.name, "request_duration")
+        XCTAssertEqual(point.unit, "s")
+        XCTAssertEqual(point.description, "Request duration")
+    }
+
+    func test_measure_durationHistogram() throws {
+        let h = DurationExponentialHistogram(name: "latency", maxSize: 160)
+        h.record(.milliseconds(500))
+        h.record(.seconds(2))
+
+        let dp = try XCTUnwrap(h.measure(instant: DefaultTracerClock.now).data.asExponentialHistogram?.points.first)
+        XCTAssertEqual(dp.count, 2)
+        XCTAssertEqual(dp.sum, 2.5)
+        XCTAssertEqual(dp.min, 0.5)
+        XCTAssertEqual(dp.max, 2.0)
+    }
+}

--- a/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricProducer/OTelMetricRegistryProducerTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricProducer/OTelMetricRegistryProducerTests.swift
@@ -77,6 +77,26 @@ final class OTelMetricRegistryProducerTests: XCTestCase {
         XCTAssertEqual(registry.produce().count, 1)
         registry.unregisterDurationHistogram(durationHistogram)
         XCTAssertEqual(registry.produce().count, 0)
+
+        let valueExpoHistogram = registry.makeValueExponentialHistogram(name: "ve")
+        XCTAssertEqual(registry.produce().count, 1)
+        valueExpoHistogram.record(1.0)
+        XCTAssertEqual(registry.produce().count, 1)
+        valueExpoHistogram.record(Int64(42))
+        XCTAssertEqual(registry.produce().count, 1)
+        registry.unregisterValueExponentialHistogram(valueExpoHistogram)
+        XCTAssertEqual(registry.produce().count, 0)
+
+        let durationExpoHistogram = registry.makeDurationExponentialHistogram(name: "de")
+        XCTAssertEqual(registry.produce().count, 1)
+        durationExpoHistogram.record(.seconds(1))
+        XCTAssertEqual(registry.produce().count, 1)
+        durationExpoHistogram.record(.milliseconds(42))
+        XCTAssertEqual(registry.produce().count, 1)
+        durationExpoHistogram.recordNanoseconds(1234)
+        XCTAssertEqual(registry.produce().count, 1)
+        registry.unregisterDurationExponentialHistogram(durationExpoHistogram)
+        XCTAssertEqual(registry.produce().count, 0)
     }
 
     func test_produce_groupsAttributeSetsOfSameInstrumentIntoOnePoint() {

--- a/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricReader/OTelPeriodicExportingMetricsReaderTests.swift
@@ -450,6 +450,8 @@ extension OTel.Configuration.MetricsConfiguration {
             durationHistogramBuckets: durationHistogramBuckets,
             defaultValueHistogramBuckets: defaultValueHistogramBuckets,
             valueHistogramBuckets: valueHistogramBuckets,
+            defaultHistogramType: Self.default.defaultHistogramType,
+            histogramTypes: Self.default.histogramTypes,
             exporter: exporter,
             otlpExporter: otlpExporter,
             temporalityPreference: .cumulative,

--- a/Tests/OTelTests/OTelCoreTests/Metrics/SwiftMetricsFactory/OTLPMetricsFactoryTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/SwiftMetricsFactory/OTLPMetricsFactoryTests.swift
@@ -14,6 +14,7 @@
 import CoreMetrics
 import OTel
 @testable import class OTel.Counter
+@testable import class OTel.ExponentialHistogram
 @testable import class OTel.FloatingPointCounter
 @testable import class OTel.Gauge
 import XCTest
@@ -438,6 +439,115 @@ final class OTLPMetricsFactoryTests: XCTestCase {
         let factory = OTLPMetricsFactory()
         XCTAssertEqual(factory.configuration.defaultValueHistogramBuckets, defaultBucketsFromOTelSpec)
         XCTAssertEqual(factory.configuration.defaultDurationHistogramBuckets, defaultBucketsFromOTelSpec.map { .milliseconds($0) })
+    }
+
+    func test_makeTimer_exponentialConfig_returnsExponentialHistogram() throws {
+        let registry = OTelMetricRegistry()
+        var configuration = OTLPMetricsFactory.Configuration.default
+        configuration.defaultHistogramType = .exponential(maxSize: 80, maxScale: 10)
+        let factory = OTLPMetricsFactory(registry: registry, configuration: configuration)
+
+        let timer = factory.makeTimer(label: "t", dimensions: [("x", "1")])
+        let histogram = try XCTUnwrap(timer as? DurationExponentialHistogram)
+        XCTAssertEqual(histogram.name, "t")
+        XCTAssertEqual(histogram.attributes, Set([("x", "1")]))
+        XCTAssertEqual(histogram.maxSize, 80)
+        XCTAssertEqual(histogram.maxScale, 10)
+    }
+
+    func test_makeRecorder_exponentialConfig_returnsExponentialHistogram() throws {
+        let registry = OTelMetricRegistry()
+        var configuration = OTLPMetricsFactory.Configuration.default
+        configuration.defaultHistogramType = .exponential()
+        let factory = OTLPMetricsFactory(registry: registry, configuration: configuration)
+
+        let recorder = factory.makeRecorder(label: "r", dimensions: [("x", "1")], aggregate: true)
+        let histogram = try XCTUnwrap(recorder as? ValueExponentialHistogram)
+        XCTAssertEqual(histogram.name, "r")
+        XCTAssertEqual(histogram.attributes, Set([("x", "1")]))
+    }
+
+    func test_makeTimer_perLabelExponentialOverride() throws {
+        let registry = OTelMetricRegistry()
+        var configuration = OTLPMetricsFactory.Configuration.default
+        configuration.histogramTypes = ["latency": .exponential()]
+        let factory = OTLPMetricsFactory(registry: registry, configuration: configuration)
+
+        let exponential = try XCTUnwrap(factory.makeTimer(label: "latency", dimensions: []) as? DurationExponentialHistogram)
+        XCTAssertEqual(exponential.name, "latency")
+
+        let explicit = try XCTUnwrap(factory.makeTimer(label: "other", dimensions: []) as? DurationHistogram)
+        XCTAssertEqual(explicit.name, "other")
+    }
+
+    func test_exponentialTimer_methods() {
+        let registry = OTelMetricRegistry()
+        var configuration = OTLPMetricsFactory.Configuration.default
+        configuration.defaultHistogramType = .exponential()
+        let factory = OTLPMetricsFactory(registry: registry, configuration: configuration)
+        let timer = factory.makeTimer(label: "t", dimensions: [])
+
+        (timer as? DurationExponentialHistogram)?.box.withLockedValue { state in
+            XCTAssertEqual(state.positive.totalCount + state.negative.totalCount + state.zeroCount, 0)
+            XCTAssertEqual(state.sum, 0)
+        }
+
+        timer.recordNanoseconds(400)
+        (timer as? DurationExponentialHistogram)?.box.withLockedValue { state in
+            XCTAssertEqual(state.positive.totalCount + state.negative.totalCount + state.zeroCount, 1)
+            XCTAssertEqual(state.sum, Duration.nanoseconds(400).bucketRepresentation)
+        }
+
+        timer.recordNanoseconds(600)
+        (timer as? DurationExponentialHistogram)?.box.withLockedValue { state in
+            XCTAssertEqual(state.positive.totalCount + state.negative.totalCount + state.zeroCount, 2)
+            XCTAssertEqual(state.sum, Duration.nanoseconds(1000).bucketRepresentation)
+        }
+    }
+
+    func test_exponentialRecorder_methods() {
+        let registry = OTelMetricRegistry()
+        var configuration = OTLPMetricsFactory.Configuration.default
+        configuration.defaultHistogramType = .exponential()
+        let factory = OTLPMetricsFactory(registry: registry, configuration: configuration)
+        let recorder = factory.makeRecorder(label: "r", dimensions: [], aggregate: true)
+
+        (recorder as? ValueExponentialHistogram)?.box.withLockedValue { state in
+            XCTAssertEqual(state.positive.totalCount + state.negative.totalCount + state.zeroCount, 0)
+            XCTAssertEqual(state.sum, 0)
+        }
+
+        recorder.record(0.4)
+        (recorder as? ValueExponentialHistogram)?.box.withLockedValue { state in
+            XCTAssertEqual(state.positive.totalCount + state.negative.totalCount + state.zeroCount, 1)
+            XCTAssertEqual(state.sum, 0.4)
+        }
+
+        recorder.record(Int64(1))
+        (recorder as? ValueExponentialHistogram)?.box.withLockedValue { state in
+            XCTAssertEqual(state.positive.totalCount + state.negative.totalCount + state.zeroCount, 2)
+            XCTAssertEqual(state.sum, 1.4)
+        }
+    }
+
+    func test_reregister_exponentialHistograms() {
+        let duplicateRegistrationHandler = RecordingDuplicateRegistrationHandler()
+        let registry = OTelMetricRegistry(duplicateRegistrationHandler: duplicateRegistrationHandler)
+        var configuration = OTLPMetricsFactory.Configuration.default
+        configuration.defaultHistogramType = .exponential()
+        let factory = OTLPMetricsFactory(registry: registry, configuration: configuration)
+
+        let t = factory.makeTimer(label: "name", dimensions: [])
+        factory.destroyTimer(t)
+        factory.destroyTimer(t)
+
+        let r = factory.makeRecorder(label: "name", dimensions: [], aggregate: true)
+        factory.destroyRecorder(r)
+        factory.destroyRecorder(r)
+
+        _ = factory.makeTimer(label: "name", dimensions: [])
+
+        XCTAssertEqual(duplicateRegistrationHandler.invocations.withLockedValue { $0 }.count, 0)
     }
 
     func test_factoryMethods_extractUnitAndDescriptionFromDimensions() throws {

--- a/Tests/OTelTests/OTelTesting/Metrics+TestHelpers.swift
+++ b/Tests/OTelTests/OTelTesting/Metrics+TestHelpers.swift
@@ -70,6 +70,11 @@ extension OTelMetricPoint.OTelMetricData {
         return histogram
     }
 
+    var asExponentialHistogram: OTelExponentialHistogram? {
+        guard case .exponentialHistogram(let histogram) = data else { return nil }
+        return histogram
+    }
+
     func assertIsCumulativeSumWithOneValue(_ value: OTelNumberDataPoint.Value, file: StaticString = #filePath, line: UInt = #line) {
         assertIsSumWithOneValue(value, temporality: .cumulative, file: file, line: line)
     }

--- a/scripts/validate_license_headers.sh
+++ b/scripts/validate_license_headers.sh
@@ -31,7 +31,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
   # this needs to replace all acceptable forms with 'YEARS'
-  sed -e 's/202[345]/YEARS/'
+  sed -e 's/202[3456]/YEARS/'
 }
 
 printf "=> Checking license headers\n"


### PR DESCRIPTION
## Motivation

The explicit-bucket histogram requires users to pre-configure bucket boundaries. When recorded values span a wide range (e.g. latencies from sub-millisecond to minutes), fixed boundaries cause quantile estimates to snap to bucket edges, degrading precision for values far from the configured bounds.

The OTel specification defines ExponentialHistogram as an alternative that uses logarithmic bucket boundaries at `base^i` where `base = 2^(2^(-scale))`. This provides constant relative precision across all magnitudes with no upfront configuration:

> ExponentialHistogram compresses bucket boundaries using an exponential formula, making it suitable for conveying high dynamic range data with small relative error, compared with alternative representations of similar size.

— source: https://opentelemetry.io/docs/specs/otel/metrics/data-model/#exponentialhistogram

## Modifications

- Add `ExpoBuckets` value type for sparse bucket storage with `record` and `downscale` operations.
- Add `ExponentialHistogram<Value: Bucketable>` instrument with auto-scaling: starts at the finest configured scale and reduces resolution when recorded values exceed `maxSize` buckets.
- Add `OTelExponentialHistogram` and `OTelExponentialHistogramDataPoint` to the metrics data model, with measurement and protobuf export.
- Wire exponential histograms through the metric registry (storage, factory methods, `produce()`).
- Add `HistogramType` configuration to `OTLPMetricsFactory` for per-label or global selection between explicit-bucket and exponential.

## Result

Users can select exponential histograms via configuration:

```swift
configuration.defaultHistogramType = .exponential()
// or per-label:
configuration.histogramTypes = ["request_duration": .exponential(maxSize: 160, maxScale: 20)]
```

Default behavior is unchanged — all histograms remain explicit-bucket unless explicitly configured.