### PR TITLE
Group data points under a single `Metric`

### DIFF
--- a/Sources/OTel/OTelCore/Metrics/OTelMetricProducer/OTelMetricRegistry+Produce.swift
+++ b/Sources/OTel/OTelCore/Metrics/OTelMetricProducer/OTelMetricRegistry+Produce.swift
@@ -16,31 +16,61 @@ extension OTelMetricRegistry: OTelMetricProducer {
         let metrics = storage.withLockedValue { $0 }
         var buffer: [OTelMetricPoint] = []
         buffer.reserveCapacity(1024) // TODO: Make this configurable? Also, does this overlap with OTel "cardinality"?
-        for instruments in metrics.counters.values {
-            for instrument in instruments.values {
-                buffer.append(instrument.measure())
-            }
-        }
-        for instruments in metrics.floatingPointCounters.values {
-            for instrument in instruments.values {
-                buffer.append(instrument.measure())
-            }
-        }
-        for instruments in metrics.gauges.values {
-            for instrument in instruments.values {
-                buffer.append(instrument.measure())
-            }
-        }
-        for instruments in metrics.durationHistograms.values {
-            for instrument in instruments.values {
-                buffer.append(instrument.measure())
-            }
-        }
-        for instruments in metrics.valueHistograms.values {
-            for instrument in instruments.values {
-                buffer.append(instrument.measure())
-            }
-        }
+        appendGrouped(metrics.counters, to: &buffer)
+        appendGrouped(metrics.floatingPointCounters, to: &buffer)
+        appendGrouped(metrics.gauges, to: &buffer)
+        appendGrouped(metrics.durationHistograms, to: &buffer)
+        appendGrouped(metrics.valueHistograms, to: &buffer)
         return buffer
     }
+
+    /// Measure every instrument sharing an identifier (name, unit, description, kind) and emit them
+    /// as a single metric point carrying one data point per attribute set.
+    ///
+    /// Per the OTLP data model, a `Metric` object contains the individual streams for a given name,
+    /// each identified by its set of attributes. Emitting a separate `Metric` per stream produces
+    /// multiple `Metric` identities for one name, which the specification calls a "semantic error".
+    /// See https://opentelemetry.io/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model-producer-recommendations
+    private func appendGrouped(
+        _ instrumentsByIdentifier: [InstrumentIdentifier: [Set<Attribute>: some OTelMetricInstrument]],
+        to buffer: inout [OTelMetricPoint]
+    ) {
+        for instruments in instrumentsByIdentifier.values {
+            var iterator = instruments.values.makeIterator()
+            // The first measurement seeds the metric point's identifying fields and data kind; the
+            // rest only contribute their data points, which all match that kind by construction.
+            guard var point = iterator.next()?.measure() else { continue }
+            while let next = iterator.next() {
+                point.data.data.appendDataPoints(from: next.measure().data.data)
+            }
+            buffer.append(point)
+        }
+    }
+}
+
+extension OTelMetricPoint.OTelMetricData.Data {
+    /// Appends the data points of `other` to this metric data.
+    ///
+    /// - Precondition: `other` must be the same kind (sum, gauge, or histogram). Instruments that
+    ///   share an identifier always produce the same kind, so a mismatch is a programming error
+    ///   rather than something that can be silently dropped.
+    fileprivate mutating func appendDataPoints(from other: Self) {
+        switch self {
+        case .sum(var data):
+            guard case .sum(let other) = other else { preconditionFailure(Self.kindMismatch) }
+            data.points.append(contentsOf: other.points)
+            self = .sum(data)
+        case .gauge(var data):
+            guard case .gauge(let other) = other else { preconditionFailure(Self.kindMismatch) }
+            data.points.append(contentsOf: other.points)
+            self = .gauge(data)
+        case .histogram(var data):
+            guard case .histogram(let other) = other else { preconditionFailure(Self.kindMismatch) }
+            data.points.append(contentsOf: other.points)
+            self = .histogram(data)
+        }
+    }
+
+    private static let kindMismatch =
+        "Instruments sharing an identifier must produce the same metric kind."
 }

--- a/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricProducer/OTelMetricRegistryProducerTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricProducer/OTelMetricRegistryProducerTests.swift
@@ -92,10 +92,16 @@ final class OTelMetricRegistryProducerTests: XCTestCase {
         registry.makeCounter(name: "c", attributes: Set([("route", "b")])).increment()
         registry.makeGauge(name: "g", attributes: Set([("route", "a")])).set(1.0)
         registry.makeGauge(name: "g", attributes: Set([("route", "b")])).set(2.0)
-        registry.makeValueHistogram(name: "v", attributes: Set([("route", "a")]), buckets: []).record(
-            1.0)
-        registry.makeValueHistogram(name: "v", attributes: Set([("route", "b")]), buckets: []).record(
-            2.0)
+        registry.makeValueHistogram(
+    name: "v",
+    attributes: Set([("route", "a")]),
+    buckets: []
+).record(1.0)
+        registry.makeValueHistogram(
+    name: "v",
+    attributes: Set([("route", "b")]),
+    buckets: []
+).record(2.0)
 
         let points = registry.produce()
         XCTAssertEqual(points.count, 3)

--- a/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricProducer/OTelMetricRegistryProducerTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricProducer/OTelMetricRegistryProducerTests.swift
@@ -93,15 +93,15 @@ final class OTelMetricRegistryProducerTests: XCTestCase {
         registry.makeGauge(name: "g", attributes: Set([("route", "a")])).set(1.0)
         registry.makeGauge(name: "g", attributes: Set([("route", "b")])).set(2.0)
         registry.makeValueHistogram(
-    name: "v",
-    attributes: Set([("route", "a")]),
-    buckets: []
-).record(1.0)
+            name: "v",
+            attributes: Set([("route", "a")]),
+            buckets: []
+        ).record(1.0)
         registry.makeValueHistogram(
-    name: "v",
-    attributes: Set([("route", "b")]),
-    buckets: []
-).record(2.0)
+            name: "v",
+            attributes: Set([("route", "b")]),
+            buckets: []
+        ).record(2.0)
 
         let points = registry.produce()
         XCTAssertEqual(points.count, 3)

--- a/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricProducer/OTelMetricRegistryProducerTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Metrics/OTelMetricProducer/OTelMetricRegistryProducerTests.swift
@@ -78,4 +78,41 @@ final class OTelMetricRegistryProducerTests: XCTestCase {
         registry.unregisterDurationHistogram(durationHistogram)
         XCTAssertEqual(registry.produce().count, 0)
     }
+
+    func test_produce_groupsAttributeSetsOfSameInstrumentIntoOnePoint() {
+        let registry = OTelMetricRegistry()
+
+        // Each instrument is recorded with two distinct attribute sets, so each is two instruments
+        // sharing one identifier (name, unit, description, kind). The OTLP data model expects each
+        // to be emitted as a single metric stream with one data point per attribute set, not as
+        // separate metric points that happen to share a name. Registering several instruments in
+        // one registry also checks that grouping is keyed per identifier and never merges across
+        // different identifiers.
+        registry.makeCounter(name: "c", attributes: Set([("route", "a")])).increment()
+        registry.makeCounter(name: "c", attributes: Set([("route", "b")])).increment()
+        registry.makeGauge(name: "g", attributes: Set([("route", "a")])).set(1.0)
+        registry.makeGauge(name: "g", attributes: Set([("route", "b")])).set(2.0)
+        registry.makeValueHistogram(name: "v", attributes: Set([("route", "a")]), buckets: []).record(
+            1.0)
+        registry.makeValueHistogram(name: "v", attributes: Set([("route", "b")]), buckets: []).record(
+            2.0)
+
+        let points = registry.produce()
+        XCTAssertEqual(points.count, 3)
+
+        guard case .sum(let sum) = points.first(where: { $0.name == "c" })?.data.data else {
+            return XCTFail("Expected a single sum metric point named 'c', got \(points)")
+        }
+        XCTAssertEqual(sum.points.count, 2)
+
+        guard case .gauge(let gauge) = points.first(where: { $0.name == "g" })?.data.data else {
+            return XCTFail("Expected a single gauge metric point named 'g', got \(points)")
+        }
+        XCTAssertEqual(gauge.points.count, 2)
+
+        guard case .histogram(let histogram) = points.first(where: { $0.name == "v" })?.data.data else {
+            return XCTFail("Expected a single histogram metric point named 'v', got \(points)")
+        }
+        XCTAssertEqual(histogram.points.count, 2)
+    }
 }


### PR DESCRIPTION
### Motivation:

When an instrument is recorded with multiple different attribute sets, `swift-otel` [emits](https://github.com/swift-otel/swift-otel/blob/main/Sources/OTel/OTelCore/Metrics/OTelInstrument/Histogram%2BOTelInstrument.swift#L53) a separate `OTelMetricPoint` for each attribute set. They all share the same name, so a single `Opentelemetry_Proto_Metrics_V1_ScopeMetrics` ends up containing multiple `Metric` objects with identical identities.

Per the OTLP data model, a `Metric` object should contain the individual _streams_ for a given name, each identified by its attribute set as data points within one `Metric`. Producing **multiple** `Metric` identities for one name is explicitly called a ["semantic error"](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#opentelemetry-protocol-data-model-producer-recommendations).

### Modifications:

Group data points from instruments with the same name, but different attributes, when producing `OTelMetricPoint`s.

### Result:

No duplicate `Metric` objects reported. Fixes #424.