### PR TITLE
Propagate context even if a span is dropped

### DIFF
--- a/Sources/OTel/OTelCore/Tracing/OTelTracer.swift
+++ b/Sources/OTel/OTelCore/Tracing/OTelTracer.swift
@@ -118,8 +118,6 @@ extension OTelTracer: Service {
     }
 }
 
-private let noOpSpan = OTelSpan.noOp(NoOpTracer.NoOpSpan(context: .topLevel))
-
 extension OTelTracer: Tracer {
     func startSpan(
         _ operationName: String,
@@ -131,7 +129,9 @@ extension OTelTracer: Tracer {
         line: UInt
     ) -> OTelSpan {
         // Fast-path for constant sampler.
-        if case .constant(let sampler) = sampler, sampler.decision == .drop { return noOpSpan }
+        if case .constant(let sampler) = sampler, sampler.decision == .drop {
+            return OTelSpan.noOp(NoOpTracer.NoOpSpan(context: context()))
+        }
 
         let parentContext = context()
 
@@ -154,24 +154,26 @@ extension OTelTracer: Tracer {
             parentContext: parentContext
         )
 
+        // The SpanContext is created the same way regardless of the sampling decision: only whether the span is
+        // recorded/exported depends on the decision, not whether its context is valid and propagatable downstream.
+        // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/sdk.md#sampling
+        let spanID = idGenerator.nextSpanID()
+        let traceFlags: TraceFlags = samplingResult.decision == .recordAndSample ? .sampled : []
+        let spanContext = OTelSpanContext.local(
+            traceID: traceID,
+            spanID: spanID,
+            parentSpanID: parentContext.spanContext?.spanID,
+            traceFlags: traceFlags,
+            traceState: traceState
+        )
+        var childContext = parentContext
+        childContext.spanContext = spanContext
+
         switch samplingResult.decision {
         case .drop:
-            return noOpSpan
+            return OTelSpan.noOp(NoOpTracer.NoOpSpan(context: childContext))
 
         case .record, .recordAndSample:
-            let spanID = idGenerator.nextSpanID()
-            var childContext = parentContext
-
-            let traceFlags: TraceFlags = samplingResult.decision == .recordAndSample ? .sampled : []
-            let spanContext = OTelSpanContext.local(
-                traceID: traceID,
-                spanID: spanID,
-                parentSpanID: parentContext.spanContext?.spanID,
-                traceFlags: traceFlags,
-                traceState: traceState
-            )
-            childContext.spanContext = spanContext
-
             let recordingSpan = OTelSpan.recording(
                 operationName: operationName,
                 kind: kind,

--- a/Sources/OTel/OTelCore/Tracing/OTelTracer.swift
+++ b/Sources/OTel/OTelCore/Tracing/OTelTracer.swift
@@ -128,11 +128,6 @@ extension OTelTracer: Tracer {
         file fileID: String,
         line: UInt
     ) -> OTelSpan {
-        // Fast-path for constant sampler.
-        if case .constant(let sampler) = sampler, sampler.decision == .drop {
-            return OTelSpan.noOp(NoOpTracer.NoOpSpan(context: context()))
-        }
-
         let parentContext = context()
 
         let traceID: TraceID
@@ -154,9 +149,9 @@ extension OTelTracer: Tracer {
             parentContext: parentContext
         )
 
-        // The SpanContext is created the same way regardless of the sampling decision: only whether the span is
-        // recorded/exported depends on the decision, not whether its context is valid and propagatable downstream.
-        // https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/sdk.md#sampling
+        // A span ID is generated independently of the sampling decision, even for a dropped/non-recording span:
+        // other components (such as log correlation) rely on a unique span ID regardless of whether it's recorded.
+        // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sdk-span-creation
         let spanID = idGenerator.nextSpanID()
         let traceFlags: TraceFlags = samplingResult.decision == .recordAndSample ? .sampled : []
         let spanContext = OTelSpanContext.local(

--- a/Sources/OTel/OTelCore/Tracing/OTelTracer.swift
+++ b/Sources/OTel/OTelCore/Tracing/OTelTracer.swift
@@ -140,20 +140,31 @@ extension OTelTracer: Tracer {
             traceState = TraceState()
         }
 
-        let samplingResult = sampler.samplingResult(
-            operationName: operationName,
-            kind: kind,
-            traceID: traceID,
-            attributes: [:],
-            links: [],
-            parentContext: parentContext
-        )
+        // A constant sampler's decision doesn't depend on any of the arguments, so its algorithm never needs
+        // to run at all; only a pluggable sampler's `samplingResult` is actually worth calling.
+        let decision: OTelSamplingResult.Decision
+        let attributes: SpanAttributes
+        if case .constant(let constantSampler) = sampler {
+            decision = constantSampler.decision
+            attributes = [:]
+        } else {
+            let samplingResult = sampler.samplingResult(
+                operationName: operationName,
+                kind: kind,
+                traceID: traceID,
+                attributes: [:],
+                links: [],
+                parentContext: parentContext
+            )
+            decision = samplingResult.decision
+            attributes = samplingResult.attributes
+        }
 
         // A span ID is generated independently of the sampling decision, even for a dropped/non-recording span:
         // other components (such as log correlation) rely on a unique span ID regardless of whether it's recorded.
         // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sdk-span-creation
         let spanID = idGenerator.nextSpanID()
-        let traceFlags: TraceFlags = samplingResult.decision == .recordAndSample ? .sampled : []
+        let traceFlags: TraceFlags = decision == .recordAndSample ? .sampled : []
         let spanContext = OTelSpanContext.local(
             traceID: traceID,
             spanID: spanID,
@@ -164,7 +175,7 @@ extension OTelTracer: Tracer {
         var childContext = parentContext
         childContext.spanContext = spanContext
 
-        switch samplingResult.decision {
+        switch decision {
         case .drop:
             return OTelSpan.noOp(NoOpTracer.NoOpSpan(context: childContext))
 
@@ -174,7 +185,7 @@ extension OTelTracer: Tracer {
                 kind: kind,
                 context: childContext,
                 spanContext: spanContext,
-                attributes: samplingResult.attributes,
+                attributes: attributes,
                 startTimeNanosecondsSinceEpoch: instant().nanosecondsSinceEpoch,
                 onEnd: { [weak self] span, endTimeNanosecondsSinceEpoch in
                     self?.process(span, endedAt: endTimeNanosecondsSinceEpoch)

--- a/Sources/OTel/OTelCore/Tracing/OTelTracer.swift
+++ b/Sources/OTel/OTelCore/Tracing/OTelTracer.swift
@@ -118,6 +118,8 @@ extension OTelTracer: Service {
     }
 }
 
+private let noOpSpan = OTelSpan.noOp(NoOpTracer.NoOpSpan(context: .topLevel))
+
 extension OTelTracer: Tracer {
     func startSpan(
         _ operationName: String,
@@ -128,6 +130,11 @@ extension OTelTracer: Tracer {
         file fileID: String,
         line: UInt
     ) -> OTelSpan {
+        // Fast-path for constant sampler.
+        // This breaks the OTel spec, which says a dropped span should still get a fresh, propagatable
+        // context, but we value the performance of this common always-on/always-off case more.
+        if case .constant(let sampler) = sampler, sampler.decision == .drop { return noOpSpan }
+
         let parentContext = context()
 
         let traceID: TraceID
@@ -140,31 +147,19 @@ extension OTelTracer: Tracer {
             traceState = TraceState()
         }
 
-        // A constant sampler's decision doesn't depend on any of the arguments, so its algorithm never needs
-        // to run at all; only a pluggable sampler's `samplingResult` is actually worth calling.
-        let decision: OTelSamplingResult.Decision
-        let attributes: SpanAttributes
-        if case .constant(let constantSampler) = sampler {
-            decision = constantSampler.decision
-            attributes = [:]
-        } else {
-            let samplingResult = sampler.samplingResult(
-                operationName: operationName,
-                kind: kind,
-                traceID: traceID,
-                attributes: [:],
-                links: [],
-                parentContext: parentContext
-            )
-            decision = samplingResult.decision
-            attributes = samplingResult.attributes
-        }
+        let samplingResult = sampler.samplingResult(
+            operationName: operationName,
+            kind: kind,
+            traceID: traceID,
+            attributes: [:],
+            links: [],
+            parentContext: parentContext
+        )
 
-        // A span ID is generated independently of the sampling decision, even for a dropped/non-recording span:
-        // other components (such as log correlation) rely on a unique span ID regardless of whether it's recorded.
-        // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/sdk.md#sdk-span-creation
         let spanID = idGenerator.nextSpanID()
-        let traceFlags: TraceFlags = decision == .recordAndSample ? .sampled : []
+        var childContext = parentContext
+
+        let traceFlags: TraceFlags = samplingResult.decision == .recordAndSample ? .sampled : []
         let spanContext = OTelSpanContext.local(
             traceID: traceID,
             spanID: spanID,
@@ -172,10 +167,9 @@ extension OTelTracer: Tracer {
             traceFlags: traceFlags,
             traceState: traceState
         )
-        var childContext = parentContext
         childContext.spanContext = spanContext
 
-        switch decision {
+        switch samplingResult.decision {
         case .drop:
             return OTelSpan.noOp(NoOpTracer.NoOpSpan(context: childContext))
 
@@ -185,7 +179,7 @@ extension OTelTracer: Tracer {
                 kind: kind,
                 context: childContext,
                 spanContext: spanContext,
-                attributes: attributes,
+                attributes: samplingResult.attributes,
                 startTimeNanosecondsSinceEpoch: instant().nanosecondsSinceEpoch,
                 onEnd: { [weak self] span, endTimeNanosecondsSinceEpoch in
                     self?.process(span, endedAt: endTimeNanosecondsSinceEpoch)

--- a/Tests/OTelTests/OTelCoreTests/Tracing/OTelTracerTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Tracing/OTelTracerTests.swift
@@ -142,20 +142,7 @@ final class OTelTracerTests: XCTestCase {
         let span = tracer.startSpan("test")
         XCTAssertFalse(span.isRecording)
         XCTAssertEqual(span.operationName, "noop")
-
-        // Even though the span is dropped, it still gets a valid, propagatable SpanContext with a freshly
-        // generated span ID, per the spec's SDK Span creation requirements.
-        let spanContext = try XCTUnwrap(span.context.spanContext)
-        XCTAssertEqual(
-            spanContext,
-            .local(
-                traceID: .oneToSixteen,
-                spanID: .oneToEight,
-                parentSpanID: nil,
-                traceFlags: [],
-                traceState: TraceState()
-            )
-        )
+        XCTAssertNil(span.context.spanContext)
     }
 
     func test_startSpan_whenDynamicSamplerDrops_propagatesSpanContext() throws {
@@ -332,7 +319,7 @@ final class OTelTracerTests: XCTestCase {
         )
 
         let span = tracer.startSpan("test")
-        XCTAssertIdentical(span, tracer.activeSpan(identifiedBy: span.context))
+        XCTAssertEqual(tracer.activeSpan(identifiedBy: span.context)?.context.spanContext, span.context.spanContext)
     }
 
     func test_spanIdentifiedByServiceContext_withSpanContext_identifyingEndedSpan_returnsNil() async {
@@ -453,6 +440,74 @@ final class OTelTracerTests: XCTestCase {
         var batches = exporter.batches.makeAsyncIterator()
         let batch = await batches.next()
         XCTAssertEqual(try XCTUnwrap(batch).map(\.operationName), ["test"])
+    }
+
+    func test_startSpan_whenSamplerIsConstantOff_doesNotCallAnything() async throws {
+        struct TestFailingConformer: OTelIDGenerator, OTelSampler, OTelPropagator, OTelSpanProcessor, OTelSpanExporter {
+            func nextTraceID() -> TraceID {
+                XCTFail()
+                return .allZeroes
+            }
+
+            func nextSpanID() -> SpanID {
+                XCTFail()
+                return .allZeroes
+            }
+
+            func samplingResult(operationName: String, kind: SpanKind, traceID: TraceID, attributes: Tracing.SpanAttributes, links: [SpanLink], parentContext: ServiceContext) -> OTelSamplingResult {
+                XCTFail()
+                return .init(decision: .drop)
+            }
+
+            func extractSpanContext<Carrier, Extract>(from carrier: Carrier, using extractor: Extract) throws -> OTelSpanContext? where Carrier == Extract.Carrier, Extract: Extractor {
+                XCTFail()
+                return nil
+            }
+
+            func inject<Carrier, Inject>(_ spanContext: OTelSpanContext, into carrier: inout Carrier, using injector: Inject) where Carrier == Inject.Carrier, Inject: Injector {
+                XCTFail()
+            }
+
+            func onEnd(_ span: OTelFinishedSpan) { XCTFail() }
+
+            func forceFlush() async throws { XCTFail() }
+
+            func export(_ batch: some Collection<OTelFinishedSpan> & Sendable) async throws { XCTFail() }
+
+            func shutdown() async { XCTFail() }
+
+            func run() async throws { XCTFail() }
+
+            var context: ServiceContext {
+                XCTFail()
+                return .topLevel
+            }
+
+            var instant: StubInstant {
+                XCTFail()
+                return .constant(42)
+            }
+        }
+        let testFailingConformer = TestFailingConformer()
+        let tracer = OTelTracer(
+            idGenerator: testFailingConformer,
+            sampler: .constant(OTelConstantSampler(isOn: false)),
+            propagator: testFailingConformer,
+            processor: testFailingConformer,
+            resource: OTelResource()
+        )
+
+        let span = tracer.startSpan(
+            "thing",
+            context: testFailingConformer.context,
+            ofKind: .internal,
+            at: testFailingConformer.instant,
+            function: #function,
+            file: #file,
+            line: #line
+        )
+        XCTAssertFalse(span.isRecording)
+        XCTAssertNil(span.context.spanContext)
     }
 }
 

--- a/Tests/OTelTests/OTelCoreTests/Tracing/OTelTracerTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Tracing/OTelTracerTests.swift
@@ -145,6 +145,49 @@ final class OTelTracerTests: XCTestCase {
         XCTAssertNil(span.context.spanContext)
     }
 
+    func test_startSpan_whenDynamicSamplerDrops_propagatesSpanContext() throws {
+        let idGenerator = OTelConstantIDGenerator(traceID: .oneToSixteen, spanID: .oneToEight)
+        let sampler = OTelInlineSampler { _, _, _, _, _, _ in .init(decision: .drop) }
+        let propagator = OTelW3CPropagator()
+        let processor = OTelNoOpSpanProcessor()
+
+        let tracer = OTelTracer(
+            idGenerator: idGenerator,
+            sampler: .other(sampler),
+            propagator: propagator,
+            processor: processor,
+            resource: OTelResource()
+        )
+
+        let randomIDGenerator = OTelRandomIDGenerator()
+        let traceID = randomIDGenerator.nextTraceID()
+        let parentSpanID = randomIDGenerator.nextSpanID()
+        let traceState = TraceState([(.simple("foo"), "bar")])
+
+        var parentContext = ServiceContext.topLevel
+        parentContext.spanContext = OTelSpanContext.remoteStub(
+            traceID: traceID,
+            spanID: parentSpanID,
+            traceFlags: .sampled,
+            traceState: traceState
+        )
+
+        let span = tracer.startSpan("test", context: parentContext)
+        XCTAssertFalse(span.isRecording)
+
+        let spanContext = try XCTUnwrap(span.context.spanContext)
+        XCTAssertEqual(
+            spanContext,
+            .local(
+                traceID: traceID,
+                spanID: .oneToEight,
+                parentSpanID: parentSpanID,
+                traceFlags: [],
+                traceState: traceState
+            )
+        )
+    }
+
     func test_startSpan_onSpanEnd_whenSpanIsSampled_forwardsSpanToProcessor() async throws {
         let idGenerator = OTelRandomIDGenerator()
         let sampler = OTelConstantSampler(isOn: true)
@@ -399,7 +442,7 @@ final class OTelTracerTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(batch).map(\.operationName), ["test"])
     }
 
-    func test_startSpan_whenSamplerIsConstantOff_doesNotCallAnything() async throws {
+    func test_startSpan_whenSamplerIsConstantOff_skipsSamplingAndIDGenerationButPropagatesContext() async throws {
         struct TestFailingConformer: OTelIDGenerator, OTelSampler, OTelPropagator, OTelSpanProcessor, OTelSpanExporter {
             func nextTraceID() -> TraceID {
                 XCTFail()
@@ -435,11 +478,6 @@ final class OTelTracerTests: XCTestCase {
 
             func run() async throws { XCTFail() }
 
-            var context: ServiceContext {
-                XCTFail()
-                return .topLevel
-            }
-
             var instant: StubInstant {
                 XCTFail()
                 return .constant(42)
@@ -454,9 +492,17 @@ final class OTelTracerTests: XCTestCase {
             resource: OTelResource()
         )
 
+        var upstreamContext = ServiceContext.topLevel
+        upstreamContext.spanContext = OTelSpanContext.remoteStub(
+            traceID: .oneToSixteen,
+            spanID: .oneToEight,
+            traceFlags: .sampled,
+            traceState: TraceState()
+        )
+
         let span = tracer.startSpan(
             "thing",
-            context: testFailingConformer.context,
+            context: upstreamContext,
             ofKind: .internal,
             at: testFailingConformer.instant,
             function: #function,
@@ -464,7 +510,8 @@ final class OTelTracerTests: XCTestCase {
             line: #line
         )
         XCTAssertFalse(span.isRecording)
-        XCTAssertNil(span.context.spanContext)
+
+        XCTAssertEqual(span.context.spanContext, upstreamContext.spanContext)
     }
 }
 

--- a/Tests/OTelTests/OTelCoreTests/Tracing/OTelTracerTests.swift
+++ b/Tests/OTelTests/OTelCoreTests/Tracing/OTelTracerTests.swift
@@ -142,7 +142,20 @@ final class OTelTracerTests: XCTestCase {
         let span = tracer.startSpan("test")
         XCTAssertFalse(span.isRecording)
         XCTAssertEqual(span.operationName, "noop")
-        XCTAssertNil(span.context.spanContext)
+
+        // Even though the span is dropped, it still gets a valid, propagatable SpanContext with a freshly
+        // generated span ID, per the spec's SDK Span creation requirements.
+        let spanContext = try XCTUnwrap(span.context.spanContext)
+        XCTAssertEqual(
+            spanContext,
+            .local(
+                traceID: .oneToSixteen,
+                spanID: .oneToEight,
+                parentSpanID: nil,
+                traceFlags: [],
+                traceState: TraceState()
+            )
+        )
     }
 
     func test_startSpan_whenDynamicSamplerDrops_propagatesSpanContext() throws {
@@ -440,78 +453,6 @@ final class OTelTracerTests: XCTestCase {
         var batches = exporter.batches.makeAsyncIterator()
         let batch = await batches.next()
         XCTAssertEqual(try XCTUnwrap(batch).map(\.operationName), ["test"])
-    }
-
-    func test_startSpan_whenSamplerIsConstantOff_skipsSamplingAndIDGenerationButPropagatesContext() async throws {
-        struct TestFailingConformer: OTelIDGenerator, OTelSampler, OTelPropagator, OTelSpanProcessor, OTelSpanExporter {
-            func nextTraceID() -> TraceID {
-                XCTFail()
-                return .allZeroes
-            }
-
-            func nextSpanID() -> SpanID {
-                XCTFail()
-                return .allZeroes
-            }
-
-            func samplingResult(operationName: String, kind: SpanKind, traceID: TraceID, attributes: Tracing.SpanAttributes, links: [SpanLink], parentContext: ServiceContext) -> OTelSamplingResult {
-                XCTFail()
-                return .init(decision: .drop)
-            }
-
-            func extractSpanContext<Carrier, Extract>(from carrier: Carrier, using extractor: Extract) throws -> OTelSpanContext? where Carrier == Extract.Carrier, Extract: Extractor {
-                XCTFail()
-                return nil
-            }
-
-            func inject<Carrier, Inject>(_ spanContext: OTelSpanContext, into carrier: inout Carrier, using injector: Inject) where Carrier == Inject.Carrier, Inject: Injector {
-                XCTFail()
-            }
-
-            func onEnd(_ span: OTelFinishedSpan) { XCTFail() }
-
-            func forceFlush() async throws { XCTFail() }
-
-            func export(_ batch: some Collection<OTelFinishedSpan> & Sendable) async throws { XCTFail() }
-
-            func shutdown() async { XCTFail() }
-
-            func run() async throws { XCTFail() }
-
-            var instant: StubInstant {
-                XCTFail()
-                return .constant(42)
-            }
-        }
-        let testFailingConformer = TestFailingConformer()
-        let tracer = OTelTracer(
-            idGenerator: testFailingConformer,
-            sampler: .constant(OTelConstantSampler(isOn: false)),
-            propagator: testFailingConformer,
-            processor: testFailingConformer,
-            resource: OTelResource()
-        )
-
-        var upstreamContext = ServiceContext.topLevel
-        upstreamContext.spanContext = OTelSpanContext.remoteStub(
-            traceID: .oneToSixteen,
-            spanID: .oneToEight,
-            traceFlags: .sampled,
-            traceState: TraceState()
-        )
-
-        let span = tracer.startSpan(
-            "thing",
-            context: upstreamContext,
-            ofKind: .internal,
-            at: testFailingConformer.instant,
-            function: #function,
-            file: #file,
-            line: #line
-        )
-        XCTAssertFalse(span.isRecording)
-
-        XCTAssertEqual(span.context.spanContext, upstreamContext.spanContext)
     }
 }
 


### PR DESCRIPTION
OTelTracer.startSpan returns a [no-op span](https://github.com/swift-otel/swift-otel/blob/main/Sources/OTel/OTelCore/Tracing/OTelTracer.swift#L121) for dropped spans. This span has an empty ServiceContext (.topLevel). It effectively drops the context if a span is dropped or if sampling is disabled. If a span is dropped, any downstream service starts and new disconnected trace.

Changes
- If an individual span is dropped, create child context, pass it downstream, but do not export anything.
- If sampling is disabled, pass the provided context.

Closes #432.