### PR TITLE
Sort metric attributes

### DIFF
--- a/Sources/OTel/OTLPCore+Extensions/Metrics/OTelMetricDataModel+Proto.swift
+++ b/Sources/OTel/OTLPCore+Extensions/Metrics/OTelMetricDataModel+Proto.swift
@@ -125,7 +125,9 @@ extension Opentelemetry_Proto_Metrics_V1_NumberDataPoint {
 
 extension [Opentelemetry_Proto_Common_V1_KeyValue] {
     init(_ attributes: [OTelAttribute]) {
-        self = attributes.map(Element.init)
+        // Sort by key so the wire format is deterministic regardless of producer order
+        // (metric attributes originate from a `Set` and have no defined iteration order).
+        self = attributes.sorted { $0.key < $1.key }.map(Element.init)
     }
 }
 

--- a/Tests/OTelTests/OTLPCoreTests/Metrics/OTelMetricDataModelProtoTests.swift
+++ b/Tests/OTelTests/OTLPCoreTests/Metrics/OTelMetricDataModelProtoTests.swift
@@ -168,6 +168,16 @@ final class OTelMetricDataModelProtoTests: XCTestCase {
         XCTAssertEqual(value, 42)
     }
 
+    func test_initProto_pointAttributes_protoSortedByKey() {
+        let point = OTelNumberDataPoint.stub(attributes: [
+            .stub(key: "z", value: "3"),
+            .stub(key: "a", value: "1"),
+            .stub(key: "m", value: "2"),
+        ])
+        let proto = Opentelemetry_Proto_Metrics_V1_NumberDataPoint(point)
+        XCTAssertEqual(proto.attributes.map(\.key), ["a", "m", "z"])
+    }
+
     func test_initProto_histogramPointFields_protoHasFields() {
         let point = OTelHistogramDataPoint.stub(
             attributes: [.stub()],


### PR DESCRIPTION
Sort metric attributes by key when serializing to OTLP.

## Motivation

Metric attributes are stored on instruments as `Set<Attribute>`, which has no defined iteration order, so the array of attributes attached to each exported data point can vary across exports and across processes — even for the same instrument with the same attribute values.

Per the OTLP spec, attribute lists are unordered. However, in practice, the nondeterminism surfaces in user-visible places: tests, protobuf dumps, etc. Some downstream consumers that hash or render attributes without first canonicalizing them can behave inconsistently.

## Modifications

- Sort attributes by key inside the `Opentelemetry_Proto_Common_V1_KeyValue` initializer in `Sources/OTel/OTLPCore+Extensions/Metrics/OTelMetricDataModel+Proto.swift`.
- Added `test_initProto_pointAttributes_protoSortedByKey` to test the new logic.

## Result

The order of attributes on the wire is now deterministic.