### PR TITLE
Make OTel.bootstrap overload taking an environment, public

### DIFF
--- a/Sources/OTel/OTelAPI/OTel+Bootstrap.swift
+++ b/Sources/OTel/OTelAPI/OTel+Bootstrap.swift
@@ -116,7 +116,12 @@ extension OTel {
         try Self.bootstrap(configuration: configuration, environment: ProcessInfo.processInfo.environment)
     }
 
-    package static func bootstrap(configuration: Configuration = .default, environment: [String: String]) throws -> some Service {
+    /// Bootstrap observability backends with OTLP exporters, reading the process environment from a user-provided
+    /// dictionary rather than the process environment.
+    ///
+    /// - SeeAlso:
+    ///   - ``bootstrap(configuration:)`` for a description of the bootstrapped OTel backends.
+    public static func bootstrap(configuration: Configuration = .default, environment: [String: String]) throws -> some Service {
         let logger = configuration.makeDiagnosticLogger().withMetadata(component: "bootstrap")
         var configuration = configuration
         if configuration.logs.disabled, configuration.metrics.disabled, configuration.traces.disabled {


### PR DESCRIPTION
This allows a managed environment to be injected, rather than being hardcoded to process global state. For example, it allows `OTEL_HEADERS=X-Auth:secret` to be read from a file instead of setting the secret as an environment variable.